### PR TITLE
feat(ui): custom About window with project links

### DIFF
--- a/App/PacerApp.swift
+++ b/App/PacerApp.swift
@@ -110,7 +110,14 @@ struct PacerApp: App {
             // knows.
             CommandGroup(replacing: .appInfo) {
                 Button("About Pacer") {
-                    showAboutPanel()
+                    // Open the custom About window (singleton scene
+                    // below). `activate()` brings it forward even from
+                    // accessory mode, where no main window is open —
+                    // the `ignoringOtherApps:` form was neutered in
+                    // macOS 14, so the no-arg call is what works for a
+                    // user-initiated menu command.
+                    openWindow(id: "about")
+                    NSApp.activate()
                 }
                 // Sparkle's standard "Check for Updates…" item. Lives
                 // under the application menu, above "Settings…", which
@@ -185,52 +192,19 @@ struct PacerApp: App {
         // Menu-bar status item is owned by `PacerAppDelegate` (custom
         // NSStatusItem so we can support right-click context menu and
         // a pulse animation, neither of which MenuBarExtra exposed).
-    }
 
-    // MARK: - About panel
-
-    private func showAboutPanel() {
-        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
-        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-
-        // PacerLogo is bundled in the app target's Asset Catalog;
-        // fall back to the system app-icon image if the lookup fails
-        // for any reason (matches the asset-catalog default).
-        let icon = NSImage(named: "PacerLogo") ?? NSApp.applicationIconImage
-
-        // NSAttributedString credits — a brief description of what
-        // Pacer is. Renders below the version line in the panel.
-        let creditsBody = """
-        Native macOS tracking for Claude Code usage.
-
-        Storage is local to this Mac. The only network egress is the \
-        five-minute OAuth poll to api.anthropic.com.
-        """
-        let credits = NSAttributedString(
-            string: creditsBody,
-            attributes: [
-                .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
-                .foregroundColor: NSColor.labelColor
-            ]
-        )
-
-        var options: [NSApplication.AboutPanelOptionKey: Any] = [
-            .applicationName: "Pacer",
-            .applicationVersion: version,
-            .version: "build \(build)",
-            .credits: credits,
-        ]
-        if let icon {
-            options[.applicationIcon] = icon
+        // Custom About window. A singleton `Window` (not WindowGroup)
+        // so the "About Pacer" menu item reuses one window rather than
+        // stacking panels. `.hiddenTitleBar` drops the chrome for a
+        // clean centered card; `.contentSize` resizability pins the
+        // window to AboutView's intrinsic size (no resize handles on a
+        // fixed layout). Replaces the bare `orderFrontStandardAboutPanel`
+        // — see AboutView for the rationale.
+        Window("About Pacer", id: "about") {
+            AboutView()
         }
-
-        // Bring the app forward so the panel is interactive — without
-        // activation a click on the menu-bar "About" item from
-        // accessory-mode (no main window open) would float the panel
-        // behind whatever app is foregrounded. Use the modern no-arg
-        // `activate()` — the `ignoringOtherApps:` form was neutered in
-        // macOS 14.
-        NSApp.activate()
-        NSApp.orderFrontStandardAboutPanel(options: options)
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultPosition(.center)
     }
 }

--- a/App/Views/AboutView.swift
+++ b/App/Views/AboutView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import PacerUI
+
+/// Custom "About Pacer" window. Replaces `orderFrontStandardAboutPanel`
+/// — the system panel renders a bare icon + version + credits blob with
+/// no affordance to reach the project, file a bug, or star the repo,
+/// which for an open-source utility is the whole point of an About box.
+///
+/// Shown via a singleton `Window(id: "about")` scene in `PacerApp`, so
+/// the menu item reuses the one window instead of stacking panels. Uses
+/// the shared `PacerUI` design tokens so it reads as the same surface as
+/// the dashboard rather than a one-off.
+struct AboutView: View {
+    // Project links. Hard-coded rather than read from a plist: these are
+    // the canonical home for the open-source project and don't vary per
+    // build the way the version strings do.
+    private static let repoURL = URL(string: "https://github.com/EricAndrechek/Pacer")!
+    private static let issuesURL = URL(string: "https://github.com/EricAndrechek/Pacer/issues")!
+    private static let releasesURL = URL(string: "https://github.com/EricAndrechek/Pacer/releases")!
+
+    private var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+    }
+    private var build: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+    }
+    private var copyright: String {
+        Bundle.main.object(forInfoDictionaryKey: "NSHumanReadableCopyright") as? String
+            ?? "Copyright © 2026 Eric Andrechek"
+    }
+
+    var body: some View {
+        VStack(spacing: 18) {
+            // Logo. The asset already carries the purple→blue gradient
+            // badge, so it needs no extra chrome beyond a soft shadow to
+            // lift it off the window background.
+            Image("PacerLogo")
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 84, height: 84)
+                .shadow(color: .black.opacity(0.18), radius: 8, y: 3)
+
+            VStack(spacing: 5) {
+                Text("Pacer")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                Text("Version \(version) (\(build))")
+                    .font(.callout)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("Native macOS tracking for Claude Code usage.")
+                .font(.callout)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 280)
+
+            // Project links. A star nudge first (the ask), then the two
+            // destinations a user actually reaches for from an About box.
+            HStack(spacing: 10) {
+                AboutLinkButton(title: "Star", systemImage: "star.fill", url: Self.repoURL)
+                AboutLinkButton(title: "Issues", systemImage: "ladybug.fill", url: Self.issuesURL)
+                AboutLinkButton(title: "Releases", systemImage: "shippingbox.fill", url: Self.releasesURL)
+            }
+            .padding(.top, 2)
+
+            Divider()
+                .frame(width: 220)
+                .padding(.vertical, 2)
+
+            VStack(spacing: 6) {
+                Text("Storage is local to this Mac. The only network egress is the OAuth poll to api.anthropic.com.")
+                    .font(.caption)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 300)
+                Text(copyright)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        // Generous top padding clears the floating traffic-light buttons
+        // that the `.hiddenTitleBar` window style leaves overlaid on the
+        // content's top-left corner.
+        .padding(.top, 38)
+        .padding(.horizontal, 40)
+        .padding(.bottom, 32)
+        .frame(width: 400)
+        .background(.background)
+    }
+}
+
+// MARK: - Link button
+
+/// A compact bordered link with an SF Symbol over its label. Wraps
+/// `Link` so it opens the destination in the user's browser and inherits
+/// the standard hover/press states, while a `VStack` icon-over-text
+/// layout keeps the three project links narrow enough to sit in one row.
+private struct AboutLinkButton: View {
+    let title: String
+    let systemImage: String
+    let url: URL
+
+    var body: some View {
+        Link(destination: url) {
+            VStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 16, weight: .medium))
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .frame(width: 76, height: 54)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.tint)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(PacerDesign.cardStroke, lineWidth: 1)
+        )
+        .help(url.absoluteString)
+    }
+}


### PR DESCRIPTION
## What

Replaces the bare native `orderFrontStandardAboutPanel` with a custom SwiftUI About window. The system panel showed only an icon, version, and a credits blob — no way to reach the repo, file a bug, or star the project. For an open-source utility that's the whole point of an About box.

## Changes

- **`App/Views/AboutView.swift`** (new): logo, app name, version/build, a one-line description, and a row of three link buttons — **Star**, **Issues**, **Releases** — pointing at the GitHub project. Plus the local-storage privacy note and copyright. Built on the shared `PacerUI` design tokens so it matches the dashboard surface.
- **`App/PacerApp.swift`**: adds a singleton `Window(id: "about")` scene with `.hiddenTitleBar` + `.contentSize` resizability; the "About Pacer" menu item now opens it via `openWindow` instead of the NSPanel. Old `showAboutPanel()` removed.

## Verification

`make install` (build + notarize + staple + install) succeeded. Opened the window from the app menu and confirmed it renders: centered logo, "Pacer" + "Version 0.1.1 (1)", the description line, the three link buttons, and the privacy/copyright footer. Hidden title bar gives a clean card; top padding clears the traffic-light buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)