### PR TITLE
chore(release): prep 0.1.2 — version bump + release notes in update dialog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# Configures GitHub's automatically-generated release notes
+# (`gh release create --generate-notes`, used by .github/workflows/release.yml).
+# These notes are also mirrored into Sparkle's update dialog via the
+# appcast <description>, so keep them clean and readable.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    # Label-based grouping. PRs aren't always labeled; anything without a
+    # matching label falls through to the catch-all below, so notes stay
+    # complete either way. Labelled PRs get grouped — apply these labels
+    # to make a release read at a glance.
+    - title: 🚀 Features
+      labels: [enhancement, feature]
+    - title: 🐛 Fixes
+      labels: [bug, fix]
+    - title: 🧹 Maintenance, Docs & Tests
+      labels: [chore, documentation, docs, test]
+    # Catch-all. Titled "What's Changed" so an unlabeled release reads
+    # exactly like GitHub's default while staying future-proofed.
+    - title: What's Changed
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,22 @@ jobs:
           pubdate="$(LC_TIME=en_US.UTF-8 date -u +"%a, %d %b %Y %H:%M:%S +0000")"
           dmg_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}/${DMG_NAME}"
 
+          # Release notes for Sparkle's update dialog. Mirror the GitHub
+          # Release body (the same `--generate-notes` content) by rendering
+          # it to HTML through GitHub's own markdown API, then embed it as
+          # the item's <description> (Sparkle shows that HTML in the
+          # "what's new" pane). Defensive: any failure leaves the
+          # description empty rather than breaking appcast generation — a
+          # missing "what's new" is cosmetic, a malformed appcast is not.
+          DESCRIPTION_BLOCK=""
+          if body="$(gh release view "v${version}" --json body -q .body 2>/dev/null)" && [ -n "${body}" ]; then
+            printf '%s' "${body}" > "${RUNNER_TEMP}/notes.md"
+            if notes_html="$(gh api --method POST /markdown -f mode=gfm -F text=@"${RUNNER_TEMP}/notes.md" 2>/dev/null)" \
+               && [ -n "${notes_html}" ]; then
+              DESCRIPTION_BLOCK="<description><![CDATA[${notes_html}]]></description>"
+            fi
+          fi
+
           # Build the <item> entry for this release. Sparkle is tolerant
           # of HTML-encoded vs raw attributes; we use the raw form that
           # `sign_update` already produced.
@@ -421,6 +437,7 @@ jobs:
           cat > "${ITEM_FILE}" <<EOF
               <item>
                   <title>Version ${version}</title>
+                  ${DESCRIPTION_BLOCK}
                   <pubDate>${pubdate}</pubDate>
                   <sparkle:version>${build}</sparkle:version>
                   <sparkle:shortVersionString>${version}</sparkle:shortVersionString>

--- a/project.yml
+++ b/project.yml
@@ -118,7 +118,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.ericandrechek.pacer
         PRODUCT_NAME: Pacer
         CODE_SIGN_ENTITLEMENTS: App/Pacer.entitlements
-        MARKETING_VERSION: "0.1.1"
+        MARKETING_VERSION: "0.1.2"
         CURRENT_PROJECT_VERSION: "1"
     dependencies:
       - package: PacerCore
@@ -157,7 +157,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.ericandrechek.pacer.widgets
         PRODUCT_NAME: PacerWidgets
         CODE_SIGN_ENTITLEMENTS: Widgets/PacerWidgets.entitlements
-        MARKETING_VERSION: "0.1.1"
+        MARKETING_VERSION: "0.1.2"
         CURRENT_PROJECT_VERSION: "1"
     dependencies:
       - package: PacerCore


### PR DESCRIPTION
Release prep for 0.1.2.

## Changes

- **Version bump** to `0.1.2` for the `Pacer` app and `PacerWidgets` (the tag overrides this at build time; bumping in-repo keeps dev builds honest and matches prior practice).
- **Release notes in Sparkle's update dialog.** The appcast `<item>` now carries a `<description>` built by rendering the GitHub Release body (the same `--generate-notes` content) to HTML via GitHub's markdown API and embedding it as CDATA. Existing users updating in-place now get a real "what's new" pane instead of a blank one. Defensive: any fetch/render failure leaves the description empty rather than breaking appcast generation (a missing changelog is cosmetic; a malformed appcast would break auto-update for everyone).
- **`.github/release.yml`** so auto-notes are categorized (Features / Fixes / Maintenance) once PRs are labeled, with a `What's Changed` catch-all so unlabeled releases read exactly like GitHub's default, and bot authors excluded.

## Validation

Rendered a representative `--generate-notes` body through `gh api /markdown` and confirmed the resulting `<description><![CDATA[…]]></description>` produces valid appcast XML. `make install` builds and reports `0.1.2`. (The appcast step isn't exercised by the release `dry_run`, so this was validated locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)