### PR TITLE
Fix release pipeline (Sparkle signing), bump checkout, gitignore keys/, doc wt PR flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Show toolchain
         run: |
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Show toolchain
         run: xcodebuild -version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Need full history so `git describe` against the tag works
           # for embedding the version into the build (and so we can

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,12 @@ jobs:
         # lives under build/SourcePackages/checkouts/Sparkle.
         run: |
           set -euo pipefail
-          SIGN_UPDATE="$(find build/SourcePackages/checkouts/Sparkle/bin -name sign_update | head -1)"
+          # Sparkle ships TWO `sign_update`s: the modern EdDSA tool at
+          # bin/sign_update and a legacy DSA shell script at
+          # bin/old_dsa_scripts/sign_update. A bare `find ... | head -1`
+          # can pick the DSA one (it does on the GitHub runner), which
+          # rejects the `-f <keyfile>` EdDSA args and exits 1. Exclude it.
+          SIGN_UPDATE="$(find build/SourcePackages/checkouts/Sparkle/bin -name sign_update -not -path '*old_dsa_scripts*' | head -1)"
           if [ -z "${SIGN_UPDATE}" ] || [ ! -x "${SIGN_UPDATE}" ]; then
             echo "::error::Could not locate Sparkle's sign_update tool"
             find build -name sign_update 2>/dev/null | head -5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,12 +340,15 @@ jobs:
         # lives under build/SourcePackages/checkouts/Sparkle.
         run: |
           set -euo pipefail
-          # Sparkle ships TWO `sign_update`s: the modern EdDSA tool at
-          # bin/sign_update and a legacy DSA shell script at
-          # bin/old_dsa_scripts/sign_update. A bare `find ... | head -1`
-          # can pick the DSA one (it does on the GitHub runner), which
-          # rejects the `-f <keyfile>` EdDSA args and exits 1. Exclude it.
-          SIGN_UPDATE="$(find build/SourcePackages/checkouts/Sparkle/bin -name sign_update -not -path '*old_dsa_scripts*' | head -1)"
+          # The EdDSA `sign_update` we need is a PREBUILT binary inside the
+          # Sparkle artifact bundle, NOT in the source checkout. The source
+          # checkout's bin/ only carries the legacy DSA shell script
+          # (bin/old_dsa_scripts/sign_update), which rejects the `-f
+          # <keyfile>` EdDSA args and exits 1. The real tool lives at
+          # SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update. Search
+          # the whole SourcePackages tree for */Sparkle/bin/sign_update and
+          # exclude old_dsa_scripts so we land on the EdDSA binary.
+          SIGN_UPDATE="$(find build/SourcePackages -path '*/Sparkle/bin/sign_update' -not -path '*old_dsa_scripts*' | head -1)"
           if [ -z "${SIGN_UPDATE}" ] || [ ! -x "${SIGN_UPDATE}" ]; then
             echo "::error::Could not locate Sparkle's sign_update tool"
             find build -name sign_update 2>/dev/null | head -5

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,15 @@ Icon
 sparkle-private-key
 *.priv
 
+# Local release secrets — NEVER commit. The keys/ folder holds the
+# Developer ID .p12, the App Store Connect .p8, and a .env with the
+# cert password + notary IDs. The *.p12/*.p8/.env globs are belt-and-
+# suspenders in case a key file ever lands outside keys/.
+keys/
+*.p12
+*.p8
+.env
+
 # Local build artifacts
 *.app
 *.dmg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,34 @@ These are subtle, easy to miss, and break user-visible numbers:
   Anthropic OAuth fallback) — leave a comment so the next reader doesn't
   "fix" it back.
 
+## Reviewing pull requests
+
+- **Always pull a PR into an isolated worktree with `wt`** — never check
+  it out over your working tree. Use the [`wt`](https://worktrunk.dev)
+  CLI:
+
+  ```sh
+  wt switch pr:7          # fetches PR #7, creates ./.worktrees/<branch>, cds in
+  ```
+
+  Worktrees keep the PR's build artifacts, generated `Pacer.xcodeproj`,
+  and any local fix-ups from polluting `main`, and let the installed
+  `/Applications` app come from exactly one branch at a time.
+
+- **Verify before merging — build *and* run it.** `make test` +
+  `make verify` is the floor; `make install` and watch `make logs` is the
+  bar. Two classes of bug only show up when you actually run the branch:
+  - **Build-path drift.** Xcode's product dir under `-derivedDataPath`
+    is version-dependent (`<ddp>/Products/Debug` vs
+    `<ddp>/Build/Products/Debug`). Resolve the bundle by its
+    `*/Products/Debug/Pacer.app` suffix, never a hardcoded nesting — a
+    path that works on the contributor's toolchain can break on yours.
+  - **Keychain v1/v2 compat.** Confirm the OAuth poller logs
+    `[OAuthPoller] ok …` after install — that proves the live keychain
+    read still works. The reader tries `-a NSUserName()` (Claude Code
+    2.x per-user item) first and falls back to no-acct only on
+    `errSecItemNotFound`, so v1 (`acct=""`) installs keep working.
+
 ## App target — what's where
 
 The SwiftUI app is organized like this (under `App/`):


### PR DESCRIPTION
Infra/setup fixes uncovered while finishing the repo's release setup. Independent of #7 (no overlapping files).

## What's here
- **release: fix Sparkle update signing (release-blocker).** A \`dry_run\` of the release workflow surfaced that the \"Sign Sparkle update\" step picked the **legacy DSA** \`sign_update\` shell script (under \`bin/old_dsa_scripts/\`) instead of the **EdDSA** tool, which is a prebuilt binary in the Sparkle *artifacts* bundle (\`SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update\`). The DSA script rejects the \`-f <keyfile>\` args and exits 1. Now searches the whole \`SourcePackages\` tree for \`*/Sparkle/bin/sign_update\` excluding \`old_dsa_scripts\`. This was latent — no release had ever been cut, so the step had never executed.
- **CI: \`actions/checkout@v4 → v5\`** (Node 24 native; clears the deprecation warning).
- **gitignore: exclude local \`keys/\` folder** (Developer ID \`.p12\`, App Store Connect \`.p8\`, \`.env\`) + \`*.p12\`/\`*.p8\`/\`.env\` globs.
- **agents.md: require \`wt\` worktrees for PR review** + verify-before-merge (documents the build-path-drift and keychain-compat gotchas).

## Verification
Release workflow run end-to-end with \`dry_run=true\` on this branch: **green** — cert import, bundle signing, notarization + staple, DMG build, DMG sign + notarize, **and Sparkle signing** all pass (only \`Publish Release\`/\`Update appcast\` skipped, as designed under dry-run). All 8 release secrets confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)