### PR TITLE
fix(ui): stop toolbar activity pill clipping on window open (#1)

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -463,6 +463,12 @@ private struct ToolbarFreshness: View {
         .background(
             Capsule().fill(Color.primary.opacity(0.06))
         )
+        // Without this the NSToolbar host compresses the pill below its
+        // ideal height when the window mounts from the menu-bar "Open
+        // Pacer" path, clipping the Capsule's top edge (issue #1). Pin
+        // both axes to the intrinsic size so the toolbar centers the
+        // pill at full height instead of squashing it.
+        .fixedSize()
         .help(tooltip)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Activity status: \(label)")


### PR DESCRIPTION
Closes #1.

The freshness pill (green dot + `active`/`live`/relative-time) lives in an `NSToolbar` item. On the menu-bar → **Open Pacer** mount path, the toolbar compressed it below its ideal height and clipped the `Capsule` top edge (matches the reporter`'s screenshot).

Fix: `.fixedSize()` pins the pill to its intrinsic size so the toolbar centers it at full height instead of squashing it.

**Note:** this is a layout fix reasoned from the symptom — I could not pixel-verify headlessly (the menu-bar window can`'t be surfaced without a click). Shipping it in v0.1.1 means the fix can be confirmed by eye after auto-update — which also exercises the update path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)