### PR TITLE
docs: rewrite README for non-technical users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,158 +3,125 @@
 [![CI](https://github.com/EricAndrechek/Pacer/actions/workflows/ci.yml/badge.svg)](https://github.com/EricAndrechek/Pacer/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![macOS 15+](https://img.shields.io/badge/macOS-15%2B-black?logo=apple)](https://www.apple.com/macos/)
+[![Latest release](https://img.shields.io/github/v/release/EricAndrechek/Pacer?label=download)](https://github.com/EricAndrechek/Pacer/releases/latest)
 
-A native macOS app for tracking Claude Code usage — token counts, costs,
-rate-limit pacing, per-project breakdowns. SwiftUI + SwiftData + Charts,
-signed with Developer ID + notarized, auto-updates via Sparkle.
+**Know what Claude Code is costing you — and how close you are to your limits — right from your Mac's menu bar.**
 
-> **Pre-release.** Pacer is under active development. The download link
-> below ships the latest signed build; expect rough edges and breaking
-> data-schema changes between 0.x versions.
+Pacer is a free, open-source macOS app that keeps an eye on your Claude Code
+usage: the tokens you're burning, what they cost, how close you are to your
+5-hour and weekly rate limits, and where the spend is going — by project, by
+model, by day. It sits quietly in your menu bar, keeps itself up to date, and
+keeps all of your data on your own Mac.
 
-## Install
+> **Heads up — early days.** Pacer is pre-1.0 and under active development. It
+> works and it's useful today, but expect the occasional rough edge, and your
+> saved history may need to be rebuilt between 0.x versions.
 
-1. Download the latest `Pacer-x.y.z.dmg` from the
-   [Releases page](https://github.com/EricAndrechek/Pacer/releases/latest).
-2. Open the DMG, drag `Pacer.app` to `/Applications`.
-3. Launch it. The first run registers Pacer as a menu-bar agent — there's
-   no Dock icon by default; click the gauge in your menu bar to open the
-   dashboard.
-4. macOS will prompt once for permission to read Claude Code's data
-   directory (`~/.claude/projects/`). Approve it.
+## Download & install
 
-Pacer checks for updates on launch and every 24 hours after that, via
-Sparkle. New releases install in-place — no manual download needed.
+1. **[Download the latest version →](https://github.com/EricAndrechek/Pacer/releases/latest)**
+   (grab the `Pacer-x.y.z.dmg` file under "Assets").
+2. Open the downloaded file and drag **Pacer** into your **Applications** folder.
+3. Launch Pacer. It lives in your **menu bar** — look for the little gauge icon
+   up top (there's no Dock icon). Click it to open the dashboard.
+4. The first time, macOS asks permission for Pacer to read Claude Code's files.
+   Click **Allow** — that's how Pacer sees your usage. Nothing leaves your Mac.
 
-**Requirements:** macOS 15 (Sequoia) or later, on Apple Silicon or Intel.
+That's all. **Pacer keeps itself up to date automatically:** when a new version
+ships, it offers to install it for you — no re-downloading, no reinstalling.
 
-## What it does
+**You'll need** macOS 15 (Sequoia) or newer, on either Apple Silicon or Intel.
 
-- **Real-time tracking.** FSEvents + per-file byte-offset cursors mean
-  Pacer picks up new JSONL writes within seconds and the dashboard
-  re-renders incrementally — no full-history rescans on each event.
-- **Rate-limit pacing.** 5-hour and 7-day windows are visualized as
-  cycle-anchored pace charts (cycle start → reset on the X axis, dashed
-  pace line, actual usage curve, 4-band coloring: behind / on track /
-  ahead / >90% or >15pp ahead). Data comes from Anthropic's
-  `/api/oauth/usage` endpoint at a 5-minute cadence.
-- **Cost in three modes.** `auto` (prefer Claude Code's stored
-  `costUSD`, calculate when missing — matches `ccusage`), `calculate`
-  (always price from tokens × LiteLLM rates), `display` (only show
-  server-supplied numbers). Selectable in Settings → Data.
-- **Multiple surfaces.**
-    - Main app with five tabs: Dashboard, History, Projects, Models,
-      Settings. ⌘1..⌘4 jumps between the activity tabs; ⌘, opens
-      Settings.
-    - `MenuBarExtra` status item with configurable display
-      (icon-only / percent-only / both / hidden) and icon style
-      (gauge needle / ring fill / dot).
-    - Three Widget families: TodayCost (small), PaceGauges (small +
-      medium), DailyChart (medium + large).
-- **History views.** Lifetime totals, GitHub-style 26-week activity
-  heatmap, monthly bar chart, top expensive days. Click any day → drill
-  into that day's per-model and per-project detail.
-- **Per-project breakdown.** Sortable list with cost / tokens / sessions
-  / last-active, filtered by 30d / 90d / all and a substring search.
-  Click a project → drill into daily activity, models, sessions.
-- **Live activity.** Last-hour burn rate plus a wall-clock-aware
-  "if you keep this rate, today will end at $X" projection.
-- **Local notifications** (opt-in) for rate-limit threshold crossings
-  (5h or 7d at 50/75/90%) and a configurable daily-cost ceiling. Cycle
-  dedup means the same crossing won't fire twice in one window.
-- **CSV export.** Daily totals, daily by model, or project totals to a
-  spreadsheet — File menu, ⌘⇧E for the most common.
-- **App Group SwiftData.** Pacer.app and the widget extension share
-  one on-disk store; no IPC plumbing for read paths.
+## What you get
+
+- **Rate-limit pacing.** Your 5-hour and weekly windows as easy-to-read pace
+  charts — are you ahead, on track, or about to hit the wall? Color bands
+  (behind / on track / ahead / nearly maxed) tell you at a glance, refreshed
+  every few minutes from Anthropic's usage data.
+- **Costs, your way.** See spend the way Claude Code reports it, or have Pacer
+  price it from tokens itself — switchable in Settings. Daily, monthly, and
+  all-time totals included.
+- **Where it's going.** Break usage down by project and by model, drill into any
+  single day, and see a GitHub-style activity heatmap of the last six months.
+- **Live "today" view.** Your current burn rate plus a running "at this pace,
+  today will end at about $X" projection.
+- **At a glance, always.** A configurable menu-bar readout (icon, percent, or
+  both) plus home-screen-style widgets for cost and pacing.
+- **Optional nudges.** Local notifications when you cross a rate-limit threshold
+  (50 / 75 / 90%) or blow past a daily spending limit you set. Off by default.
+- **Export.** Send daily totals, daily-by-model, or per-project numbers to a
+  CSV for your own spreadsheets.
 
 ## Privacy
 
-Pacer is local-first. It only reads data files that Claude Code already
-writes to your Mac:
+Pacer is **local-first**. It reads only the files Claude Code already writes to
+your own Mac, and it sends nothing about your usage anywhere:
 
-- `~/.claude/projects/*.jsonl` — session token usage, parsed in-process.
-- The OAuth token Claude Code stores in your macOS Keychain — used to
-  query Anthropic's `/api/oauth/usage` endpoint for rate-limit window
-  state, the same endpoint Claude Code itself polls.
+- `~/.claude/projects/*.jsonl` — your session token usage, read on your machine.
+- The Claude Code login token in your macOS Keychain — used only to ask
+  Anthropic for your rate-limit status, the same way Claude Code itself does.
 
-Pacer makes **no other network requests** except:
-- Anthropic's `api.anthropic.com/api/oauth/usage` (rate-limit polling, ~12 requests/hour while running).
-- Sparkle's appcast on `github.com` (update check, once per launch + every 24h).
+The **only** network connections Pacer makes are:
 
-No analytics, no telemetry, no third-party services. Your usage data
-stays on your Mac in `~/Library/Group Containers/YZXWMJ5VBY.com.ericandrechek.pacer/pacer.sqlite`.
+- `api.anthropic.com` — to check your rate-limit windows (~12 small requests an
+  hour while it's running).
+- `github.com` — to check for app updates (once at launch, then every 24 hours).
 
-## Components
+**No analytics, no telemetry, no third parties.** Your data stays on your Mac in
+`~/Library/Group Containers/…/pacer.sqlite`, and it persists across app updates.
+
+---
+
+## For developers
+
+Pacer is SwiftUI + SwiftData + Charts, signed with Developer ID and notarized,
+auto-updating via [Sparkle](https://sparkle-project.org). Contributions welcome —
+see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+### Components
 
 | Component | Role |
 | --- | --- |
-| `Pacer.app` | Main UI + MenuBarExtra. Data collection (FSEvents JSONL scan + OAuth poll) runs in-process inside this binary. |
+| `Pacer.app` | Main UI + menu-bar item. Data collection (FSEvents JSONL scan + OAuth poll) runs in-process inside this binary — there is no separate daemon. |
 | `PacerWidgets` | WidgetKit extension — reads the shared App Group store directly. |
 | `PacerCore` | Shared Swift package — parsers, models, scan coordinator, recomputers. |
 
-There is intentionally no separate daemon binary — `Pacer.app` runs
-LSUIElement-hidden when no window is open and keeps collecting in
-the background.
+### Building from source
 
-## Building from source
+For everyday use, the [released DMG](https://github.com/EricAndrechek/Pacer/releases/latest)
+is what you want — this section is only for hacking on Pacer.
 
-You only need this section if you want to hack on Pacer. For daily
-use, the released DMG above is what you want.
-
-**Requirements:**
-- macOS 15 SDK (Xcode 16+).
-- `xcodegen` (`brew install xcodegen`).
-- An Apple Developer account for signing — change `DEVELOPMENT_TEAM`
-  in `project.yml` and the `SIGN_IDENTITY` in `bin/dev-install.sh` to
-  your Team ID + cert name. Without your own cert you can still run
-  `make verify` (unsigned compile-only) and `make test`.
+**Requirements:** macOS 15 SDK (Xcode 16+) and `xcodegen` (`brew install xcodegen`).
+The Xcode project is generated from `project.yml` — never edit the `.xcodeproj`
+directly.
 
 ```sh
-make verify     # unsigned compile-only check (~30s)
+make verify     # unsigned compile-only check (no Apple account needed)
 make test       # PacerCore unit + ground-truth tests
 make install    # signed + notarized build → /Applications/Pacer.app
-                # (requires your own Developer ID cert + notarytool profile)
-make logs       # tail -F Pacer's stderr log
-make status     # quick health check
 make help       # everything else
 ```
 
-`make install` is **idempotent** — re-run it after any code change. It
-quits the running Pacer.app GUI, replaces `/Applications/Pacer.app`,
-and re-opens Pacer.app if it was running before.
+`make verify` and `make test` need no signing setup and are all that CI runs.
+To build a *runnable* app you need your own Apple Developer account — point the
+install at it with `PACER_SIGN_IDENTITY="Developer ID Application: <Name> (<TEAMID>)" make install`.
+See [CONTRIBUTING → "Building and running it yourself"](CONTRIBUTING.md#building-and-running-it-yourself)
+for the full story (and why an App Group ties signing to your Team ID).
 
-For interactive Xcode debugging:
+[`AGENTS.md`](AGENTS.md) is the deep architectural guide (performance invariants,
+the SwiftData schema, the recomputer pattern); [`docs/`](docs) covers the design
+and perf-tuning work.
 
-```sh
-xcodegen generate
-open Pacer.xcodeproj
-```
+### Releasing
 
-The Xcode project is regenerated from `project.yml` — never edit the
-`.xcodeproj` directly.
-
-Logs land at `~/Library/Logs/Pacer/Pacer.err.log`. SwiftData store
-at `~/Library/Group Containers/YZXWMJ5VBY.com.ericandrechek.pacer/pacer.sqlite`.
-Both persist across reinstalls; `make clean-data` is the only thing
-that wipes them, and it prompts for confirmation.
-
-See [`AGENTS.md`](AGENTS.md) for the full architectural guide
-(performance invariants, signing/notarization workflow, the SwiftData
-schema, why the recomputer pattern exists). [`docs/design.md`](docs/design.md)
-covers the v1 design; [`docs/perf-tuning.md`](docs/perf-tuning.md)
-documents the read-path optimization work.
-
-## Releasing
-
-Tagged releases (`vX.Y.Z`) trigger
-[`.github/workflows/release.yml`](.github/workflows/release.yml), which
-builds, signs, notarizes, packages as a DMG, signs the Sparkle update,
-publishes the GitHub Release, and updates `appcast.xml` on the
-`gh-pages` branch. See [`docs/releasing.md`](docs/releasing.md) for the
-secrets that need to be configured and the cut-a-release checklist.
+Pushing a `vX.Y.Z` tag triggers
+[`.github/workflows/release.yml`](.github/workflows/release.yml), which builds,
+signs, notarizes, packages a DMG, signs the Sparkle update, publishes the GitHub
+Release, and updates `appcast.xml` on the `gh-pages` branch. See
+[`docs/releasing.md`](docs/releasing.md) for the secrets and the cut-a-release
+checklist.
 
 ## License
 
-[MIT](LICENSE). See `LICENSE` for the full text. Pacer reads data from
-Anthropic's Claude Code product but is not affiliated with or endorsed
-by Anthropic.
+[MIT](LICENSE). Pacer reads data from Anthropic's Claude Code product but is not
+affiliated with or endorsed by Anthropic.


### PR DESCRIPTION
Makes the README friendly for a lay-person who just wants to download and use Pacer, per the goal of a clear download + auto-update story now that the app ships that way.

## Changes

- **Leads with plain-language value** and a dead-simple **Download & install** section (download DMG → drag to Applications → click Allow → it auto-updates).
- **Feature bullets rewritten as benefits** ("are you ahead, on track, or about to hit the wall?") instead of implementation detail (FSEvents, byte-offset cursors, etc.).
- **Privacy section kept** — it's a selling point — and tightened.
- **All technical material moved under a clearly-marked "For developers" section**: components, building from source, releasing.
- **Fixes stale build instructions**: bring-your-own-account is now `PACER_SIGN_IDENTITY="…" make install` (per CONTRIBUTING), not hand-editing `DEVELOPMENT_TEAM`/`SIGN_IDENTITY`.
- Adds a download/latest-release badge.

No screenshot committed on purpose — a real dashboard would expose the maintainer's usage, costs, and project names on a public repo. A curated/redacted one could be added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)