### PR TITLE
docs: issue templates + CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Something in Pacer is broken, wrong, or misbehaving.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting! A screenshot and the version/OS info below make bugs much faster to fix.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see, and what did you expect instead?
+      placeholder: When I click the menu-bar icon and choose "Open Pacer", the activity pill in the toolbar is clipped…
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Click the menu-bar gauge
+        2. Click "Open Pacer"
+        3. Look at the top-right of the window
+    validations:
+      required: false
+  - type: input
+    id: pacer-version
+    attributes:
+      label: Pacer version
+      description: Pacer → About, or the version on the DMG you installed.
+      placeholder: "0.1.1"
+    validations:
+      required: true
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: "15.5 (Sequoia), Apple Silicon"
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot / logs
+      description: Drag in a screenshot if it's visual. For crashes/stalls, `make logs-tail` output (or Console.app) helps.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest a new capability or an improvement to an existing one.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem or use case?
+      description: What are you trying to do that Pacer doesn't (well) support today?
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like to see?
+      description: A rough sketch is fine — mockups welcome but not required.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Pacer
+
+Thanks for your interest! Pacer is a native macOS menu-bar app for tracking
+Claude Code usage. Bug reports, feature ideas, and PRs are all welcome.
+
+> **Heads up:** day-to-day maintenance of this repo — triage, PR review, and
+> merges — is largely handled by an AI agent (Claude Code) acting on the
+> owner's behalf. Comments and commits attributed that way are from the agent,
+> not Eric personally. You're still talking to a real project; just know who's
+> on the other end.
+
+## Reporting bugs / requesting features
+
+Open an issue — the templates ask for the few things that make a report
+actionable (Pacer version, macOS version, a screenshot for visual bugs). A
+screenshot is worth a thousand words for UI issues.
+
+## Development setup
+
+Requirements: macOS 15+, Xcode 16+, and [`xcodegen`](https://github.com/yonsm/XcodeGen)
+(`brew install xcodegen`). The Xcode project is generated from `project.yml`, so
+you never edit `.xcodeproj` directly.
+
+```sh
+make verify     # fast compile-only check (no signing, no install)
+make test       # PacerCore unit + ground-truth tests
+make install    # build + sign + notarize + install to /Applications, relaunch
+make help       # all targets
+```
+
+Architecture, invariants, and the non-negotiable correctness/performance rules
+live in [`agents.md`](agents.md) — worth a skim before a non-trivial change.
+
+## Pull requests
+
+1. Branch off `main`, make your change, and make sure `make verify` and
+   `make test` pass.
+2. Open a PR. CI (PacerCore tests + a verify build) runs automatically; for
+   first-time contributors a maintainer approves the run.
+3. PRs are **squash-merged** to `main`, so your branch history doesn't need to
+   be tidy — a clear PR description does more good.
+4. Comments explain *why*, not *what* — especially where Pacer deliberately
+   deviates from `ccusage` or upstream defaults.
+
+By contributing you agree your contributions are licensed under the repository's
+[MIT License](LICENSE).


### PR DESCRIPTION
Lowers contribution friction for the growing contributor base:
- Bug + feature issue forms (the bug form asks for Pacer/macOS version and a screenshot — the info that made #1 quick to fix).
- A concise `CONTRIBUTING.md`: make-based dev loop, squash-merge PR flow, pointer to `agents.md`, and an honest note that the repo is largely AI-maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)