### PR TITLE
feat(dev): let contributors build under their own Apple Developer account

### DIFF
--- a/App/Views/AboutView.swift
+++ b/App/Views/AboutView.swift
@@ -52,10 +52,14 @@ struct AboutView: View {
             VStack(spacing: 5) {
                 Text("Pacer")
                     .font(.system(size: 30, weight: .bold, design: .rounded))
-                Text("Version \(version) (\(build))")
+                // Only the marketing version is shown; the build number
+                // (a unix-timestamp, meaningful only to Sparkle's update
+                // ordering) is tucked into a hover tooltip so it's still
+                // available for bug reports without cluttering the line.
+                Text("Version \(version)")
                     .font(.callout)
-                    .monospacedDigit()
                     .foregroundStyle(.secondary)
+                    .help("Build \(build)")
                 // Reuses the menu item's Sparkle integration (KVO-driven
                 // disable while a check is in flight). `.link` style
                 // renders it as a quiet hyperlink right under the version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,43 @@ make help       # all targets
 Architecture, invariants, and the non-negotiable correctness/performance rules
 live in [`agents.md`](agents.md) — worth a skim before a non-trivial change.
 
+### Building and running it yourself
+
+`make verify` and `make test` need no signing setup — that's all CI runs, and
+it's enough to develop and validate most changes.
+
+To build a *runnable* app (`make install`), macOS needs it code-signed, and
+Pacer stores its data in an [App Group](https://developer.apple.com/documentation/xcode/configuring-app-groups)
+container shared between the app and its widget. macOS only resolves that
+container when the group's `<TeamID>.` prefix matches the signing certificate's
+team — so running your own build requires **your own Apple Developer account**
+(a `Developer ID Application` certificate; a paid membership). Point the install
+at it with environment variables — no source edits required:
+
+```sh
+PACER_SIGN_IDENTITY="Developer ID Application: <Your Name> (<TEAMID>)" make install
+```
+
+- The Team ID in parentheses is auto-detected and used to re-prefix the App
+  Group in the entitlements at sign time; `PacerStore` reads the resulting
+  identifier back from the signed binary at runtime, so the app and widget
+  share a container under *your* account.
+- Override `PACER_TEAM_ID` explicitly if your identity string doesn't end in
+  `(TEAMID)`.
+- Notarization (Apple's `pacer-notarization` keychain profile by default,
+  overridable with `PACER_NOTARY_PROFILE`) is only needed to silence the macOS
+  "access data from other apps" prompt and to run on other Macs. For a
+  local-only build you can skip it:
+
+  ```sh
+  PACER_SIGN_IDENTITY="..." PACER_DEV_SKIP_NOTARIZE=1 make install
+  ```
+
+List your available identities with `security find-identity -v -p codesigning`.
+The widget extension additionally needs the App Group registered on your
+account (Apple Developer portal → Identifiers); if it isn't, the app still runs
+but its widgets won't show data.
+
 ## Pull requests
 
 1. Branch off `main`, make your change, and make sure `make verify` and

--- a/PacerCore/Sources/PacerCore/PacerStore.swift
+++ b/PacerCore/Sources/PacerCore/PacerStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import SwiftData
 
 public enum PacerStoreError: Error, Sendable {
@@ -6,11 +7,39 @@ public enum PacerStoreError: Error, Sendable {
 }
 
 public enum PacerStore {
-    /// TeamID-prefixed App Group identifier. The legacy `group.` prefix
+    /// The maintainer's canonical TeamID-prefixed App Group identifier.
+    /// Used as the fallback when the running binary's entitlement can't
+    /// be read (e.g. the unit-test runner) and as the value the
+    /// published build is signed with. The legacy `group.` prefix
     /// triggers the macOS Sequoia App Management prompt on every launch;
-    /// `<TeamID>.<bundleid>` does not. Must match the entitlements files.
-    /// See `docs/research/tcc-app-management.md`.
-    public static let appGroupIdentifier = "YZXWMJ5VBY.com.ericandrechek.pacer"
+    /// `<TeamID>.<bundleid>` does not. See `docs/research/tcc-app-management.md`.
+    static let defaultAppGroupIdentifier = "YZXWMJ5VBY.com.ericandrechek.pacer"
+
+    /// Live App Group identifier, derived once from the running binary's
+    /// `com.apple.security.application-groups` entitlement. Deriving it
+    /// (rather than hardcoding the Team ID) means a contributor who
+    /// builds under their *own* Apple Developer account — `dev-install.sh`
+    /// templates the entitlements with their Team ID — gets a matching
+    /// `<TheirTeamID>.com.ericandrechek.pacer` container with no source
+    /// edits. Falls back to `defaultAppGroupIdentifier` when no
+    /// entitlement is present. Must match the entitlements files.
+    /// See CONTRIBUTING "Building and running it yourself".
+    public static let appGroupIdentifier: String = resolveAppGroupIdentifier()
+
+    private static func resolveAppGroupIdentifier() -> String {
+        guard let task = SecTaskCreateFromSelf(nil),
+              let value = SecTaskCopyValueForEntitlement(
+                task, "com.apple.security.application-groups" as CFString, nil
+              ),
+              let groups = value as? [String],
+              !groups.isEmpty
+        else {
+            return defaultAppGroupIdentifier
+        }
+        // Pick the Pacer group by suffix so an unrelated group added to
+        // the entitlements later wouldn't silently win the `first` slot.
+        return groups.first { $0.hasSuffix(".com.ericandrechek.pacer") } ?? groups[0]
+    }
     /// Pre-rename identifier. Only ever used by `bin/dev-install.sh` to
     /// copy SwiftData + UserDefaults from the legacy Group Container on
     /// upgrade. No first-release end-user has data here.

--- a/PacerCore/Tests/PacerCoreTests/PacerStoreTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PacerStoreTests.swift
@@ -6,6 +6,12 @@ import Testing
 @Test func appGroupIdentifierIsStable() {
     // TeamID-prefixed; legacy "group." prefix triggers the macOS Sequoia
     // App Management prompt on every launch. See PacerStore comment.
+    //
+    // The maintainer's canonical group id. The live `appGroupIdentifier`
+    // is derived from the signed entitlement (so a contributor's own-team
+    // build adapts), and the test runner — which carries no app-group
+    // entitlement — falls back to exactly this value.
+    #expect(PacerStore.defaultAppGroupIdentifier == "YZXWMJ5VBY.com.ericandrechek.pacer")
     #expect(PacerStore.appGroupIdentifier == "YZXWMJ5VBY.com.ericandrechek.pacer")
 }
 

--- a/bin/dev-install.sh
+++ b/bin/dev-install.sh
@@ -43,6 +43,52 @@ echo "    repo:   ${REPO_ROOT}"
 echo "    target: ${INSTALLED_APP}"
 echo "    logs:   ${LOG_DIR}"
 
+# ---------------------------------------------------------------------------
+# Signing configuration. Override via env to build under your OWN Apple
+# Developer account — see CONTRIBUTING "Building and running it yourself".
+#
+#   PACER_SIGN_IDENTITY   codesign identity. Default: the maintainer's
+#                         Developer ID. Set to your own
+#                         "Developer ID Application: <Name> (<TEAMID>)".
+#   PACER_TEAM_ID         Team ID used to prefix the App Group in the
+#                         entitlements. Auto-derived from the "(TEAMID)"
+#                         suffix of PACER_SIGN_IDENTITY when unset.
+#   PACER_NOTARY_PROFILE  notarytool keychain profile. Default
+#                         "pacer-notarization". Notarization only silences
+#                         the TCC App-Management prompt / lets the build run
+#                         on other Macs — set PACER_DEV_SKIP_NOTARIZE=1 to
+#                         skip it for a local-only build.
+# ---------------------------------------------------------------------------
+DEFAULT_TEAM_ID="YZXWMJ5VBY"
+PACER_SIGN_IDENTITY="${PACER_SIGN_IDENTITY:-Developer ID Application: Eric Andrechek (${DEFAULT_TEAM_ID})}"
+PACER_NOTARY_PROFILE="${PACER_NOTARY_PROFILE:-pacer-notarization}"
+if [ -z "${PACER_TEAM_ID:-}" ]; then
+    # Parse the 10-char Team ID out of "...(TEAMID)"; fall back to default.
+    PACER_TEAM_ID="$(printf '%s' "${PACER_SIGN_IDENTITY}" | sed -nE 's/.*\(([A-Z0-9]{10})\)$/\1/p')"
+    PACER_TEAM_ID="${PACER_TEAM_ID:-${DEFAULT_TEAM_ID}}"
+fi
+echo "    signing: ${PACER_SIGN_IDENTITY}"
+echo "    team:    ${PACER_TEAM_ID}"
+
+# Fail early with an actionable message if the identity isn't in the
+# keychain — otherwise codesign fails deeper in the script with a terser one.
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "${PACER_SIGN_IDENTITY}"; then
+    echo
+    echo "ERROR: signing identity not found in your keychain:"
+    echo "    ${PACER_SIGN_IDENTITY}"
+    echo
+    echo "To build under your own Apple Developer account, run:"
+    echo "    PACER_SIGN_IDENTITY=\"Developer ID Application: <Your Name> (<TEAMID>)\" make install"
+    echo "  The Team ID in parentheses is auto-detected and used to prefix the"
+    echo "  App Group, so the app + widget share a container under your account."
+    echo
+    echo "List your available identities with:"
+    echo "    security find-identity -v -p codesigning"
+    echo
+    echo "See CONTRIBUTING.md -> \"Building and running it yourself\"."
+    exit 1
+fi
+
 # 1. Regenerate the Xcode project from project.yml so any source
 #    additions (new files in App/Views/, new PacerCore modules) get
 #    picked up. Skipped if no project.yml change since the last
@@ -100,9 +146,29 @@ echo "    built: ${BUILD_OUTPUT}"
 #     populated csreq and the grant persists across launches. Signing
 #     inside-out (deepest first) is required so each enclosing bundle's
 #     signature seals the inner ones.
-SIGN_IDENTITY="Developer ID Application: Eric Andrechek (YZXWMJ5VBY)"
+SIGN_IDENTITY="${PACER_SIGN_IDENTITY}"
 APP_ENTITLEMENTS="${REPO_ROOT}/App/Pacer.entitlements"
 WIDGETS_ENTITLEMENTS="${REPO_ROOT}/Widgets/PacerWidgets.entitlements"
+
+# When building under a non-default Team ID, the App Group string in the
+# entitlements must be re-prefixed to that team: macOS resolves the group
+# container only when the group's <TeamID> prefix matches the signing
+# cert's team. PacerStore derives the matching identifier from the signed
+# entitlement at runtime, so no source edits are needed — we just feed
+# codesign templated entitlements. Write them to temp copies so the
+# tracked .entitlements files stay clean.
+APP_ENTITLEMENTS_SIGN="${APP_ENTITLEMENTS}"
+WIDGETS_ENTITLEMENTS_SIGN="${WIDGETS_ENTITLEMENTS}"
+if [ "${PACER_TEAM_ID}" != "${DEFAULT_TEAM_ID}" ]; then
+    ENT_TMP="$(mktemp -d)"
+    APP_ENTITLEMENTS_SIGN="${ENT_TMP}/Pacer.entitlements"
+    WIDGETS_ENTITLEMENTS_SIGN="${ENT_TMP}/PacerWidgets.entitlements"
+    sed "s/${DEFAULT_TEAM_ID}\.com\.ericandrechek\.pacer/${PACER_TEAM_ID}.com.ericandrechek.pacer/g" \
+        "${APP_ENTITLEMENTS}" > "${APP_ENTITLEMENTS_SIGN}"
+    sed "s/${DEFAULT_TEAM_ID}\.com\.ericandrechek\.pacer/${PACER_TEAM_ID}.com.ericandrechek.pacer/g" \
+        "${WIDGETS_ENTITLEMENTS}" > "${WIDGETS_ENTITLEMENTS_SIGN}"
+    echo "==> Templated App Group prefix -> ${PACER_TEAM_ID}.com.ericandrechek.pacer"
+fi
 echo
 echo "==> Signing with ${SIGN_IDENTITY}"
 
@@ -166,11 +232,11 @@ for bundle in \
 done
 
 # Widget extension binary, then the .appex itself.
-sign "${WIDGETS_ENTITLEMENTS}" "${BUILD_OUTPUT}/Contents/PlugIns/PacerWidgets.appex/Contents/MacOS/PacerWidgets"
-sign "${WIDGETS_ENTITLEMENTS}" "${BUILD_OUTPUT}/Contents/PlugIns/PacerWidgets.appex"
+sign "${WIDGETS_ENTITLEMENTS_SIGN}" "${BUILD_OUTPUT}/Contents/PlugIns/PacerWidgets.appex/Contents/MacOS/PacerWidgets"
+sign "${WIDGETS_ENTITLEMENTS_SIGN}" "${BUILD_OUTPUT}/Contents/PlugIns/PacerWidgets.appex"
 
 # Outer app bundle last, so its signature covers everything inside.
-sign "${APP_ENTITLEMENTS}" "${BUILD_OUTPUT}"
+sign "${APP_ENTITLEMENTS_SIGN}" "${BUILD_OUTPUT}"
 
 # Verify the whole bundle is consistent before installing.
 codesign --verify --deep --strict --verbose=2 "${BUILD_OUTPUT}" 2>&1 \
@@ -188,7 +254,7 @@ echo "    signed."
 # is enough) but will trip TCC's "App Management" prompt on every
 # launch and won't open on other machines. The NEXT non-skip install
 # re-notarizes and clears the prompt.
-NOTARY_PROFILE="pacer-notarization"
+NOTARY_PROFILE="${PACER_NOTARY_PROFILE}"
 NOTARY_ZIP="$(mktemp -d)/Pacer.zip"
 
 if [ "${PACER_DEV_SKIP_NOTARIZE:-0}" = "1" ]; then


### PR DESCRIPTION
Makes `make install` work for contributors with their own Apple Developer account, not just the maintainer. (Scope: account-holders — no Apple-account-free path, per discussion. App Groups require a Team ID, so a disk fallback would be needed for the account-less case; deferred.)

## Why

Running a local build needs code signing, and Pacer's data lives in a TeamID-prefixed App Group that macOS only resolves when the group prefix matches the signing cert's team. The team (`YZXWMJ5VBY`) was hardcoded in `dev-install.sh` plus the two `.entitlements` files and the `PacerStore` constant, so the install flow only worked for the maintainer.

## Changes

- **`bin/dev-install.sh`**: `PACER_SIGN_IDENTITY` / `PACER_TEAM_ID` / `PACER_NOTARY_PROFILE` env overrides (defaults unchanged). Team ID is auto-parsed from the identity's `(TEAMID)` suffix and used to re-prefix the App Group in **temp-copied** entitlements at sign time, so tracked files stay clean. Adds an actionable preflight when the identity isn't in the keychain.
- **`PacerStore.appGroupIdentifier`**: derived at runtime from the signed binary's `application-groups` entitlement (via `SecTask`), falling back to the maintainer's canonical value when absent (test runner). A contributor's own-team build adapts with **no source edits**.
- **About window**: shows just `Version 0.1.1`; the build number (a unix timestamp meaningful only to Sparkle's ordering) moves to a hover tooltip.
- **`CONTRIBUTING.md`**: documents the bring-your-own-account flow.

## Verification

- Default-path `make install` unchanged: team auto-derives to `YZXWMJ5VBY`, no templating, signed group entitlement intact (`YZXWMJ5VBY.com.ericandrechek.pacer`), app runs and reads its store (so the runtime-derived group resolves).
- `PacerStoreTests` pass (runtime derivation falls back to the literal under xctest).
- Note: the 8 `CCusageGroundTruthTests` failures on this machine are **pre-existing** (reproduced on clean `main` via stash) — a stale captured ccusage fixture vs live `~/.claude` data, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)