### PR TITLE
chore(release): v0.1.1 (toolbar pill fix + first release on corrected appcast pipeline)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -118,7 +118,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.ericandrechek.pacer
         PRODUCT_NAME: Pacer
         CODE_SIGN_ENTITLEMENTS: App/Pacer.entitlements
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.1.1"
         CURRENT_PROJECT_VERSION: "1"
     dependencies:
       - package: PacerCore
@@ -157,7 +157,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.ericandrechek.pacer.widgets
         PRODUCT_NAME: PacerWidgets
         CODE_SIGN_ENTITLEMENTS: Widgets/PacerWidgets.entitlements
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.1.1"
         CURRENT_PROJECT_VERSION: "1"
     dependencies:
       - package: PacerCore


### PR DESCRIPTION
Bumps `MARKETING_VERSION` to 0.1.1 ahead of tagging.

v0.1.1 ships:
- #12 — toolbar activity-pill clipping fix (closes #1)
- The first release on the corrected appcast pipeline (#11 made `sparkle:version` = CFBundleVersion, so update ordering actually works).

Tagging `v0.1.1` after merge will publish it and append the appcast item — and a v0.1.0 install auto-updating to it is the end-to-end proof of the update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)