### PR TITLE
release: fix gh-pages appcast bootstrap (rm -rf nuked .git)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,8 +429,12 @@ jobs:
           if gh api "repos/${GITHUB_REPOSITORY}/branches/gh-pages" >/dev/null 2>&1; then
             git worktree add -B gh-pages "${worktree}" origin/gh-pages
           else
+            # --orphan checks out an unborn branch, so the working tree is
+            # already empty (only the .git link file). Do NOT `rm -rf .* *`
+            # here: the .* glob matches .git and destroys the worktree link,
+            # which made every later git command fail with "not a git
+            # repository" (the v0.1.0 appcast bootstrap hit exactly this).
             git worktree add --orphan -B gh-pages "${worktree}"
-            (cd "${worktree}" && rm -rf .* * 2>/dev/null || true)
           fi
 
           appcast="${worktree}/appcast.xml"


### PR DESCRIPTION
The v0.1.0 release published its signed/notarized DMG successfully, but the **Update appcast on gh-pages** step failed (exit 128): after `git worktree add --orphan` it ran `rm -rf .* *`, and the `.*` glob matched the worktree`'s `.git` link file, destroying it — every later git command then failed with `fatal: not a git repository`.

An `--orphan` worktree is already empty, so the cleanup is unnecessary. Removed it.

After merge I will move the `v0.1.0` tag onto this commit and re-run the release so the appcast publishes and `gh-pages` is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)