### PR TITLE
fix(ui): refresh "today" views automatically at the local day rollover

### DIFF
--- a/App/Background/PacerAppDelegate.swift
+++ b/App/Background/PacerAppDelegate.swift
@@ -498,8 +498,10 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate {
         // so we can resize the NSStatusItem to fit.
         let host = SizingHostingView(
             rootView: AnyView(
-                MenuBarLabel()
-                    .modelContainer(container)
+                DayKeyedContent {
+                    MenuBarLabel()
+                        .modelContainer(self.container)
+                }
             )
         )
         host.translatesAutoresizingMaskIntoConstraints = false
@@ -576,8 +578,10 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate {
         // already current.
         let contentController = NSHostingController(
             rootView: AnyView(
-                MenuStatusContent()
-                    .modelContainer(container)
+                DayKeyedContent {
+                    MenuStatusContent()
+                        .modelContainer(self.container)
+                }
             )
         )
         // NSMenuItem.view doesn't auto-size — the menu reads the

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -258,13 +258,42 @@ struct ContentView: View {
 
     @ViewBuilder
     private var detail: some View {
+        // Key the active destination on the current local day. Reading
+        // `PacerToday.shared.key` here (tracked by `@Observable`) makes
+        // `detail` re-evaluate at the midnight rollover; the `.id` then
+        // rebuilds the destination — re-running every card's `init()`
+        // against a fresh `Date()` so date-pinned `@Query` predicates
+        // stop matching yesterday. This is the automatic equivalent of
+        // the manual "switch tabs and back" that users relied on.
+        let dayKey = PacerToday.shared.key
         switch selection.wrappedValue {
-        case .dashboard: DashboardView()
-        case .history:   HistoryView()
-        case .projects:  ProjectsView()
-        case .models:    ModelsView()
+        case .dashboard: DashboardView().id(dayKey)
+        case .history:   HistoryView().id(dayKey)
+        case .projects:  ProjectsView().id(dayKey)
+        case .models:    ModelsView().id(dayKey)
         case .settings:  SettingsView()
         }
+    }
+}
+
+// MARK: - Day-rollover keying
+
+/// Rebuilds `content` whenever the local day rolls over.
+///
+/// Date-pinned `@Query` predicates (`$0.date == <today captured in
+/// init>`) freeze at the day the host view was last initialized. For
+/// long-lived hosts that never get torn down — the menu-bar status
+/// item's retained `NSHostingController`s — that means today's rows
+/// stop matching after midnight and the chips look stale until the app
+/// restarts. Reading `PacerToday.shared.key` in `body` (tracked by
+/// `@Observable`) re-evaluates this view on rollover; the changed `.id`
+/// then rebuilds `content`, re-running its `init()` against a fresh
+/// `Date()`. The main window achieves the same effect via the `.id` on
+/// `ContentView.detail`.
+struct DayKeyedContent<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+    var body: some View {
+        content().id(PacerToday.shared.key)
     }
 }
 

--- a/PacerCore/Sources/PacerCore/Util/PacerToday.swift
+++ b/PacerCore/Sources/PacerCore/Util/PacerToday.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Observation
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// Shared "what local day is it right now?" state, expressed as the same
+/// `yyyy-MM-dd` key `TokenSample.formatDate` writes into aggregate rows.
+///
+/// **Why this exists**: every "today" card builds its `@Query` predicate
+/// from `TokenSample.formatDate(Date())` captured *once* in `init()`.
+/// `@Query` reactively tracks row changes but its predicate is frozen at
+/// init time, so a Dashboard window left open across midnight keeps
+/// asking for *yesterday's* date string — today's rows land under a key
+/// the predicate no longer matches and the card looks stale. The only
+/// thing that fixed it was switching tabs, which tears down and rebuilds
+/// the cards (re-running their inits against a fresh `Date()`).
+///
+/// Views read `PacerToday.shared.key` while computing their body and key
+/// the relevant subtree on it (`.id(PacerToday.shared.key)`). Because
+/// the read is tracked by `@Observable`, a day rollover re-evaluates the
+/// body, the `.id` changes, and SwiftUI rebuilds exactly what a manual
+/// tab switch used to — now automatically.
+///
+/// Rollover is driven by `NSCalendarDayChanged` (the system posts it on
+/// the main thread when the local day changes). We *also* refresh on app
+/// activation and system wake: if the Mac slept through midnight the
+/// calendar notification can be missed, and the user's first interaction
+/// after waking should already show the correct day.
+///
+/// MainActor-isolated `@Observable`, single shared instance — same shape
+/// as `PacerWindowVisibility`; the current day is a property of the
+/// process, not of any one subscriber.
+@MainActor
+@Observable
+public final class PacerToday {
+
+    public static let shared = PacerToday()
+
+    /// Local-day key in `TokenSample.formatDate` form (`yyyy-MM-dd`).
+    /// Matches the value aggregate rows are stored under so it can be
+    /// compared directly against `DailyAggregate.date` predicates.
+    public private(set) var key: String
+
+    private init() {
+        key = TokenSample.formatDate(Date())
+        subscribe()
+    }
+
+    /// Recompute the day key and publish if it changed. Idempotent —
+    /// re-publishing the same value is suppressed so subscribers don't
+    /// rebuild on every app activation, only on an actual rollover.
+    public func refresh() {
+        let current = TokenSample.formatDate(Date())
+        guard current != key else { return }
+        key = current
+    }
+
+    private func subscribe() {
+        let center = NotificationCenter.default
+
+        // System posts this on the main thread at the local midnight
+        // boundary — the primary, precise rollover signal.
+        center.addObserver(
+            forName: .NSCalendarDayChanged, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+
+        #if canImport(AppKit)
+        // Backstops for the slept-through-midnight case, where the
+        // calendar notification can be coalesced or missed:
+        //   - app brought back to the foreground
+        //   - machine woken from sleep
+        center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+        #endif
+    }
+}


### PR DESCRIPTION
## Problem

When the app is left open on the Dashboard across midnight, it keeps showing **yesterday's** data. Switching to another tab and back is the only thing that refreshes it. The same staleness affects other date-pinned surfaces (Projects detail, menu-bar chips, etc.).

## Root cause

Every "today" card builds its `@Query` predicate from a date string captured **once** in `init()`:

```swift
init() {
    let today = TokenSample.formatDate(Date())   // frozen at init
    _aggregates = Query(filter: #Predicate { $0.date == today })
}
```

`@Query` reactively tracks SwiftData *row* changes, but its **predicate is frozen** at the value it had when the view was last initialized. Nothing in the view tree depends on the current date, so a long-lived Dashboard keeps asking for yesterday's key — today's rows land under a different key and silently don't match. The tab-switch workaround happens to tear down and rebuild the cards (`ContentView.detail`'s `switch`), re-running their inits against a fresh `Date()`. The retained menu-bar hosting controllers never tear down at all, so they stay stale until restart.

## Fix

- **`PacerToday`** — a `@MainActor @Observable` singleton (mirroring `PacerWindowVisibility`) that publishes the current local-day key and recomputes it on `NSCalendarDayChanged`, with app-activate and system-wake backstops for the slept-through-midnight case.
- **`ContentView.detail`** keys each destination on `PacerToday.shared.key`; the menu-bar hosts use a small `DayKeyedContent` wrapper. Reading the key during `body` evaluation makes a rollover re-evaluate, and the changed `.id` rebuilds the subtree — the automatic equivalent of the manual tab switch. Settings is left unkeyed (no date-pinned queries).

No `.id` thrash day-to-day: the key only changes at the local midnight boundary (or first activation/wake after it).

## Testing

Builds, signs, notarizes, and installs cleanly via `make install`. The midnight rollover itself is awkward to exercise live; the mechanism reproduces the exact known-good rebuild path that a manual tab switch already triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)