### PR TITLE
release: drop duplicate length attr in appcast enclosure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,9 +359,13 @@ jobs:
           KEY_FILE="${RUNNER_TEMP}/sparkle.key"
           echo "${SPARKLE_ED_PRIVATE_KEY}" > "${KEY_FILE}"
 
-          # `sign_update -f <keyfile> <dmg>` emits an `sparkle:edSignature`
-          # attribute string suitable for direct inclusion in the appcast.
-          SIGNATURE="$("${SIGN_UPDATE}" -f "${KEY_FILE}" "${DMG_PATH}")"
+          # `sign_update -f <keyfile> <dmg>` emits both an
+          # `sparkle:edSignature="..."` AND a `length="..."` attribute. The
+          # appcast <enclosure> template already sets length="${size}" from
+          # stat, so keep only the edSignature here — otherwise the rendered
+          # enclosure has `length` twice, which is malformed XML ("Attribute
+          # length redefined") and Sparkle rejects the whole feed.
+          SIGNATURE="$("${SIGN_UPDATE}" -f "${KEY_FILE}" "${DMG_PATH}" | sed -E 's/[[:space:]]*length="[0-9]+"//')"
           echo "signature=${SIGNATURE}" >> "${GITHUB_OUTPUT}"
 
           SIZE="$(stat -f%z "${DMG_PATH}")"


### PR DESCRIPTION
`sign_update` emits `sparkle:edSignature="..." length="..."`, and the `<enclosure>` template also sets `length="${size}"` — so the rendered enclosure carried `length` twice. That is malformed XML (`Attribute length redefined`, confirmed with `xmllint`), and Sparkle rejects the entire feed.

Strip `length` from `sign_update`s output and keep the explicit stat-derived `length`. Caught on the live v0.1.0 appcast; the live `gh-pages` feed is being repaired surgically in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)