### PR TITLE
release: appcast sparkle:version must be CFBundleVersion (auto-update would never fire)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,16 +129,20 @@ jobs:
             | grep "Developer ID Application"
 
       - name: Stamp version into project.yml
+        id: stamp
         # Override the in-repo MARKETING_VERSION so the built bundle
         # carries the tag's version (without committing it back).
         run: |
           set -e
           version="${{ steps.version.outputs.version }}"
-          # Increment CFBundleVersion (CI build number) by a unix-time
-          # suffix so every release has a strictly-monotonic build value
-          # — Sparkle prefers CFBundleVersion for ordering, marketing
-          # version is informational.
+          # CFBundleVersion (CI build number) is a unix timestamp so every
+          # release has a strictly-monotonic build value. Sparkle orders
+          # updates by CFBundleVersion (its sparkle:version), NOT by the
+          # marketing string — so this `build` value must also become the
+          # appcast's <sparkle:version> (see the appcast step). Exposed as a
+          # step output so that step can read it.
           build="$(date -u +%s)"
+          echo "build=${build}" >> "${GITHUB_OUTPUT}"
           sed -i.bak -E \
             -e "s/MARKETING_VERSION: \"[^\"]+\"/MARKETING_VERSION: \"${version}\"/g" \
             -e "s/CURRENT_PROJECT_VERSION: \"[^\"]+\"/CURRENT_PROJECT_VERSION: \"${build}\"/g" \
@@ -404,7 +408,8 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
-          signature='${{ steps.sparkle.outputs.signature }}'   # e.g. sparkle:edSignature="..." length="N"
+          build="${{ steps.stamp.outputs.build }}"             # CFBundleVersion of this build (unix ts)
+          signature='${{ steps.sparkle.outputs.signature }}'   # e.g. sparkle:edSignature="..."
           size='${{ steps.sparkle.outputs.size }}'
           pubdate="$(LC_TIME=en_US.UTF-8 date -u +"%a, %d %b %Y %H:%M:%S +0000")"
           dmg_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}/${DMG_NAME}"
@@ -417,7 +422,7 @@ jobs:
               <item>
                   <title>Version ${version}</title>
                   <pubDate>${pubdate}</pubDate>
-                  <sparkle:version>${version}</sparkle:version>
+                  <sparkle:version>${build}</sparkle:version>
                   <sparkle:shortVersionString>${version}</sparkle:shortVersionString>
                   <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
                   <enclosure


### PR DESCRIPTION
Sparkle orders updates by `<sparkle:version>` compared against the host app`'s `CFBundleVersion`. The release build stamps `CFBundleVersion` to a unix timestamp (v0.1.0 shipped as `1780500840`), but the appcast wrote `<sparkle:version>0.1.0</sparkle:version>`.

**Impact:** a future `v0.1.1` appcast (`sparkle:version` = `0.1.1`) compares as *far older* than an installed timestamp `CFBundleVersion`, so Sparkle would never offer the update. v0.1.0 alone reads "up to date" by accident; every subsequent auto-update would silently fail.

Fix: emit the build timestamp as a step output and use it for `<sparkle:version>`; keep the marketing string as `<sparkle:shortVersionString>` (display only). The live v0.1.0 feed item is being patched to match in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)