### PR TITLE
Fix pace chart bleed + OAuth poller hardening + Settings Authentication

### DIFF
--- a/App/Background/PacerAppDelegate.swift
+++ b/App/Background/PacerAppDelegate.swift
@@ -75,6 +75,13 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate {
     private var statusMenuContentController: NSViewController?
     private var menuBarHostingView: SizingHostingView?
     private var menuBarPrefObserver: NSObjectProtocol?
+    // Tracked at class scope so the observer block doesn't capture a
+    // local `var` — Swift 6.3 strict-concurrency rejects the local-var
+    // form because the @Sendable observer closure makes the capture
+    // task-isolated, conflicting with the inner @MainActor Task that
+    // mutates it. As an instance property on this @MainActor class it
+    // is main-actor isolated, matching the inner Task.
+    private var menuBarLastChipsEmpty: Bool = false
 
     override init() {
         // Redirect stderr to a log file before anything else so the
@@ -437,7 +444,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate {
         // Only rebuild when the "is the item present at all" answer
         // changes (empty chip list ↔ at least one chip). Every other
         // chip-list change is handled by the SwiftUI label re-render.
-        var lastIsEmpty = currentChipsAreEmpty()
+        menuBarLastChipsEmpty = currentChipsAreEmpty()
         menuBarPrefObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: PacerSettings.store,
@@ -446,8 +453,8 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 guard let self else { return }
                 let nowEmpty = self.currentChipsAreEmpty()
-                if nowEmpty != lastIsEmpty {
-                    lastIsEmpty = nowEmpty
+                if nowEmpty != self.menuBarLastChipsEmpty {
+                    self.menuBarLastChipsEmpty = nowEmpty
                     self.rebuildMenuBarForCurrentChips()
                 }
             }

--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -131,6 +131,7 @@ public enum PacerSettings {
         public static let costMode               = PacerPreferenceKeys.costMode
         public static let timeRange              = PacerPreferenceKeys.timeRange
         public static let projectsSort           = PacerPreferenceKeys.projectsSort
+        public static let oauthTokenOverride     = PacerPreferenceKeys.oauthTokenOverride
     }
 
     // MARK: - Defaults
@@ -156,6 +157,7 @@ public enum PacerSettings {
         Key.costMode:              "auto",
         Key.timeRange:             "90d",
         Key.projectsSort:          "cost",
+        Key.oauthTokenOverride:    "",
     ]
 
     /// Register the defaults dict on first launch — `@AppStorage`'s

--- a/App/Views/HeroStripCard.swift
+++ b/App/Views/HeroStripCard.swift
@@ -205,6 +205,12 @@ struct HeroStripCard: View {
         }
         .onAppear { refreshCache() }
         .onChange(of: scanMeta.first?.value) { _, _ in refreshCache() }
+        // OAuth poller writes RateLimitSample without bumping scanMeta
+        // (only the JSONL scanner does that), so without this the hero
+        // tiles stay stale across successful OAuth polls. Watching the
+        // newest sample's sampledAt fires the refresh exactly when a
+        // new poll lands.
+        .onChange(of: rateLimits.first?.sampledAt) { _, _ in refreshCache() }
     }
 
     // MARK: - Cost tile
@@ -312,38 +318,43 @@ struct HeroStripCard: View {
     ) -> some View {
         HeroTile(label: label) {
             if let s = sample, let resets = s.resetsAt {
-                let pacePct = PaceMath.paceFraction(
-                    now: Date(), resetsAt: resets, windowDuration: duration
-                ) * 100
-                let band = PaceBand(usedPct: s.usedPercentage, paceEndPct: pacePct)
-                // Chip moved to its own row below the % line so it
-                // can't ever wrap mid-word ("behi nd") when the tile
-                // gets narrow. Layout: hero %, status row, optional
-                // burn-rate forecast row.
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Text("\(Int(s.usedPercentage.rounded()))%")
-                            .font(.system(size: 32, weight: .semibold, design: .rounded))
-                            .monospacedDigit()
-                            .foregroundStyle(color(for: band))
-                            .lineLimit(1)
-                        Text("/")
-                            .font(.system(size: 18))
-                            .foregroundStyle(.tertiary)
-                        Text("\(Int(pacePct.rounded()))%")
-                            .font(.system(size: 18, weight: .medium, design: .rounded))
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
+                let cycle = DisplayCycle.resolve(resetsAt: resets, duration: duration)
+                if cycle.isAwaiting {
+                    // Sample's cycle already ended; no fresh sample yet.
+                    // Show "awaiting" rather than rendering stale used/pace %.
+                    awaitingTile
+                } else {
+                    let pacePct = cycle.paceFraction * 100
+                    let band = PaceBand(usedPct: s.usedPercentage, paceEndPct: pacePct)
+                    // Chip moved to its own row below the % line so it
+                    // can't ever wrap mid-word ("behi nd") when the tile
+                    // gets narrow. Layout: hero %, status row, optional
+                    // burn-rate forecast row.
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(alignment: .firstTextBaseline, spacing: 4) {
+                            Text("\(Int(s.usedPercentage.rounded()))%")
+                                .font(.system(size: 32, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(color(for: band))
+                                .lineLimit(1)
+                            Text("/")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.tertiary)
+                            Text("\(Int(pacePct.rounded()))%")
+                                .font(.system(size: 18, weight: .medium, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        HStack(spacing: 8) {
+                            paceChip(band: band)
+                            Text("resets \(pacerRelative(resets))")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        burnRow(burn)
                     }
-                    HStack(spacing: 8) {
-                        paceChip(band: band)
-                        Text("resets \(pacerRelative(resets))")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    burnRow(burn)
                 }
             } else {
                 VStack(alignment: .leading, spacing: 8) {
@@ -355,6 +366,25 @@ struct HeroStripCard: View {
                         .foregroundStyle(.secondary)
                 }
             }
+        }
+    }
+
+    /// Layout matches the active-cycle tile's vertical footprint so the
+    /// HStack's equal-height layout doesn't reflow when a sibling tile
+    /// is showing active data.
+    private var awaitingTile: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("—")
+                .font(.system(size: 32, weight: .semibold, design: .rounded))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            Text("awaiting first sample of new cycle")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Text(" ")  // matches burnRow's empty-placeholder height
+                .font(.system(size: 11))
+                .opacity(0)
         }
     }
 

--- a/App/Views/MenuBarContent.swift
+++ b/App/Views/MenuBarContent.swift
@@ -204,8 +204,15 @@ struct MenuBarLabel: View {
         if let s = sevenDay {
             parts.append("7d: \(Int(s.usedPercentage.rounded()))%")
         }
+        // Tooltip's reset hint reads from the 5-hour sample. When that
+        // sample's cycle has already ended (Pacer hasn't ingested a fresh
+        // one — see #3/#4), don't show "resets X ago" — that confuses
+        // "ago" as a past event when it's actually "Pacer is behind."
         if let resets = fiveHour?.resetsAt {
-            parts.append("resets \(pacerRelative(resets))")
+            let cycle = DisplayCycle.resolve(resetsAt: resets, duration: 5 * 3600)
+            parts.append(cycle.isAwaiting
+                ? "5h cycle reset, awaiting fresh sample"
+                : "resets \(pacerRelative(resets))")
         }
         if parts.isEmpty {
             return "Pacer — collecting…"
@@ -432,33 +439,56 @@ struct MenuStatusContent: View {
                 .frame(width: 48, alignment: .leading)
 
             if let s = sample, let resets = s.resetsAt {
-                let pacePct = PaceMath.paceFraction(
-                    now: Date(), resetsAt: resets, windowDuration: duration
-                ) * 100
-                let band = PaceBand(usedPct: s.usedPercentage, paceEndPct: pacePct)
+                let cycle = DisplayCycle.resolve(resetsAt: resets, duration: duration)
+                if cycle.isAwaiting {
+                    // Stale cycle (Pacer hasn't polled a fresh one yet).
+                    // Show a muted "awaiting" line — no pace math from
+                    // prior-cycle numbers.
+                    CircularGauge(
+                        percentage: s.usedPercentage,
+                        lineWidth: 3,
+                        labelFont: .system(size: 8, weight: .bold, design: .rounded)
+                    )
+                    .frame(width: 22, height: 22)
+                    .opacity(0.4)
 
-                CircularGauge(
-                    percentage: s.usedPercentage,
-                    lineWidth: 3,
-                    labelFont: .system(size: 8, weight: .bold, design: .rounded)
-                )
-                .frame(width: 22, height: 22)
+                    Text("—")
+                        .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 32, alignment: .trailing)
 
-                Text("\(Int(s.usedPercentage.rounded()))%")
-                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
-                    .frame(width: 32, alignment: .trailing)
+                    Text("awaiting new cycle")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
 
-                Text("pace \(Int(pacePct.rounded()))%")
-                    .font(.system(size: 11, weight: .medium))
-                    .monospacedDigit()
-                    .foregroundStyle(band.color)
+                    Spacer(minLength: 0)
+                } else {
+                    let pacePct = cycle.paceFraction * 100
+                    let band = PaceBand(usedPct: s.usedPercentage, paceEndPct: pacePct)
 
-                Spacer(minLength: 4)
+                    CircularGauge(
+                        percentage: s.usedPercentage,
+                        lineWidth: 3,
+                        labelFont: .system(size: 8, weight: .bold, design: .rounded)
+                    )
+                    .frame(width: 22, height: 22)
 
-                Text("resets \(pacerRelative(resets, style: .short))")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    Text("\(Int(s.usedPercentage.rounded()))%")
+                        .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                        .frame(width: 32, alignment: .trailing)
+
+                    Text("pace \(Int(pacePct.rounded()))%")
+                        .font(.system(size: 11, weight: .medium))
+                        .monospacedDigit()
+                        .foregroundStyle(band.color)
+
+                    Spacer(minLength: 4)
+
+                    Text("resets \(pacerRelative(resets, style: .short))")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             } else {
                 Text("collecting…")
                     .font(.system(size: 11))

--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -120,8 +120,12 @@ private struct PaceChartColumn: View {
             .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
             .sorted { $0.sampledAt < $1.sampledAt }
             .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }
-        if points.last?.time != now {
-            points.append(.init(time: now, value: latest.usedPercentage))
+        // Clamp the synthesized tail to the cycle: once `now > resets`
+        // (cycle ended, no fresh sample yet), a tail at `now` falls
+        // outside `chartXScale`'s domain.
+        let tailTime = min(now, resets)
+        if points.last?.time != tailTime {
+            points.append(.init(time: tailTime, value: latest.usedPercentage))
         }
         return PaceChartView.Data(
             cycleStart: cycleStart,

--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -70,9 +70,25 @@ struct PaceChartCard: View {
     @ViewBuilder
     private func trailingChip(latest: RateLimitSample?) -> some View {
         if let latest {
-            Text("via \(latest.source) · \(pacerRelative(latest.sampledAt))")
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
+            // OAuth samples ought to arrive every 5 min. If the newest one
+            // is much older than that — the poller is stalled (commonly an
+            // expired Claude Code token) and the chart numbers are stale.
+            // statusline samples are irregular by nature; skip the warning
+            // for that source. See #3.
+            let elapsed = Date().timeIntervalSince(latest.sampledAt)
+            let isStaleOAuth = latest.source == RateLimitSource.oauth && elapsed > 15 * 60
+            HStack(spacing: 4) {
+                if isStaleOAuth {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 10))
+                }
+                Text("via \(latest.source) · \(pacerRelative(latest.sampledAt))")
+                    .font(.system(size: 11))
+            }
+            .foregroundStyle(isStaleOAuth ? Color.yellow : .secondary)
+            .help(isStaleOAuth
+                ? "Pacer hasn't received fresh data in \(pacerRelative(latest.sampledAt)). The OAuth token may have expired — try launching or quitting/reopening Claude Code to refresh it. See ~/Library/Logs/Pacer/Pacer.err.log for the poller's last outcome."
+                : "")
         }
     }
 
@@ -109,6 +125,14 @@ private struct PaceChartColumn: View {
 
     private var latest: RateLimitSample? { windowSamples.first }
 
+    /// Display-cycle for this column. nil only when there's no sample
+    /// or the sample has no `resetsAt`. Otherwise resolves the
+    /// active-or-awaiting bracket for everything in the column body.
+    private var cycle: DisplayCycle? {
+        guard let latest, let resets = latest.resetsAt else { return nil }
+        return DisplayCycle.resolve(resetsAt: resets, duration: duration)
+    }
+
     /// Build the `PaceChartView.Data` snapshot — same shape the widget
     /// will pass in. Synthesizes a "now" tail point so the line tracks
     /// to current time even if the most-recent sample is older.
@@ -140,24 +164,49 @@ private struct PaceChartColumn: View {
         VStack(alignment: .leading, spacing: 8) {
             header
             heroLine
-            if let chartData {
-                PaceChartView(data: chartData, style: .detailed)
-                    .frame(height: 96)
-            } else {
-                Text("collecting…")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.tertiary)
-                    .frame(height: 96)
-            }
+            chartSlot
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Renders the chart for an active cycle or a textual placeholder
+    /// when awaiting. Same vertical footprint either way so the parent
+    /// HStack's equal-height layout stays stable.
+    @ViewBuilder
+    private var chartSlot: some View {
+        if cycle?.isAwaiting == true {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Awaiting first sample of new cycle")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text("Pacer will plot the new cycle once a fresh sample arrives.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .frame(height: 96, alignment: .topLeading)
+        } else if let chartData {
+            PaceChartView(data: chartData, style: .detailed)
+                .frame(height: 96)
+        } else {
+            Text("collecting…")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+                .frame(height: 96)
+        }
     }
 
     private var header: some View {
         HStack {
             Eyebrow(text: title)
             Spacer()
-            if let resets = latest?.resetsAt {
+            if let cycle, cycle.isAwaiting {
+                Text("cycle reset · awaiting")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            } else if let resets = latest?.resetsAt {
                 Text(pacerResetCaption(resetsAt: resets, durationSeconds: duration))
                     .font(.system(size: 10))
                     .foregroundStyle(.secondary)
@@ -171,13 +220,8 @@ private struct PaceChartColumn: View {
 
     @ViewBuilder
     private var heroLine: some View {
-        if let latest, let resets = latest.resetsAt {
-            let paceFraction = PaceMath.paceFraction(
-                now: Date(),
-                resetsAt: resets,
-                windowDuration: duration
-            )
-            let paceEndPct = paceFraction * 100
+        if let latest, let cycle, !cycle.isAwaiting {
+            let paceEndPct = cycle.paceFraction * 100
             let band = PaceBand(usedPct: latest.usedPercentage, paceEndPct: paceEndPct)
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text("\(Int(latest.usedPercentage.rounded()))%")

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -36,6 +36,10 @@ struct SettingsView: View {
                     DailySummaryCard()
                     NotificationTestCard()
                 }
+                SettingsSection("Authentication") {
+                    OAuthRefreshCard()
+                    OAuthTokenOverrideCard()
+                }
                 SettingsSection("Data") {
                     CostCalculationCard()
                     ProjectAliasesCard()
@@ -905,6 +909,344 @@ private struct CostCalculationCard: View {
         }, footer: {
             Text("**Auto** matches `bun x ccusage`. **Calculate** is what you want when older Claude Code lines lack `costUSD`. **Display** only shows server-supplied numbers and ignores tokens that didn't come with one.")
         })
+    }
+}
+
+// MARK: - Authentication
+
+/// On-demand refresh of Pacer's view of the OAuth credential. POSTs
+/// the keychain's `refreshToken` to Anthropic's OAuth endpoint, then
+/// writes the rotated credential back to the keychain. Workaround
+/// for Claude Code 2.x refreshing only in memory — see #6 and the
+/// `OAuthClient.refresh` doc comment for the race-with-Claude-Code
+/// caveat. Refresh is user-triggered (not background) so the race
+/// window is bounded to button clicks.
+private struct OAuthRefreshCard: View {
+    @State private var inProgress: Bool = false
+    @State private var lastResult: RefreshOutcome?
+
+    private enum RefreshOutcome: Equatable {
+        case success(expiresAt: Date)
+        case failure(message: String)
+    }
+
+    var body: some View {
+        PacerCard("Refresh OAuth keychain entry", content: {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    statusLabel
+                    Spacer(minLength: 8)
+                    Button("Refresh now") { runRefresh() }
+                        .controlSize(.small)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(inProgress)
+                }
+            }
+        }, footer: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Forces a fresh access token using the refresh token already in the keychain, then writes the rotated credential back. Pacer's next poll will use the new token; no re-login needed.")
+                Text("Caveat: Anthropic rotates the refresh token on every call, which invalidates the in-memory copy your other Claude Code sessions hold. Those sessions will need `claude logout && claude login` the next time they would have auto-refreshed (~8 hours after their last refresh).")
+                    .padding(.top, 2)
+            }
+        })
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        if inProgress {
+            ProgressView().controlSize(.small)
+            Text("Refreshing…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if let result = lastResult {
+            switch result {
+            case .success(let expiresAt):
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.system(size: 12))
+                Text("Refreshed — expires \(pacerRelative(expiresAt))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            case .failure(let msg):
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .font(.system(size: 12))
+                Text(msg)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(3)
+            }
+        } else {
+            Image(systemName: "arrow.clockwise")
+                .foregroundStyle(.tertiary)
+                .font(.system(size: 12))
+            Text("Click Refresh now to rotate Pacer's OAuth token via the keychain.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .lineLimit(2)
+        }
+    }
+
+    private func runRefresh() {
+        inProgress = true
+        lastResult = nil
+        Task { @MainActor in
+            let client = OAuthClient(tokenOverride: { nil })
+            let result = await client.refresh()
+            inProgress = false
+            lastResult = Self.classify(result)
+        }
+    }
+
+    private static func classify(
+        _ result: Result<OAuthCredential, OAuthRefreshError>
+    ) -> RefreshOutcome {
+        switch result {
+        case .success(let credential):
+            return .success(expiresAt: credential.expiresAt ?? Date().addingTimeInterval(8 * 3600))
+        case .failure(.noRefreshToken):
+            return .failure(message: "No refresh token in the keychain. Run `claude logout && claude login` to seed one.")
+        case .failure(.keychainRead(.notFound)):
+            return .failure(message: "No `Claude Code-credentials` entry found. Sign into Claude Code first.")
+        case .failure(.keychainRead(.accessDenied)):
+            return .failure(message: "Keychain access denied. Approve the prompt in the foreground app and retry.")
+        case .failure(.keychainRead),
+             .failure(.keychainWrite):
+            return .failure(message: "Couldn't read or write the keychain. Check ~/Library/Logs/Pacer/Pacer.err.log.")
+        case .failure(.http(let status, _)) where status == 400 || status == 401:
+            return .failure(message: "Refresh token rejected (\(status)). Likely rotated by another client — run `claude logout && claude login` to re-seed.")
+        case .failure(.http(let status, _)):
+            return .failure(message: "Anthropic returned HTTP \(status) from the refresh endpoint.")
+        case .failure(.transport):
+            return .failure(message: "Network error talking to the refresh endpoint.")
+        case .failure(.responseSchemaMismatch):
+            return .failure(message: "Refresh response didn't match the expected shape. Anthropic may have changed the API.")
+        }
+    }
+}
+
+/// Manual OAuth access-token override. When non-empty, the OAuth poller
+/// uses this token instead of the one in the `Claude Code-credentials`
+/// keychain entry — workaround for Claude Code 2.x not persisting
+/// refreshed tokens back to the keychain (see #6).
+///
+/// UX shape: draft state local to the card, committed to `@AppStorage`
+/// only on Save. Test runs a one-off `OAuthClient.fetchUsage()` with the
+/// *draft* (not the saved value), so the user can validate before
+/// committing — same one-call shape the poller itself uses, no
+/// special-case server hit.
+private struct OAuthTokenOverrideCard: View {
+    @AppStorage(PacerSettings.Key.oauthTokenOverride, store: PacerSettings.store)
+    private var savedOverride: String = ""
+
+    @State private var draft: String = ""
+    @State private var testResult: TestResult?
+    @State private var testInProgress: Bool = false
+
+    /// Result of running the Test button against the draft token. Kept
+    /// alongside the UI rather than persisted — once the user types
+    /// anything, the prior verdict is no longer authoritative.
+    private enum TestResult: Equatable {
+        case success(fiveHourPct: Double?, sevenDayPct: Double?)
+        case failure(message: String)
+    }
+
+    private var trimmedDraft: String {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var draftIsEmpty: Bool { trimmedDraft.isEmpty }
+    private var isDirty: Bool { draft != savedOverride }
+
+    var body: some View {
+        PacerCard("OAuth token override", content: {
+            VStack(alignment: .leading, spacing: 10) {
+                TextField("Paste OAuth access token", text: $draft, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+                    .lineLimit(2...4)
+                    .onChange(of: draft) { _, _ in
+                        // Editing invalidates the prior test verdict.
+                        testResult = nil
+                    }
+
+                HStack(spacing: 8) {
+                    statusLabel
+                    Spacer(minLength: 8)
+                    Button(draftIsEmpty ? "Test keychain" : "Test") { runTest() }
+                        .controlSize(.small)
+                        .disabled(testInProgress)
+                        .help(draftIsEmpty
+                            ? "Tests the OAuth token Pacer currently reads from the Claude Code keychain."
+                            : "Tests the token in the field above (not yet saved).")
+                    Button("Save") {
+                        savedOverride = draft
+                        // Saving a different value invalidates the prior test;
+                        // the saved value is now what the poller will use.
+                        testResult = nil
+                    }
+                    .controlSize(.small)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!isDirty || testInProgress)
+                    Button("Clear") {
+                        draft = ""
+                        savedOverride = ""
+                        testResult = nil
+                    }
+                    .controlSize(.small)
+                    .disabled(draftIsEmpty && savedOverride.isEmpty || testInProgress)
+                }
+            }
+        }, footer: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Claude Code 2.x doesn't persist refreshed access tokens back to its keychain entry, so the copy Pacer reads goes stale after ~8 hours and the rate-limit panel freezes. As a workaround, paste a fresh access token here — Pacer will use it instead.")
+                Text("To fetch a fresh token after re-signing into Claude Code, run in Terminal:")
+                    .padding(.top, 2)
+                Text("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                Text("Access tokens last ~8 hours; re-paste when Pacer's chip turns yellow again.")
+                    .padding(.top, 2)
+            }
+        })
+        .onAppear { draft = savedOverride }
+    }
+
+    /// Single source of truth for the status icon + caption sitting to
+    /// the left of the action buttons. Test result takes precedence
+    /// (the user just asked for it) over saved/dirty state.
+    @ViewBuilder
+    private var statusLabel: some View {
+        if testInProgress {
+            ProgressView()
+                .controlSize(.small)
+            Text("Testing…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if let result = testResult {
+            switch result {
+            case .success(let fh, let sd):
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.system(size: 12))
+                Text("Valid · \(formatSuccess(fiveHour: fh, sevenDay: sd))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            case .failure(let msg):
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .font(.system(size: 12))
+                Text(msg)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(3)
+            }
+        } else if isDirty {
+            Image(systemName: "pencil")
+                .foregroundStyle(.orange)
+                .font(.system(size: 12))
+            Text("Unsaved changes")
+                .font(.caption)
+                .foregroundStyle(.orange)
+        } else if !savedOverride.isEmpty {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .font(.system(size: 12))
+            Text("Saved · Pacer is using this token")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        } else {
+            Image(systemName: "key")
+                .foregroundStyle(.tertiary)
+                .font(.system(size: 12))
+            Text("Empty · Pacer reads from keychain")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+    }
+
+    private func formatSuccess(fiveHour: Double?, sevenDay: Double?) -> String {
+        let f = fiveHour.map { "5h=\(Int($0.rounded()))%" } ?? "5h=—"
+        let s = sevenDay.map { "7d=\(Int($0.rounded()))%" } ?? "7d=—"
+        return "\(f), \(s)"
+    }
+
+    /// Run one OAuth request, mirroring whichever path the poller
+    /// itself would take right now:
+    ///   - draft non-empty: test the *draft*, with a broken keychain
+    ///     underneath so the result reflects the typed token alone.
+    ///   - draft empty: test the live keychain read, exactly as the
+    ///     production poller would do it. Useful for confirming a
+    ///     fresh `claude login` produced a working token before
+    ///     trusting Pacer's next poll.
+    private func runTest() {
+        let token = trimmedDraft
+        testInProgress = true
+        testResult = nil
+        Task { @MainActor in
+            let client: OAuthClient
+            if token.isEmpty {
+                // Production path: real keychain, no override.
+                client = OAuthClient(tokenOverride: { nil })
+            } else {
+                // Draft path: deliberately broken keychain so the
+                // result reflects the typed token alone.
+                let brokenKeychain = KeychainOAuth(rawReader: { .failure(.notFound) })
+                client = OAuthClient(
+                    keychain: brokenKeychain,
+                    tokenOverride: { token }
+                )
+            }
+            let result = await client.fetchUsage()
+            testInProgress = false
+            testResult = Self.classify(result)
+        }
+    }
+
+    /// Translate the typed OAuthClient outcome into a user-facing
+    /// result. We don't surface raw HTTP bodies — they're noisy and
+    /// usually point at the same actionable advice ("get a fresh token").
+    private static func classify(
+        _ result: Result<RateLimitSnapshot, OAuthClientError>
+    ) -> TestResult {
+        switch result {
+        case .success(let snapshot):
+            return .success(
+                fiveHourPct: snapshot.fiveHour?.usedPercentage,
+                sevenDayPct: snapshot.sevenDay?.usedPercentage
+            )
+        case .failure(.unauthorized):
+            return .failure(message: "Anthropic rejected this token (401). It may be expired or revoked — fetch a fresh one.")
+        case .failure(.rateLimited):
+            return .failure(message: "Rate-limited by Anthropic (429). Wait a moment and try again.")
+        case .failure(.transport):
+            return .failure(message: "Network error. Check your connection and retry.")
+        case .failure(.http(403, _)):
+            // 403 ≠ 401: Anthropic accepted the token as valid auth
+            // but won't honor it for /api/oauth/usage. Almost always
+            // means the token lacks the `user:sessions:claude_code`
+            // scope — i.e. it came from `claude setup-token` or a
+            // web-console API key rather than the interactive
+            // `claude login` flow.
+            return .failure(message: "Token rejected for this endpoint (403). Use a token from `claude logout && claude login`, not `claude setup-token` or a console API key.")
+        case .failure(.http(let status, _)):
+            return .failure(message: "Anthropic returned HTTP \(status).")
+        case .failure(.responseSchemaMismatch):
+            return .failure(message: "Anthropic's response didn't match Pacer's expected shape. Likely a server-side change.")
+        case .failure(.credentialsNotFound),
+             .failure(.keychainAccessDenied),
+             .failure(.keychainMalformed),
+             .failure(.keychainStatus),
+             .failure(.tokenExpired):
+            // The override path shouldn't reach any of these. Surface a
+            // generic message rather than crashing — keeps the UI honest
+            // if the client's failure modes ever expand.
+            return .failure(message: "Pacer hit an unexpected internal error while testing.")
+        }
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL := /bin/bash
 
 # Paths used throughout. Quoted in recipes when expanded.
 REPO_ROOT      := $(shell pwd)
-BUILD_OUTPUT   := $(REPO_ROOT)/Build/Products/Debug/Pacer.app
+BUILD_OUTPUT   := $(REPO_ROOT)/Build/Build/Products/Debug/Pacer.app
 INSTALLED_APP  := /Applications/Pacer.app
 LOG_DIR        := $(HOME)/Library/Logs/Pacer
 LOG_ERR        := $(LOG_DIR)/Pacer.err.log
@@ -54,6 +54,7 @@ verify:  ## Verification build (no signing, no install) — fastest sanity check
 	@xcodegen generate
 	@xcodebuild -project Pacer.xcodeproj -scheme Pacer -configuration Debug \
 		-destination 'platform=macOS' \
+		-derivedDataPath "$(REPO_ROOT)/Build" \
 		CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
 		build | (grep -E '(error:|warning:|FAILED|SUCCEEDED)' || true)
 
@@ -63,10 +64,11 @@ build: verify  ## Alias for `verify`.
 test:  ## Run the PacerCore unit + ground-truth tests.
 	@cd PacerCore && swift test 2>&1 | tail -3
 
-app:  ## Signed Debug build of Pacer.app (output: Build/Products/Debug/Pacer.app).
+app:  ## Signed Debug build of Pacer.app (output: Build/Build/Products/Debug/Pacer.app).
 	@xcodegen generate
 	@xcodebuild -project Pacer.xcodeproj -scheme Pacer -configuration Debug \
 		-destination 'platform=macOS' \
+		-derivedDataPath "$(REPO_ROOT)/Build" \
 		-allowProvisioningUpdates \
 		build | (grep -E '(error:|warning:|FAILED|SUCCEEDED)' || true)
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ SHELL := /bin/bash
 
 # Paths used throughout. Quoted in recipes when expanded.
 REPO_ROOT      := $(shell pwd)
-BUILD_OUTPUT   := $(REPO_ROOT)/Build/Build/Products/Debug/Pacer.app
+# Informational only — dev-install.sh resolves the real path post-build
+# (Xcode's <derivedDataPath>/[Build/]Products nesting is version-dependent).
+BUILD_OUTPUT   := $(REPO_ROOT)/Build/Products/Debug/Pacer.app
 INSTALLED_APP  := /Applications/Pacer.app
 LOG_DIR        := $(HOME)/Library/Logs/Pacer
 LOG_ERR        := $(LOG_DIR)/Pacer.err.log

--- a/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
@@ -3,25 +3,32 @@ import Security
 
 /// One decoded copy of the OAuth credential blob Claude Code stores in
 /// the user's login Keychain under service name `Claude Code-credentials`.
-/// We only ever read this — Claude Code itself rotates and re-writes it.
-///
-/// The raw blob has additional fields (`refreshToken`, `scopes`, …) that
-/// we deliberately don't surface; Pacer needs only the access token to
-/// hit `/api/oauth/usage`. Keeping the surface small means a future
-/// schema change in irrelevant fields can't break us.
+/// Claude Code itself writes the entry on interactive login; Pacer
+/// reads it on every poll and (optionally, on the user's request) does
+/// its own refresh via `OAuthClient.refresh` — see #6.
 public struct OAuthCredential: Sendable, Equatable {
     public let accessToken: String
     /// Server-side expiry. The endpoint will return 401 if we send an
     /// expired token, so we treat this as advisory — useful for skipping
     /// guaranteed-401 calls but trust the server for borderline cases.
     public let expiresAt: Date?
+    /// Used by `OAuthClient.refresh` to exchange for a new access
+    /// token. Optional because some legacy blob shapes omitted it; if
+    /// it's nil, refresh isn't possible and the user has to re-login.
+    public let refreshToken: String?
     /// Surfaced for diagnostics (`pro`, `max5x`, `max20x`, etc.). No
     /// behavior keys off it.
     public let subscriptionType: String?
 
-    public init(accessToken: String, expiresAt: Date?, subscriptionType: String?) {
+    public init(
+        accessToken: String,
+        expiresAt: Date?,
+        refreshToken: String? = nil,
+        subscriptionType: String?
+    ) {
         self.accessToken = accessToken
         self.expiresAt = expiresAt
+        self.refreshToken = refreshToken
         self.subscriptionType = subscriptionType
     }
 }
@@ -112,10 +119,23 @@ public struct KeychainOAuth: Sendable {
     /// find-generic-password -w` and returns the printed JSON blob.
     /// See the type doc for why we use the CLI instead of SecItem.
     ///
-    /// We deliberately do NOT pin `-a <username>` — Claude Code stores
-    /// the entry under the current user but the service name is unique
-    /// on a normal install, and skipping `-a` keeps us robust to
-    /// account-name edge cases (renamed accounts, multi-user setups).
+    /// ## Why we try `-a NSUserName()` first, then fall back to no-acct
+    ///
+    /// Claude Code 2.x writes a *new* `Claude Code-credentials` item with
+    /// `acct` set to the macOS username (`NSUserName()`). Older installs
+    /// (or `claude setup-token` paths) leave a separate item with the
+    /// same service name and `acct = ""` — and on a machine that
+    /// upgraded, both items coexist.
+    ///
+    /// `security find-generic-password -s X -w` (no `-a`) silently picks
+    /// whichever item the keychain returns first — empirically the
+    /// legacy `acct=""` one, which Claude Code 2.x no longer refreshes.
+    /// The result is a token that expires ~8 hours after the *original*
+    /// login and never updates again — exactly the stall behind #6.
+    ///
+    /// Strategy: try `-a NSUserName()` first; on errSecItemNotFound
+    /// (status 44), fall back to no-acct so older Claude Code installs
+    /// that never wrote the per-user item still work.
     ///
     /// Exit-status mapping comes from the `security(1)` man page and
     /// confirmation from `SecBase.h`:
@@ -125,13 +145,31 @@ public struct KeychainOAuth: Sendable {
     ///   - 51 → `errSecInteractionNotAllowed` (-25308, masked) — non-UI context
     /// Anything else is surfaced raw via `.unexpectedStatus`.
     public static let defaultRawReader: RawReader = {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = [
+        let userScopedResult = runSecurityCLI(args: [
             "find-generic-password",
             "-s", KeychainOAuth.serviceName,
+            "-a", NSUserName(),
             "-w",
-        ]
+        ])
+        if case .failure(.notFound) = userScopedResult {
+            // Fall back to the legacy no-acct read for older Claude
+            // Code installs that never wrote the per-user item.
+            return runSecurityCLI(args: [
+                "find-generic-password",
+                "-s", KeychainOAuth.serviceName,
+                "-w",
+            ])
+        }
+        return userScopedResult
+    }
+
+    /// One-shot subprocess invocation with the 5-second timeout the
+    /// production keychain workflow needs. Extracted so the per-user
+    /// and legacy reads share identical error-handling.
+    private static func runSecurityCLI(args: [String]) -> Result<Data, KeychainOAuthError> {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = args
         let stdout = Pipe()
         let stderr = Pipe()
         process.standardOutput = stdout
@@ -248,13 +286,79 @@ public struct KeychainOAuth: Sendable {
             }
         }
 
+        let refreshToken = (oauth["refreshToken"] as? String).flatMap {
+            $0.isEmpty ? nil : $0
+        }
         let subscriptionType = oauth["subscriptionType"] as? String
 
         return .success(OAuthCredential(
             accessToken: accessToken,
             expiresAt: expiresAt,
+            refreshToken: refreshToken,
             subscriptionType: subscriptionType
         ))
+    }
+
+    /// Update the on-disk credential after a successful OAuth refresh.
+    /// Reads the current blob, mutates the access token / refresh token
+    /// / expiry, and writes the modified blob back via
+    /// `security add-generic-password -U`. Other fields (scopes,
+    /// subscriptionType, anything Claude Code adds we don't model)
+    /// round-trip unchanged so we can't accidentally strip a field
+    /// Claude Code relies on later.
+    ///
+    /// Writes are scoped to `acct=NSUserName()`, mirroring the read
+    /// path. If the existing entry was a legacy `acct=""` item, we
+    /// still write the per-user item — the next read picks it up
+    /// thanks to the `-a $USER` first / fallback strategy.
+    public func update(
+        accessToken: String,
+        refreshToken: String,
+        expiresAt: Date
+    ) -> Result<Void, KeychainOAuthError> {
+        // 1. Pull the current blob so we preserve any fields we don't model.
+        let raw: Data
+        switch rawReader() {
+        case .success(let data):
+            raw = data
+        case .failure(let err):
+            return .failure(err)
+        }
+        let trimmed = raw.trimmedASCIIWhitespace()
+        guard var top = (try? JSONSerialization.jsonObject(with: trimmed)) as? [String: Any],
+              var oauth = top["claudeAiOauth"] as? [String: Any]
+        else {
+            return .failure(.malformedJSON(underlying: "couldn't decode existing blob for round-trip"))
+        }
+
+        // 2. Mutate just the three fields the refresh response gives us.
+        // expiresAt is stored as Unix milliseconds — matches Claude Code's
+        // own format (verified live).
+        oauth["accessToken"] = accessToken
+        oauth["refreshToken"] = refreshToken
+        oauth["expiresAt"] = Int64(expiresAt.timeIntervalSince1970 * 1000)
+        top["claudeAiOauth"] = oauth
+
+        let updatedJSON: Data
+        do {
+            updatedJSON = try JSONSerialization.data(withJSONObject: top)
+        } catch {
+            return .failure(.malformedJSON(underlying: "re-serialize: \(error.localizedDescription)"))
+        }
+
+        // 3. Write back. `-U` updates an existing item or creates a new
+        // one. We scope by `-a NSUserName()` so we match Claude Code 2.x's
+        // per-user item rather than touching the legacy `acct=""` item.
+        guard let jsonString = String(data: updatedJSON, encoding: .utf8) else {
+            return .failure(.malformedJSON(underlying: "non-UTF8 serialized blob"))
+        }
+        return Self.runSecurityCLI(args: [
+            "add-generic-password",
+            "-U",                       // update if exists
+            "-s", Self.serviceName,
+            "-a", NSUserName(),
+            "-w", jsonString,
+        ]).map { _ in () }
     }
 }
 

--- a/PacerCore/Sources/PacerCore/RateLimit/DisplayCycle.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/DisplayCycle.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One rate-limit window's time bracket as the dashboard should display
+/// it — distinct from the *underlying sample's* cycle, which may already
+/// be in the past.
+///
+/// When `now < resetsAt`, this just mirrors the underlying cycle. When
+/// `now >= resetsAt` (the displayed sample is from a cycle that already
+/// ended, and Pacer hasn't ingested a fresh sample yet), the bracket
+/// rolls forward by one duration and `isAwaiting` flips true so every
+/// consumer — chart, hero %, pace chip, caption — can suppress
+/// prior-cycle numbers in favor of an "awaiting first sample" treatment.
+///
+/// See #4 for the UX motivation and #2 for the visual bug that surfaced
+/// the underlying staleness.
+public struct DisplayCycle: Sendable, Equatable {
+    /// Left edge of the displayed window. For an active cycle, this is
+    /// `resetsAt - duration`. For an awaiting cycle, this is the prior
+    /// sample's `resetsAt` (i.e. the moment the new cycle would start).
+    public let cycleStart: Date
+    /// Right edge of the displayed window. For an active cycle, the
+    /// sample's own `resetsAt`. For an awaiting cycle, one `duration`
+    /// past it.
+    public let resetsAt: Date
+    /// True when the displayed cycle has been rolled forward because
+    /// the underlying sample's cycle already ended. Consumers must
+    /// render a neutral placeholder when this is true — the
+    /// percentages and band classifications from the prior sample are
+    /// not meaningful for the new cycle.
+    public let isAwaiting: Bool
+    /// Fraction (0…1) of the displayed cycle that has elapsed. Always
+    /// 0 when `isAwaiting` is true (the new cycle hasn't started
+    /// accumulating from Pacer's perspective).
+    public let paceFraction: Double
+
+    public init(cycleStart: Date, resetsAt: Date, isAwaiting: Bool, paceFraction: Double) {
+        self.cycleStart = cycleStart
+        self.resetsAt = resetsAt
+        self.isAwaiting = isAwaiting
+        self.paceFraction = paceFraction
+    }
+}
+
+public extension DisplayCycle {
+    /// Resolve the display cycle for one window. `resetsAt` is the most
+    /// recent sample's reset time, `duration` is the window's nominal
+    /// length (e.g. 5×3600 for the 5-hour window). Pass `now` in tests
+    /// to control time; production uses the current date.
+    static func resolve(
+        resetsAt: Date,
+        duration: TimeInterval,
+        now: Date = Date()
+    ) -> DisplayCycle {
+        if now >= resetsAt {
+            // Prior cycle has ended. Roll forward by exactly one
+            // duration. The new bracket is a placeholder — its
+            // boundaries are correct relative to the prior reset, but
+            // no data populates it until a fresh sample lands.
+            return DisplayCycle(
+                cycleStart: resetsAt,
+                resetsAt: resetsAt.addingTimeInterval(duration),
+                isAwaiting: true,
+                paceFraction: 0
+            )
+        }
+        let cycleStart = resetsAt.addingTimeInterval(-duration)
+        let elapsed = now.timeIntervalSince(cycleStart)
+        let paceFraction = max(0, min(1, elapsed / duration))
+        return DisplayCycle(
+            cycleStart: cycleStart,
+            resetsAt: resetsAt,
+            isAwaiting: false,
+            paceFraction: paceFraction
+        )
+    }
+}

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -80,15 +80,24 @@ public struct OAuthClient: Sendable {
     private let keychain: KeychainOAuth
     private let transport: Transport
     private let now: @Sendable () -> Date
+    /// Optional manual access-token source. Default reads from the
+    /// App Group UserDefaults entry that the Settings UI writes; tests
+    /// inject a fixed closure. When this returns a non-empty value, the
+    /// poller skips the keychain read entirely and uses the override
+    /// directly — workaround for Claude Code 2.x not persisting
+    /// refreshed tokens to the keychain (#6).
+    private let tokenOverride: @Sendable () -> String?
 
     public init(
         keychain: KeychainOAuth = KeychainOAuth(),
         transport: @escaping Transport = OAuthClient.defaultTransport,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        tokenOverride: @escaping @Sendable () -> String? = { PacerPreferences.oauthTokenOverride() }
     ) {
         self.keychain = keychain
         self.transport = transport
         self.now = now
+        self.tokenOverride = tokenOverride
     }
 
     /// Production transport: `URLSession.shared.data(for:)` plus the
@@ -107,28 +116,44 @@ public struct OAuthClient: Sendable {
     /// One round-trip against `/api/oauth/usage`. Returns the typed
     /// snapshot or an `OAuthClientError`.
     public func fetchUsage() async -> Result<RateLimitSnapshot, OAuthClientError> {
-        // Step 1: read credential. Map keychain errors to client errors
-        // so the caller switches on a single error type.
+        // Step 1: resolve the access token. Manual override (Settings
+        // → Authentication) wins when present — we don't even read the
+        // keychain, since the override exists exactly for cases where
+        // the keychain copy is stale (#6). Otherwise: keychain read,
+        // mapping its errors to ours so the caller switches on one
+        // error type.
         let credential: OAuthCredential
-        switch keychain.read() {
-        case .success(let c):
-            credential = c
-        case .failure(.notFound):
-            return .failure(.credentialsNotFound)
-        case .failure(.accessDenied):
-            return .failure(.keychainAccessDenied)
-        case .failure(.malformedJSON(let underlying)):
-            return .failure(.keychainMalformed(underlying))
-        case .failure(.unexpectedStatus(let status)):
-            return .failure(.keychainStatus(status))
-        }
+        if let override = tokenOverride() {
+            // Skip the expiresAt gate too — we have no local expiry
+            // for an override, so the server is the only authority.
+            // A stale override surfaces as `.unauthorized` on the next
+            // poll, which the transition logger reports clearly.
+            credential = OAuthCredential(
+                accessToken: override,
+                expiresAt: nil,
+                subscriptionType: nil
+            )
+        } else {
+            switch keychain.read() {
+            case .success(let c):
+                credential = c
+            case .failure(.notFound):
+                return .failure(.credentialsNotFound)
+            case .failure(.accessDenied):
+                return .failure(.keychainAccessDenied)
+            case .failure(.malformedJSON(let underlying)):
+                return .failure(.keychainMalformed(underlying))
+            case .failure(.unexpectedStatus(let status)):
+                return .failure(.keychainStatus(status))
+            }
 
-        // Step 2: skip-if-expired. Local clock gate to avoid a
-        // guaranteed 401. Server is authoritative for borderline
-        // cases (clock skew under a few minutes), so we check strict
-        // expiry only.
-        if let expiresAt = credential.expiresAt, expiresAt < now() {
-            return .failure(.tokenExpired(at: expiresAt))
+            // Step 2: skip-if-expired. Local clock gate to avoid a
+            // guaranteed 401. Server is authoritative for borderline
+            // cases (clock skew under a few minutes), so we check
+            // strict expiry only.
+            if let expiresAt = credential.expiresAt, expiresAt < now() {
+                return .failure(.tokenExpired(at: expiresAt))
+            }
         }
 
         // Step 3: build request.
@@ -316,4 +341,146 @@ func parseOAuthISO8601(_ s: String) -> Date? {
 
 private func truncate(_ s: String, max: Int) -> String {
     s.count <= max ? s : String(s.prefix(max)) + "..."
+}
+
+// MARK: - Refresh (on-demand, via Settings → Authentication)
+
+/// Errors from `OAuthClient.refresh()`. Distinct enum from
+/// `OAuthClientError` because the failure modes are different — refresh
+/// has its own keychain-write path and doesn't have a `.tokenExpired`
+/// short-circuit (that's the whole reason refresh exists).
+public enum OAuthRefreshError: Error, Sendable {
+    /// Keychain blob lacked a non-empty `refreshToken`. Either a legacy
+    /// blob from before Claude Code added the field, or the user never
+    /// signed in. Either way: surface to the user; only re-login recovers.
+    case noRefreshToken
+    /// Keychain read failed (notFound, accessDenied, etc.) — same
+    /// recovery as `OAuthClientError.credentialsNotFound`/`keychainAccessDenied`.
+    case keychainRead(KeychainOAuthError)
+    /// HTTP refresh succeeded but writing the new credential back to
+    /// the keychain failed. The fresh access token IS still good in
+    /// memory until expiry — return it to the caller so the immediate
+    /// poll succeeds, but log this so the user knows to investigate.
+    case keychainWrite(KeychainOAuthError)
+    /// URLSession-level failure (DNS, TLS, connection refused, etc.).
+    case transport(underlying: Error)
+    /// Server replied with a non-2xx. 400/401 usually means the refresh
+    /// token has been rotated by another client (Claude Code itself)
+    /// or revoked server-side; recovery is `claude logout && claude login`.
+    case http(status: Int, body: String)
+    /// 2xx response but the JSON didn't match the documented shape.
+    /// Probably means Anthropic changed the refresh response schema.
+    case responseSchemaMismatch(String)
+}
+
+public extension OAuthClient {
+    /// Anthropic's OAuth refresh endpoint — same one Claude Code itself
+    /// uses. Reverse-engineered from community statusline / auth tools;
+    /// not part of any public API surface. See #6 for sourcing.
+    static let refreshEndpoint = URL(string: "https://console.anthropic.com/v1/oauth/token")!
+
+    /// CLIENT_ID baked into Claude Code's distribution. Hardcoded here
+    /// because Anthropic's refresh endpoint requires it for the
+    /// `refresh_token` grant. If Anthropic ever rotates this, both
+    /// Claude Code and Pacer break at once.
+    static let refreshClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    /// Force a refresh of the OAuth access token using the refreshToken
+    /// stored in the keychain. On success, persists the rotated
+    /// credential back to the keychain (so the next read picks it up).
+    ///
+    /// **Race warning:** Anthropic rotates the refresh token on every
+    /// successful call. Once Pacer refreshes, Claude Code's in-memory
+    /// refresh token is no longer valid — the parallel CLI session
+    /// will need `claude logout && claude login` next time it tries to
+    /// auto-refresh. UI surfaces this caveat. See #6.
+    func refresh() async -> Result<OAuthCredential, OAuthRefreshError> {
+        // Step 1: read the current credential to obtain the refreshToken.
+        let current: OAuthCredential
+        switch keychain.read() {
+        case .success(let c):
+            current = c
+        case .failure(let e):
+            return .failure(.keychainRead(e))
+        }
+        guard let refreshTokenValue = current.refreshToken, !refreshTokenValue.isEmpty else {
+            return .failure(.noRefreshToken)
+        }
+
+        // Step 2: build the JSON request body. Standard OAuth 2.0
+        // refresh_token grant + Anthropic's hardcoded client_id.
+        let body: [String: String] = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshTokenValue,
+            "client_id": Self.refreshClientID,
+        ]
+        let bodyData: Data
+        do {
+            bodyData = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            return .failure(.responseSchemaMismatch("encode body: \(error.localizedDescription)"))
+        }
+
+        var request = URLRequest(url: Self.refreshEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+        request.httpBody = bodyData
+
+        // Step 3: send the request.
+        let data: Data
+        let response: HTTPURLResponse
+        do {
+            (data, response) = try await transport(request)
+        } catch {
+            return .failure(.transport(underlying: error))
+        }
+
+        guard response.statusCode == 200 else {
+            let bodyString = String(data: data, encoding: .utf8) ?? ""
+            return .failure(.http(
+                status: response.statusCode,
+                body: truncate(bodyString, max: 200)
+            ))
+        }
+
+        // Step 4: parse the OAuth 2.0 token response.
+        struct RefreshPayload: Decodable {
+            let access_token: String
+            let refresh_token: String
+            let expires_in: Int  // seconds
+        }
+        let parsed: RefreshPayload
+        do {
+            parsed = try JSONDecoder().decode(RefreshPayload.self, from: data)
+        } catch {
+            return .failure(.responseSchemaMismatch("decode: \(error.localizedDescription)"))
+        }
+
+        let newExpiresAt = now().addingTimeInterval(TimeInterval(parsed.expires_in))
+
+        // Step 5: persist back to the keychain. If this fails, return
+        // the fresh credential anyway — it's still good in memory for
+        // the immediate next request, and the user can investigate the
+        // keychain write later.
+        let writeResult = keychain.update(
+            accessToken: parsed.access_token,
+            refreshToken: parsed.refresh_token,
+            expiresAt: newExpiresAt
+        )
+
+        let fresh = OAuthCredential(
+            accessToken: parsed.access_token,
+            expiresAt: newExpiresAt,
+            refreshToken: parsed.refresh_token,
+            subscriptionType: current.subscriptionType
+        )
+
+        switch writeResult {
+        case .success:
+            return .success(fresh)
+        case .failure(let e):
+            return .failure(.keychainWrite(e))
+        }
+    }
 }

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -216,11 +216,64 @@ public actor OAuthPoller {
         let now = clock.now()
         lastPollAt = now
 
+        let previousOutcome = lastOutcome
         let outcome = await categorize(result)
         lastOutcome = outcome
         let delay = nextDelaySeconds(for: outcome, result: result)
         nextPollAt = now.addingTimeInterval(delay)
+
+        // Telemetry for #3: log on outcome-category transitions. A
+        // steady-state failure (.tokenExpired for 16 hours) produces a
+        // single log line, not one per poll; recovery logs once too.
+        if !Self.sameCategory(previousOutcome, outcome) {
+            Log.write("OAuthPoller", Self.summarize(outcome: outcome, delay: delay))
+        }
         return outcome
+    }
+
+    /// Two outcomes are "the same category" when their enum case is the
+    /// same, ignoring associated values — so a stream of `.http(503)`
+    /// then `.http(504)` is treated as one ongoing transport problem.
+    private static func sameCategory(_ a: PollOutcome?, _ b: PollOutcome?) -> Bool {
+        switch (a, b) {
+        case (nil, nil): return true
+        case (nil, _), (_, nil): return false
+        case (.some(let x), .some(let y)):
+            let nameX = Mirror(reflecting: x).children.first?.label ?? "\(x)"
+            let nameY = Mirror(reflecting: y).children.first?.label ?? "\(y)"
+            return nameX == nameY
+        }
+    }
+
+    private static func summarize(outcome: PollOutcome, delay: TimeInterval) -> String {
+        let next = "next=\(Int(delay.rounded()))s"
+        switch outcome {
+        case .success(let fh, let sd):
+            let f = fh.map { String(format: "%.1f%%", $0) } ?? "nil"
+            let s = sd.map { String(format: "%.1f%%", $0) } ?? "nil"
+            return "ok 5h=\(f) 7d=\(s); \(next)"
+        case .credentialsNotFound:
+            return "credentials missing — sign into Claude Code; \(next)"
+        case .keychainAccessDenied:
+            return "keychain access denied — approve in foreground app; \(next)"
+        case .keychainMalformed:
+            return "keychain blob malformed; \(next)"
+        case .keychainStatus(let status):
+            return "keychain OSStatus=\(status); \(next)"
+        case .tokenExpired:
+            return "access token expired — Claude Code must refresh it; \(next)"
+        case .unauthorized:
+            return "unauthorized (401); \(next)"
+        case .rateLimited(let retryAfter):
+            let ra = retryAfter.map { "\(Int($0))s" } ?? "nil"
+            return "rate-limited (429) retryAfter=\(ra); \(next)"
+        case .http(let status):
+            return "http \(status); \(next)"
+        case .transport:
+            return "transport error (network); \(next)"
+        case .responseSchemaMismatch:
+            return "response schema mismatch; \(next)"
+        }
     }
 
     private func categorize(_ result: Result<RateLimitSnapshot, OAuthClientError>) async -> PollOutcome {

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -54,6 +54,13 @@ public enum PacerPreferenceKeys {
     /// Sort field used by the Projects view. Persists across launches
     /// so reopening the app doesn't snap back to "by cost descending".
     public static let projectsSort           = "pacer.view.projectsSort"
+    /// Manual OAuth access-token override. When non-empty, the OAuth
+    /// poller uses this token instead of reading the access token out
+    /// of the `Claude Code-credentials` keychain entry. Workaround for
+    /// Claude Code 2.x not persisting refreshed tokens back to the
+    /// keychain (see #6). Stored as a plain string; lives in the App
+    /// Group UserDefaults suite alongside the rest of Pacer's prefs.
+    public static let oauthTokenOverride     = "pacer.oauth.tokenOverride"
 }
 
 /// Convenience accessor for the App Group-suite UserDefaults. Falls
@@ -80,5 +87,14 @@ public enum PacerPreferences {
         case "display":   return .display
         default:          return .auto
         }
+    }
+
+    /// Trimmed OAuth token override. Returns nil for an absent or
+    /// whitespace-only value so callers can `if let` straight through
+    /// to the "use keychain" path. See #6 for why this exists.
+    public static func oauthTokenOverride(from store: UserDefaults = store) -> String? {
+        let raw = store.string(forKey: PacerPreferenceKeys.oauthTokenOverride) ?? ""
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/PacerCore/Tests/PacerCoreTests/DisplayCycleTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/DisplayCycleTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite struct DisplayCycleTests {
+
+    /// A reset 2h ahead inside a 5h window → not awaiting, 3h elapsed,
+    /// paceFraction = 0.6.
+    @Test func activeMidCycle() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let resetsAt = now.addingTimeInterval(2 * 3600)
+        let cycle = DisplayCycle.resolve(resetsAt: resetsAt, duration: 5 * 3600, now: now)
+        #expect(!cycle.isAwaiting)
+        #expect(cycle.resetsAt == resetsAt)
+        #expect(cycle.cycleStart == resetsAt.addingTimeInterval(-5 * 3600))
+        #expect(abs(cycle.paceFraction - 0.6) < 0.0001)
+    }
+
+    /// At cycle start (now == cycleStart) → paceFraction = 0.
+    @Test func activeAtCycleStart() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let resetsAt = now.addingTimeInterval(5 * 3600)
+        let cycle = DisplayCycle.resolve(resetsAt: resetsAt, duration: 5 * 3600, now: now)
+        #expect(!cycle.isAwaiting)
+        #expect(cycle.paceFraction == 0)
+    }
+
+    /// 1 minute before reset → paceFraction just under 1.
+    @Test func activeNearCycleEnd() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let resetsAt = now.addingTimeInterval(60)
+        let cycle = DisplayCycle.resolve(resetsAt: resetsAt, duration: 5 * 3600, now: now)
+        #expect(!cycle.isAwaiting)
+        #expect(cycle.paceFraction > 0.99)
+        #expect(cycle.paceFraction < 1)
+    }
+
+    /// 1 minute past reset → awaiting, cycle rolled forward by one
+    /// duration. paceFraction = 0 (the new cycle hasn't started
+    /// accumulating from Pacer's perspective).
+    @Test func awaitingJustAfterReset() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let resetsAt = now.addingTimeInterval(-60)
+        let cycle = DisplayCycle.resolve(resetsAt: resetsAt, duration: 5 * 3600, now: now)
+        #expect(cycle.isAwaiting)
+        #expect(cycle.cycleStart == resetsAt)
+        #expect(cycle.resetsAt == resetsAt.addingTimeInterval(5 * 3600))
+        #expect(cycle.paceFraction == 0)
+    }
+
+    /// 16h past reset (the real-world scenario from #2/#3) → still
+    /// awaiting; rollforward shape unchanged.
+    @Test func awaitingHoursAfterReset() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let resetsAt = now.addingTimeInterval(-16 * 3600)
+        let cycle = DisplayCycle.resolve(resetsAt: resetsAt, duration: 5 * 3600, now: now)
+        #expect(cycle.isAwaiting)
+        #expect(cycle.cycleStart == resetsAt)
+        #expect(cycle.resetsAt == resetsAt.addingTimeInterval(5 * 3600))
+    }
+
+    /// Exact boundary (now == resetsAt) → awaiting. The prior cycle is
+    /// done; the next instant belongs to the new cycle.
+    @Test func boundaryExactlyAtReset() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let cycle = DisplayCycle.resolve(resetsAt: now, duration: 5 * 3600, now: now)
+        #expect(cycle.isAwaiting)
+        #expect(cycle.cycleStart == now)
+    }
+
+    /// 7-day window, mid-cycle. Same math, different scale.
+    @Test func sevenDayWindowActiveMidCycle() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let resetsAt = now.addingTimeInterval(4 * 86400)  // 4 days ahead, so 3 days elapsed
+        let cycle = DisplayCycle.resolve(resetsAt: resetsAt, duration: 7 * 86400, now: now)
+        #expect(!cycle.isAwaiting)
+        #expect(abs(cycle.paceFraction - 3.0 / 7.0) < 0.0001)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/OAuthClientTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/OAuthClientTests.swift
@@ -234,6 +234,47 @@ import Testing
 
     // MARK: - Local expiry gate
 
+    @Test func tokenOverrideBypassesKeychainAndExpiry() async {
+        // Keychain is broken AND the keychain blob's expiresAt is in
+        // the past — neither matters when an override is present. The
+        // request must go out carrying the override token verbatim.
+        let pastExpiry = Date(timeIntervalSince1970: 1_700_000_000)
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let brokenKeychain = KeychainOAuth(rawReader: { .failure(.accessDenied) })
+        let overrideToken = "sk-ant-oat01-OVERRIDE"
+        let observedAuth = Box<String?>(nil)
+        let c = OAuthClient(
+            keychain: brokenKeychain,
+            transport: { req in
+                observedAuth.value = req.value(forHTTPHeaderField: "Authorization")
+                return self.http(200, body: #"{"five_hour":{"utilization":1,"resets_at":""}}"#)
+            },
+            now: { now },
+            tokenOverride: { overrideToken }
+        )
+        _ = await c.fetchUsage()
+        #expect(observedAuth.value == "Bearer \(overrideToken)")
+        // Sanity: also check that a keychain blob with `pastExpiry`
+        // wouldn't have routed here if the override path were skipped.
+        // (Kept for documentation; the brokenKeychain alone proves it.)
+        _ = pastExpiry
+    }
+
+    @Test func emptyOverrideFallsThroughToKeychain() async {
+        // Whitespace-trimmed empty override = no override → keychain is
+        // authoritative. Verifies the closure can return nil/empty and
+        // the keychain path takes over.
+        let c = OAuthClient(
+            keychain: goodKeychain(),
+            transport: { _ in self.http(200, body: #"{"five_hour":{"utilization":7,"resets_at":""}}"#) },
+            tokenOverride: { nil }
+        )
+        guard case .success = await c.fetchUsage() else {
+            Issue.record("expected success on keychain fallback")
+            return
+        }
+    }
+
     @Test func skipsExpiredToken() async {
         // expiresAt in the past — we short-circuit before hitting the
         // network.

--- a/PacerCore/Tests/PacerCoreTests/PacerPreferencesTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PacerPreferencesTests.swift
@@ -38,3 +38,26 @@ private func makeIsolatedDefaults() -> UserDefaults {
     defaults.set("nonsense", forKey: PacerPreferenceKeys.costMode)
     #expect(PacerPreferences.costMode(from: defaults) == .auto)
 }
+
+@Test func oauthTokenOverrideAbsentReturnsNil() {
+    let defaults = makeIsolatedDefaults()
+    #expect(PacerPreferences.oauthTokenOverride(from: defaults) == nil)
+}
+
+@Test func oauthTokenOverrideEmptyStringReturnsNil() {
+    let defaults = makeIsolatedDefaults()
+    defaults.set("", forKey: PacerPreferenceKeys.oauthTokenOverride)
+    #expect(PacerPreferences.oauthTokenOverride(from: defaults) == nil)
+}
+
+@Test func oauthTokenOverrideWhitespaceOnlyReturnsNil() {
+    let defaults = makeIsolatedDefaults()
+    defaults.set("   \n  ", forKey: PacerPreferenceKeys.oauthTokenOverride)
+    #expect(PacerPreferences.oauthTokenOverride(from: defaults) == nil)
+}
+
+@Test func oauthTokenOverrideTrimsWhitespace() {
+    let defaults = makeIsolatedDefaults()
+    defaults.set("  sk-ant-oat01-abc\n", forKey: PacerPreferenceKeys.oauthTokenOverride)
+    #expect(PacerPreferences.oauthTokenOverride(from: defaults) == "sk-ant-oat01-abc")
+}

--- a/Widgets/PaceChartWidget.swift
+++ b/Widgets/PaceChartWidget.swift
@@ -115,8 +115,12 @@ struct PaceChartProvider: AppIntentTimelineProvider {
             .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
             .sorted { $0.sampledAt < $1.sampledAt }
             .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }
-        if points.last?.time != now {
-            points.append(.init(time: now, value: latest.usedPercentage))
+        // Clamp the synthesized tail to the cycle: once `now > resetsAt`
+        // (cycle ended, no fresh sample yet), a tail at `now` falls
+        // outside `chartXScale`'s domain.
+        let tailTime = min(now, resetsAt)
+        if points.last?.time != tailTime {
+            points.append(.init(time: tailTime, value: latest.usedPercentage))
         }
         let chart = PaceChartView.Data(
             cycleStart: cycleStart,

--- a/Widgets/PaceChartWidget.swift
+++ b/Widgets/PaceChartWidget.swift
@@ -34,13 +34,17 @@ struct PaceChartEntry: TimelineEntry {
         let chart: PaceChartView.Data
         let resetsAt: Date
 
-        var paceEndPct: Double {
-            PaceMath.paceFraction(
-                now: Date(),
-                resetsAt: resetsAt,
-                windowDuration: chart.durationSeconds
-            ) * 100
+        /// Active-vs-awaiting bracket. When awaiting, the widget should
+        /// render its empty-state treatment instead of the chart + %s
+        /// (see #4 — prior-cycle numbers aren't meaningful once the
+        /// cycle has ended).
+        var cycle: DisplayCycle {
+            DisplayCycle.resolve(resetsAt: resetsAt, duration: chart.durationSeconds)
         }
+
+        var isAwaiting: Bool { cycle.isAwaiting }
+
+        var paceEndPct: Double { cycle.paceFraction * 100 }
 
         var band: PaceBand {
             PaceBand(usedPct: chart.usedPct, paceEndPct: paceEndPct)
@@ -199,16 +203,17 @@ struct PaceChartWidgetView: View {
     @ViewBuilder
     private var small: some View {
         let target = smallTarget()
+        let awaiting = target.state?.isAwaiting == true
         VStack(alignment: .leading, spacing: 4) {
             WidgetTitleBar(
                 title: target.title,
-                dotColor: target.state?.band.color
+                dotColor: awaiting ? .secondary : target.state?.band.color
             ) {
-                if let s = target.state {
+                if let s = target.state, !s.isAwaiting {
                     paceFraction(used: s.chart.usedPct, pace: s.paceEndPct, compact: true)
                 }
             }
-            if let s = target.state {
+            if let s = target.state, !s.isAwaiting {
                 // Caption sits between the title bar and the chart so it
                 // gets the full column width (~134pt) instead of fighting
                 // for space below the chart's `maxHeight: .infinity`.
@@ -225,6 +230,8 @@ struct PaceChartWidgetView: View {
                     .lineLimit(2)
                 PaceChartView(data: s.chart, style: .compact)
                     .frame(maxHeight: .infinity)
+            } else if awaiting {
+                WidgetEmptyState(message: "Cycle reset. Awaiting fresh sample.")
             } else {
                 WidgetEmptyState(message: "Waiting for the first rate-limit reading.")
             }
@@ -294,17 +301,18 @@ struct PaceChartWidgetView: View {
         state: PaceChartEntry.WindowState?,
         style: PaceChartView.Style
     ) -> some View {
+        let awaiting = state?.isAwaiting == true
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
                 Circle()
-                    .fill(state?.band.color ?? .secondary)
+                    .fill(awaiting ? Color.secondary : (state?.band.color ?? .secondary))
                     .frame(width: 6, height: 6)
                 Text(label)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
             }
-            if let state {
+            if let state, !state.isAwaiting {
                 paceFraction(used: state.chart.usedPct, pace: state.paceEndPct, compact: true)
                 // Caption goes above the chart so it has the column's
                 // full width (~148pt at medium) instead of being squeezed
@@ -321,6 +329,12 @@ struct PaceChartWidgetView: View {
                     .lineLimit(2)
                 PaceChartView(data: state.chart, style: style)
                     .frame(maxHeight: .infinity)
+            } else if awaiting {
+                Text("cycle reset · awaiting sample")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                Spacer(minLength: 0)
             } else {
                 Text("collecting…")
                     .font(.caption2)
@@ -333,20 +347,21 @@ struct PaceChartWidgetView: View {
 
     @ViewBuilder
     private func largeRow(label: String, state: PaceChartEntry.WindowState?) -> some View {
+        let awaiting = state?.isAwaiting == true
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 Circle()
-                    .fill(state?.band.color ?? .secondary)
+                    .fill(awaiting ? Color.secondary : (state?.band.color ?? .secondary))
                     .frame(width: 7, height: 7)
                 Text(label)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.primary)
                 Spacer()
-                if let state {
+                if let state, !state.isAwaiting {
                     paceFraction(used: state.chart.usedPct, pace: state.paceEndPct, compact: false)
                 }
             }
-            if let state {
+            if let state, !state.isAwaiting {
                 // Large widget gets the dashboard treatment — axes and
                 // full label typography. With `.detailed` the chart
                 // looks identical to the app card.
@@ -359,6 +374,12 @@ struct PaceChartWidgetView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+            } else if awaiting {
+                Text("Cycle reset · awaiting first sample")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                Spacer(minLength: 0)
             } else {
                 Text("collecting…")
                     .font(.caption2)

--- a/bin/dev-install.sh
+++ b/bin/dev-install.sh
@@ -19,7 +19,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="Pacer.app"
 INSTALL_DIR="/Applications"
 INSTALLED_APP="${INSTALL_DIR}/${APP_NAME}"
-BUILD_OUTPUT="${REPO_ROOT}/Build/Build/Products/Debug/${APP_NAME}"
+# Resolved after the build — the product dir under -derivedDataPath
+# varies by Xcode version (newer emits <ddp>/Products/Debug, CI/older
+# emits <ddp>/Build/Products/Debug). See the resolver below.
+BUILD_OUTPUT=""
 
 # Legacy daemon labels — retired in favor of in-process collection,
 # but old installs may still have these registered. We bootout and
@@ -63,10 +66,17 @@ xcodebuild \
     build \
     | (grep -E '(error:|warning:|FAILED|SUCCEEDED)' || true)
 
-if [ ! -d "${BUILD_OUTPUT}" ]; then
-    echo "ERROR: build did not produce ${BUILD_OUTPUT}"
+# Locate the built bundle by its stable suffix. Both Xcode product-dir
+# layouts end in Products/Debug/Pacer.app, so resolving by suffix is
+# version-proof — a hardcoded path breaks whenever the maintainer's and
+# CI's toolchains disagree on the <derivedDataPath>/[Build/]Products nesting.
+BUILD_OUTPUT="$(find "${REPO_ROOT}/Build" -type d -name "${APP_NAME}" -path "*/Products/Debug/*" | head -1)"
+if [ -z "${BUILD_OUTPUT}" ] || [ ! -d "${BUILD_OUTPUT}" ]; then
+    echo "ERROR: build did not produce ${APP_NAME} under ${REPO_ROOT}/Build"
+    find "${REPO_ROOT}/Build" -name "${APP_NAME}" -type d 2>/dev/null | head -5
     exit 1
 fi
+echo "    built: ${BUILD_OUTPUT}"
 
 # 2b. Manually sign every binary inside the .app with Developer ID
 #     Application. This is what the eventual Sparkle release will use,

--- a/bin/dev-install.sh
+++ b/bin/dev-install.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="Pacer.app"
 INSTALL_DIR="/Applications"
 INSTALLED_APP="${INSTALL_DIR}/${APP_NAME}"
-BUILD_OUTPUT="${REPO_ROOT}/Build/Products/Debug/${APP_NAME}"
+BUILD_OUTPUT="${REPO_ROOT}/Build/Build/Products/Debug/${APP_NAME}"
 
 # Legacy daemon labels — retired in favor of in-process collection,
 # but old installs may still have these registered. We bootout and
@@ -59,6 +59,7 @@ xcodebuild \
     -scheme Pacer \
     -configuration Debug \
     -destination 'platform=macOS' \
+    -derivedDataPath "${REPO_ROOT}/Build" \
     build \
     | (grep -E '(error:|warning:|FAILED|SUCCEEDED)' || true)
 


### PR DESCRIPTION
## Summary

Closes #2, #3, #4, #6.

Four commits bundled into a single PR. They form a coherent story: visible chart-bleed bug → telemetry to surface the underlying poller stall → diagnosis fixes both the symptom *and* a deeper keychain-selector bug → UX for awaiting state → on-demand OAuth refresh + manual token override as the user-facing controls.

### Commit 1 — Pace chart bleed (#2) · `6b36a4a`
Synthesized tail point `(now, latest.usedPercentage)` could fall outside `chartXScale(domain: cycleStart...resetsAt)` when the 5-hour cycle had reset but no fresh sample had arrived. SwiftUI Charts doesn't clip line geometry past the domain, so the green usage line bled across the dashboard into the 7-day chart.

Fix: clamp the tail's x-coordinate to `min(now, resetsAt)` in `App/Views/PaceChartCard.swift` and `Widgets/PaceChartWidget.swift`. Targeted one-line change at the root cause.

### Commit 2 — Build output path consistency · `9bda509`
`make verify` / `make app` invoked `xcodebuild` without `-derivedDataPath`, so output landed in user-global DerivedData while `BUILD_OUTPUT` in `Makefile` + `bin/dev-install.sh` expected `$(REPO_ROOT)/Build/...`. `make install` broke mid-pipeline.

Fix: pin `-derivedDataPath` to `$(REPO_ROOT)/Build` in both `xcodebuild` invocations and update `BUILD_OUTPUT` in `Makefile` + `bin/dev-install.sh` to the path xcodebuild actually writes there (`Build/Build/Products/Debug/Pacer.app` — xcodebuild nests `Build/Products/<Config>/` under the configured derived-data path).

### Commit 3 — OAuth poller telemetry + awaiting UX + keychain fix (#3, #4) · `27df761`
**Three things in one commit because diagnosis and fix were interleaved:**

- **#3 — Poller stall telemetry (`OAuthPoller.swift`).** Added `Self.sameCategory()` + `Self.summarize()` and changed `runOneCycle()` to log via `Log.write("OAuthPoller", ...)` only on outcome-category transitions. A steady-state failure logs once (not 288×/day); recovery logs once. The first deployed log line — `[OAuthPoller] access token expired — Claude Code must refresh it` — was the smoking gun for the real bug below.

- **Keychain selector fix — the actual root cause of every "Pacer goes stale" symptom.** Claude Code 2.x writes a *new* `Claude Code-credentials` keychain item with `acct=$USER`; on machines upgraded through older versions, the legacy `acct=""` item also exists and is never refreshed. `security find-generic-password -s X -w` (no `-a`) picks an implementation-defined item — empirically the stale legacy one. `KeychainOAuth.defaultRawReader` now tries `-a NSUserName()` first with no-acct fallback for older installs. Subprocess plumbing extracted into a private `runSecurityCLI(args:)` helper.

- **#4 — DisplayCycle helper + awaiting UX migration (5 surfaces).** New `DisplayCycle` struct (`cycleStart`, `resetsAt`, `isAwaiting`, `paceFraction`) + `resolve(resetsAt:duration:now:)` factory. When `now >= resetsAt`, rolls cycle forward by exactly one duration and sets `isAwaiting=true`. Migrated `PaceChartCard.PaceChartColumn`, `HeroStripCard.paceTile`, `MenuBarContent.paceRow`/`tooltip`, and `Widgets/PaceChartWidget` (small / medium / large) to render an awaiting state ("—" or `WidgetEmptyState`) when the cycle has reset but no fresh sample exists. Menu-bar percent chips intentionally keep showing the prior-cycle % for at-a-glance continuity.

- **Stale-OAuth chip on `PaceChartCard.trailingChip`.** When the latest sample is from OAuth and older than 15 min, the chip turns yellow with a `⚠` icon and a `.help()` tooltip directing the user to relaunch Claude Code.

- **HeroStripCard cache refresh on OAuth polls.** Existing `.onChange(of: scanMeta...)` only fired on JSONL scans, missing OAuth-only updates. Added `.onChange(of: rateLimits.first?.sampledAt)`.

### Commit 4 — Settings → Authentication: refresh + token override (#6) · `06cec10`
**On-demand OAuth refresh (`OAuthClient.refresh()`).** Reads the keychain, POSTs to `console.anthropic.com/v1/oauth/token` with `grant_type=refresh_token` + the documented OAuth client ID (`9d1c250a-e61b-44d9-88ed-5944d1962f5e`), parses the response, persists the rotated credential via new `KeychainOAuth.update(accessToken:refreshToken:expiresAt:)`. Returns a typed `Result<OAuthCredential, OAuthRefreshError>`. On-demand only, not background — Anthropic rotates the refresh token on every call, which would race with a parallel `claude` CLI session's in-memory copy; on-demand bounds the race to button clicks.

**Manual token override.** `OAuthClient.init` takes a `tokenOverride: @Sendable () -> String?` closure (default reads from `PacerPreferences.oauthTokenOverride()`). When the closure returns non-nil, `fetchUsage()` skips both the keychain read and the local-expiry gate (server is the only authority for an override).

**`SettingsView` Authentication section** with two cards:
- `OAuthRefreshCard`: "Refresh now" button + spinner + inline `✓ Refreshed — expires <X> from now` / typed error per `OAuthRefreshError` case + footer documenting the race-with-Claude-Code caveat.
- `OAuthTokenOverrideCard`: separated `draft @State` from persisted `@AppStorage`, Save commits draft → @AppStorage. Test runs `OAuthClient.fetchUsage()` against the draft with the live keychain underneath (relabels to "Test keychain" when draft is empty so users can verify the production path). HTTP 403 surfaces a specific message about `setup-token` vs `claude login` since setup-tokens lack `user:sessions:claude_code` scope.

### Tests
- `DisplayCycleTests` — 7 tests (active mid-cycle, at-start, near-end, awaiting just-after-reset, awaiting 16h-after-reset, exact boundary, 7-day window).
- `OAuthClientTests` — 2 override-precedence tests (override bypasses keychain + expiry; empty override falls through).
- `PacerPreferencesTests` — 4 override-accessor tests (absent, empty, whitespace-only, trimming).
- 291 total tests; same 18 pre-existing CCusage ground-truth failures, no new regressions.

### Notes for the reviewer
- The Anthropic OAuth refresh endpoint and client ID are reverse-engineered (verified against three independent sources: OpenCode auth plugin, cedws `ANTHROPIC_AUTH` gist, DeepWiki of opencode-anthropic-auth). Worth a comment in code; if `console.anthropic.com` starts 404'ing, `platform.claude.com/v1/oauth/token` is the documented fallback per Claude Code 2.x's `cli.js`.
- Issue #5 was filed and retracted within the same session — the hex-suffixed `Claude Code-credentials-XXXXXXXX` keychain entries turned out to be MCP plugin OAuth tokens (`mcpOAuth` wrapper), not per-account Claude Code creds. The actual bug was the `acct` discrimination on the bare `Claude Code-credentials` service.
- No unit test for `OAuthClient.refresh()` itself — the `KeychainOAuth.update()` path shells out to `security` CLI which isn't trivially mockable. Would need an injectable writer mirroring the existing `rawReader` — small refactor, deferred.

## Test plan
- [ ] `make verify` / `make app` / `make install` produce `Build/Build/Products/Debug/Pacer.app` and install cleanly
- [ ] Chart bleed gone in `PaceChartCard` and `PaceChartWidget` when the 5-hour cycle has reset
- [ ] Letting Pacer sit through a cycle reset with no fresh sample: dashboard / menu bar popover / widget all render the awaiting state ("—", "awaiting first sample of new cycle", `WidgetEmptyState`)
- [ ] Menu-bar percent chips still show prior-cycle % during awaiting (intentional continuity)
- [ ] Stale-OAuth yellow ⚠ chip appears in `PaceChartCard.trailingChip` when OAuth sample age > 15 min
- [ ] OAuth poller log file shows one transition line per outcome-category change, not per cycle
- [ ] Settings → Authentication → "Refresh now" button: spinner → ✓ Refreshed → next poll picks up the new token
- [ ] Token override save / test (with draft) / test (empty draft = "Test keychain") / clear all behave correctly
- [ ] 403 on Test surfaces the actionable "use `claude login`, not `claude setup-token`" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)