### PR TITLE
fix(dev): stop Sparkle offering phantom updates to local dev builds

### DIFF
--- a/App/Update/PacerUpdater.swift
+++ b/App/Update/PacerUpdater.swift
@@ -13,20 +13,74 @@ import SwiftUI
 final class PacerUpdater: ObservableObject {
     let controller: SPUStandardUpdaterController
 
+    #if DEBUG
+    // Retained for the updater's lifetime — `SPUUpdater` holds its
+    // delegate weakly, so without this strong reference the delegate
+    // would deallocate immediately and the gate below would never fire.
+    private let devDelegate: DevBuildUpdaterDelegate
+    #endif
+
     init() {
         // `startingUpdater: true` schedules the on-launch check + 24h
         // recurrence using the feed URL and interval declared in
         // Info.plist (SUFeedURL, SUScheduledCheckInterval). No extra
         // wiring needed here.
-        controller = SPUStandardUpdaterController(
+        #if DEBUG
+        // Local Debug builds: install a delegate that vetoes automatic
+        // (launch + scheduled) update checks. See DevBuildUpdaterDelegate.
+        // Construct the delegate as a local first — `self` isn't fully
+        // initialized until `controller` is set, so we can't reference
+        // `self.devDelegate` while building the controller.
+        let delegate = DevBuildUpdaterDelegate()
+        self.devDelegate = delegate
+        self.controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: delegate,
+            userDriverDelegate: nil
+        )
+        #else
+        self.controller = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        #endif
     }
 
     var updater: SPUUpdater { controller.updater }
 }
+
+#if DEBUG
+/// Vetoes Sparkle's *automatic* update checks in local Debug builds.
+///
+/// A dev build's `CFBundleVersion` is stamped with its build timestamp
+/// (see bin/dev-install.sh), which keeps a *fresh* build at or above the
+/// latest release — but a dev build left running while a newer release
+/// ships would still see that release as "newer" on the next scheduled
+/// check and offer to install it, silently replacing the locally-built
+/// app with the public DMG. Blocking only the background check closes
+/// that footgun while leaving the user-initiated "Check for Updates…"
+/// item fully functional, so the flow can still be exercised on purpose.
+///
+/// This denies at runtime rather than flipping `automaticallyChecksForUpdates`,
+/// which would persist into the `SUEnableAutomaticChecks` user default and
+/// leak into a release build sharing the same bundle identifier.
+///
+/// Compiled out of Release builds entirely.
+private final class DevBuildUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    func updater(_ updater: SPUUpdater, mayPerform updateCheck: SPUUpdateCheck) throws {
+        // `.updatesInBackground` is the launch/scheduled check;
+        // `.updates` is the user clicking "Check for Updates…".
+        if updateCheck == .updatesInBackground {
+            throw NSError(
+                domain: "com.ericandrechek.pacer",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Automatic update checks are disabled in Debug builds."]
+            )
+        }
+    }
+}
+#endif
 
 /// SwiftUI bridge for the Check-for-Updates menu item. Watches the
 /// updater's `canCheckForUpdates` (true except during an active check)

--- a/bin/dev-install.sh
+++ b/bin/dev-install.sh
@@ -55,14 +55,29 @@ xcodegen generate
 # 2. Build unsigned. project.yml sets CODE_SIGNING_ALLOWED=NO globally
 #    so xcodebuild produces unsigned bundles (no provisioning profile
 #    round-trip, no Apple Development cert). We sign manually below.
+#
+#    CFBundleVersion (CURRENT_PROJECT_VERSION) is stamped with the build
+#    time as a unix timestamp, exactly like the release workflow does.
+#    Sparkle orders updates by CFBundleVersion (its sparkle:version), so
+#    the in-repo default of "1" sits *below* every published release's
+#    timestamp — which made Sparkle offer to "update" a freshly-built
+#    dev app back to the public DMG (silently replacing your local
+#    build). Stamping the build time makes a fresh local build always
+#    >= the latest release, so a manual "Check for Updates…" correctly
+#    reports up to date. (Debug builds also suppress *automatic* checks
+#    entirely — see PacerUpdater.swift — so this covers the manual path.)
+#    The override applies to both the app and the widget extension, which
+#    macOS requires to share a version.
+DEV_BUILD_VERSION="$(date -u +%s)"
 echo
-echo "==> Building Pacer.app (Debug, unsigned)"
+echo "==> Building Pacer.app (Debug, unsigned, build ${DEV_BUILD_VERSION})"
 xcodebuild \
     -project Pacer.xcodeproj \
     -scheme Pacer \
     -configuration Debug \
     -destination 'platform=macOS' \
     -derivedDataPath "${REPO_ROOT}/Build" \
+    CURRENT_PROJECT_VERSION="${DEV_BUILD_VERSION}" \
     build \
     | (grep -E '(error:|warning:|FAILED|SUCCEEDED)' || true)
 


### PR DESCRIPTION
## Problem

A local `make install` build left `CFBundleVersion` at the in-repo default `"1"`, while published releases stamp it with a build-time unix timestamp. Sparkle orders updates by `CFBundleVersion` (its `sparkle:version`), so it saw every release as "newer" than a dev build and offered to install it — **silently replacing the locally-built app with the public DMG**, wiping uncommitted work.

## Fix

- **`bin/dev-install.sh`**: stamps `CURRENT_PROJECT_VERSION` with the build timestamp (`date -u +%s`), mirroring the release workflow. A fresh dev build is always `>=` the latest release, so a manual "Check for Updates…" reports up to date. Applies to both the app and the widget (macOS requires them to share a version).
- **`App/Update/PacerUpdater.swift`**: a `#if DEBUG` `SPUUpdaterDelegate` vetoes *automatic* (launch + scheduled) checks via `updater(_:mayPerform:)`, so a dev build left running while a newer release ships isn't nagged either. User-initiated checks still work. Denies at runtime rather than flipping `automaticallyChecksForUpdates` — that would persist into `SUEnableAutomaticChecks` and leak into a release build sharing the bundle id. Compiled out of Release.

## Verification

`make install` succeeded. Installed build → `CFBundleVersion = 1780573670`; latest published `v0.1.1` → `sparkle:version = 1780503333`. Local now outranks the release, so the phantom update is gone. About window renders correctly with the timestamped build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)