### PR TITLE
feat(notifications): detect off-schedule global rate-limit resets

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -27,6 +27,15 @@ final class AppBackgroundService {
     /// we relay to `ScanCoordinator.runOnce()` so the user doesn't
     /// have to wait up to a backstop interval for the next cycle.
     private var immediateScanObserver: NSObjectProtocol?
+    /// Observer for `.pacerScanCycleDidComplete`. When a cycle reports
+    /// fresh rate-limit rows, we run `GlobalRateLimitReset.detect` over
+    /// the recent OAuth history and dispatch an early-reset banner if it
+    /// fires. Lives here — in the process-lived background service —
+    /// rather than in `NotificationsHost` (which only exists while the
+    /// dashboard window is open) so this notification works headless:
+    /// the whole point is to tell the user limits reset early while they
+    /// weren't looking.
+    private var globalResetObserver: NSObjectProtocol?
     /// Bridges `pacerScanCycleDidComplete` notifications to per-kind
     /// `WidgetCenter.reloadTimelines` calls so the WidgetKit extension
     /// — which can't observe SwiftData — refreshes when new data
@@ -80,6 +89,7 @@ final class AppBackgroundService {
         }
 
         installImmediateScanObserver()
+        installGlobalResetObserver()
         widgetRefreshCoordinator.start()
         startPricingRefreshTask()
     }
@@ -96,6 +106,10 @@ final class AppBackgroundService {
         if let observer = immediateScanObserver {
             NotificationCenter.default.removeObserver(observer)
             immediateScanObserver = nil
+        }
+        if let observer = globalResetObserver {
+            NotificationCenter.default.removeObserver(observer)
+            globalResetObserver = nil
         }
         widgetRefreshCoordinator.stop()
         pricingRefreshTask?.cancel()
@@ -207,6 +221,71 @@ final class AppBackgroundService {
                     Log.write("AppBackground", "alias migration failed: \(error)")
                 }
             }
+        }
+    }
+
+    // MARK: - Global rate-limit reset detection
+
+    /// How far back to look for the pre-reset high + the confirming low
+    /// run. Bounded to the authoritative OAuth source (~12 rows/hour/
+    /// window), so even 6 hours is ~150 rows total — cheap to scan on
+    /// the ~5-minute cadence the OAuth poller writes rate-limit rows.
+    private static let globalResetLookback: TimeInterval = 6 * 3600
+
+    /// Observe scan-cycle completions and, when one carries fresh
+    /// rate-limit rows, check whether Anthropic just reset limits early.
+    /// Gated on `rateLimitsChanged` so the chatty JSONL scan path (which
+    /// posts `samplesChanged` many times a minute) never triggers it.
+    private func installGlobalResetObserver() {
+        globalResetObserver = NotificationCenter.default.addObserver(
+            forName: .pacerScanCycleDidComplete,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            // Extract the Sendable summary outside the Task — capturing
+            // the whole Notification would carry its non-Sendable
+            // userInfo across the actor hop.
+            let rateLimitsChanged =
+                (note.object as? ScanCycleSummary)?.rateLimitsChanged ?? false
+            guard rateLimitsChanged else { return }
+            Task { @MainActor [weak self] in
+                await self?.checkForGlobalReset()
+            }
+        }
+    }
+
+    /// Run `GlobalRateLimitReset.detect` over recent OAuth samples for
+    /// each window and dispatch an early-reset banner on a hit. The
+    /// detector is the gatekeeper for "is this real / not a blip"; the
+    /// coordinator handles the settings gate and per-cycle dedup.
+    private func checkForGlobalReset() async {
+        let context = ModelContext(container)
+        let cutoff = Date().addingTimeInterval(-Self.globalResetLookback)
+        let oauthSource = RateLimitSource.oauth
+
+        for window in [RateLimitWindowName.fiveHour, RateLimitWindowName.sevenDay] {
+            let descriptor = FetchDescriptor<RateLimitSample>(
+                predicate: #Predicate {
+                    $0.source == oauthSource
+                        && $0.window == window
+                        && $0.sampledAt >= cutoff
+                },
+                sortBy: [SortDescriptor(\.sampledAt, order: .forward)]
+            )
+            guard let rows = try? context.fetch(descriptor) else { continue }
+            let observations = rows.map {
+                GlobalRateLimitReset.Observation(
+                    sampledAt: $0.sampledAt,
+                    usedPercentage: $0.usedPercentage,
+                    resetsAt: $0.resetsAt
+                )
+            }
+            guard let detection = GlobalRateLimitReset.detect(observations) else { continue }
+            await NotificationCoordinator.shared.handleGlobalRateLimitReset(
+                window: window,
+                detection: detection,
+                context: context
+            )
         }
     }
 }

--- a/App/Notifications/NotificationCoordinator.swift
+++ b/App/Notifications/NotificationCoordinator.swift
@@ -303,6 +303,44 @@ public final class NotificationCoordinator {
         return f.localizedString(for: date, relativeTo: Date())
     }
 
+    /// "Anthropic reset your limits early" detection. Distinct from
+    /// `handleRateLimitReset`: that one fires on the on-schedule rollover
+    /// (the anchor advances); this fires on an *off-schedule* global
+    /// reset where utilization collapsed but the cycle anchor stayed put.
+    /// The hard part — confirming it's sustained and not a blip — is done
+    /// upstream by `GlobalRateLimitReset.detect`; this method just gates
+    /// on settings, dedups, and posts.
+    ///
+    /// Dedup is keyed on the unchanged anchor so we fire at most once per
+    /// cycle. A later cycle has a different anchor and fires fresh.
+    public func handleGlobalRateLimitReset(
+        window: String,
+        detection: GlobalRateLimitReset.Detection,
+        context: ModelContext
+    ) async {
+        let defaults = PacerSettings.store
+        guard defaults.bool(forKey: PacerSettings.Key.notificationsEnabled) else { return }
+        guard defaults.bool(forKey: PacerSettings.Key.notifyGlobalReset) else { return }
+
+        let anchorKey = detection.resetsAt.map { ISO8601DateFormatter().string(from: $0) } ?? "noreset"
+        let cycleKey = "notif.globalreset.\(window).\(anchorKey)"
+        if alreadyNotified(key: cycleKey, in: context) {
+            return
+        }
+
+        await requestAuthorizationIfNeeded()
+        let content = UNMutableNotificationContent()
+        let label: String = window == "five_hour" ? "5-hour" : "7-day"
+        content.title = "Pacer: \(label) limit reset early"
+        content.body = "Anthropic appears to have reset limits ahead of schedule — \(label) usage dropped from \(Int(detection.droppedFrom.rounded()))% to \(Int(detection.droppedTo.rounded()))% without your reset day moving. You've got headroom again."
+        content.sound = .default
+        content.interruptionLevel = .timeSensitive
+
+        let request = UNNotificationRequest(identifier: cycleKey, content: content, trigger: nil)
+        try? await center.add(request)
+        markNotified(key: cycleKey, in: context)
+    }
+
     /// Today's-cost ceiling notification. Fires once per day-and-threshold
     /// pair so re-launching the app doesn't re-notify.
     public func handleDailyCostUpdate(

--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -126,6 +126,7 @@ public enum PacerSettings {
         public static let notifyOnDailyCost      = PacerPreferenceKeys.notifyOnDailyCost
         public static let dailyCostThresholdUSD  = PacerPreferenceKeys.dailyCostThresholdUSD
         public static let notifyOnReset          = PacerPreferenceKeys.notifyOnReset
+        public static let notifyGlobalReset      = PacerPreferenceKeys.notifyGlobalReset
         public static let notifyDailySummary     = PacerPreferenceKeys.notifyDailySummary
         public static let dailySummaryHour       = PacerPreferenceKeys.dailySummaryHour
         public static let costMode               = PacerPreferenceKeys.costMode
@@ -152,6 +153,7 @@ public enum PacerSettings {
         Key.notifyOnDailyCost:     false,
         Key.dailyCostThresholdUSD: 50.0,
         Key.notifyOnReset:         false,
+        Key.notifyGlobalReset:     false,
         Key.notifyDailySummary:    false,
         Key.dailySummaryHour:      21,
         Key.costMode:              "auto",

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -771,11 +771,17 @@ private struct ResetAlertCard: View {
     @AppStorage(PacerSettings.Key.notifyOnReset, store: PacerSettings.store)
     private var resetEnabled: Bool = false
 
+    @AppStorage(PacerSettings.Key.notifyGlobalReset, store: PacerSettings.store)
+    private var globalResetEnabled: Bool = false
+
     var body: some View {
         PacerCard("Reset notifications", content: {
-            Toggle("Notify when a rate-limit window resets", isOn: $resetEnabled)
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle("Notify when a rate-limit window resets", isOn: $resetEnabled)
+                Toggle("Notify when Anthropic resets limits early", isOn: $globalResetEnabled)
+            }
         }, footer: {
-            Text("Fires when the 5-hour or 7-day window rolls over (usage drops near zero and the next reset moves forward). Quiet, informational banner — useful for pacing work around the rolling window.")
+            Text("The first fires on a normal rollover — the 5-hour or 7-day window rolling over on schedule (usage drops near zero and the next reset moves forward). The second fires when Anthropic resets everyone's limits ahead of schedule: usage collapses to zero but your reset day doesn't move. Pacer waits for the drop to hold across a few minutes of polling, so a transient blip won't trigger it.")
         })
     }
 }

--- a/PacerCore/Sources/PacerCore/RateLimit/GlobalRateLimitReset.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/GlobalRateLimitReset.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+/// Detects an *off-schedule global reset* of a rate-limit window — the
+/// event where Anthropic resets everyone's usage ahead of the normal
+/// cycle boundary (they've done this a few times, usually before they
+/// announce it). The fingerprint that distinguishes it from an ordinary
+/// rollover: utilization collapses from a meaningful level to near-zero
+/// while the `resetsAt` cycle anchor does **not** move forward.
+///
+/// Contrast with the normal-rollover path in `NotificationCoordinator`
+/// (`handleRateLimitReset`), which fires only when `resetsAt` advances.
+/// The two are mutually exclusive by construction: a rollover advances
+/// the anchor; an early global reset leaves it where it was. That
+/// "anchor didn't move" check is the whole reason this needs its own
+/// detector rather than reusing the rollover logic.
+///
+/// Pure and source-agnostic so it's unit-testable without a
+/// `ModelContext`. Callers map their persisted samples — filtered to a
+/// single window and ideally to the authoritative OAuth source — into
+/// `Observation` values and hand them over in any order; `detect` sorts
+/// internally. The function reads only the observations' own
+/// timestamps, never the wall clock, so it's deterministic.
+public enum GlobalRateLimitReset {
+
+    /// One window observation, source-agnostic. Maps from a
+    /// `RateLimitSample` at the call site.
+    public struct Observation: Equatable, Sendable {
+        public let sampledAt: Date
+        public let usedPercentage: Double
+        public let resetsAt: Date?
+
+        public init(sampledAt: Date, usedPercentage: Double, resetsAt: Date?) {
+            self.sampledAt = sampledAt
+            self.usedPercentage = usedPercentage
+            self.resetsAt = resetsAt
+        }
+    }
+
+    /// A confirmed early-reset event.
+    public struct Detection: Equatable, Sendable {
+        /// Utilization at the drop edge — the last reading before the
+        /// collapse. The "from" in "dropped from X% to Y%".
+        public let droppedFrom: Double
+        /// Utilization now (the sustained low). The "to".
+        public let droppedTo: Double
+        /// The cycle anchor that stayed put across the drop — the proof
+        /// this was an early reset and not a rollover. Used as the
+        /// dedup key so we alert at most once per cycle.
+        public let resetsAt: Date?
+        /// `sampledAt` of the most recent confirming low sample.
+        public let confirmedAt: Date
+
+        public init(droppedFrom: Double, droppedTo: Double, resetsAt: Date?, confirmedAt: Date) {
+            self.droppedFrom = droppedFrom
+            self.droppedTo = droppedTo
+            self.resetsAt = resetsAt
+            self.confirmedAt = confirmedAt
+        }
+    }
+
+    // MARK: - Tunables
+
+    /// The drop edge must have been at least this high for the collapse
+    /// to be worth reporting. A window sitting at 8% ticking to 0% isn't
+    /// a meaningful "you got headroom back" event.
+    public static let highWatermark: Double = 25
+    /// Post-reset utilization must be at or below this to count as a
+    /// collapse to (near) zero.
+    public static let lowWatermark: Double = 5
+    /// `resetsAt` readings within this tolerance are treated as
+    /// unchanged. Absorbs sub-minute server clock jitter in the anchor
+    /// without admitting a real forward rollover (those jump by hours).
+    public static let anchorTolerance: TimeInterval = 5 * 60
+    /// The low state must hold across at least this many observations…
+    public static let minConfirmingSamples: Int = 2
+    /// …spanning at least this much wall-clock time. Together these two
+    /// reject a single bad reading (fails the count) and a burst of
+    /// rapid same-second pushes (fails the duration), so only a low that
+    /// genuinely persists fires the alert — the user's "confirm it's not
+    /// just a blip" requirement.
+    public static let minConfirmDuration: TimeInterval = 4 * 60
+    /// The drop must be observed *live*: the gap between the last high
+    /// reading and the first low reading must be no larger than this.
+    /// A multi-hour gap means the app was closed / asleep across the
+    /// transition, so we can't say when in that gap the reset happened
+    /// and it's probably stale — suppress rather than fire a banner
+    /// about something from this morning.
+    public static let maxDropGap: TimeInterval = 30 * 60
+
+    /// Returns a `Detection` if the most recent observations show a
+    /// sustained, anchor-stable collapse to near-zero preceded by a
+    /// meaningfully high reading on the same cycle anchor. Otherwise nil.
+    public static func detect(_ observations: [Observation]) -> Detection? {
+        let series = observations.sorted { $0.sampledAt < $1.sampledAt }
+        // Need at least the confirming low run plus one drop-edge sample.
+        guard series.count >= minConfirmingSamples + 1 else { return nil }
+
+        // The newest sample must currently be low and carry a cycle
+        // anchor we can compare against (we can't prove "anchor didn't
+        // move" without one).
+        guard let newest = series.last,
+              newest.usedPercentage <= lowWatermark,
+              let anchor = newest.resetsAt else { return nil }
+
+        // Walk back from the newest sample collecting the maximal suffix
+        // of anchor-stable low readings — the confirming low run.
+        var startIdx = series.count - 1
+        var i = series.count - 1
+        while i >= 0 {
+            let s = series[i]
+            guard s.usedPercentage <= lowWatermark,
+                  let r = s.resetsAt,
+                  abs(r.timeIntervalSince(anchor)) <= anchorTolerance else { break }
+            startIdx = i
+            i -= 1
+        }
+        let lowRun = series[startIdx...]
+
+        // Sustained: enough samples AND enough elapsed time.
+        guard lowRun.count >= minConfirmingSamples else { return nil }
+        guard newest.sampledAt.timeIntervalSince(lowRun.first!.sampledAt) >= minConfirmDuration else {
+            return nil
+        }
+
+        // There must be a sample immediately before the low run to act
+        // as the drop edge.
+        guard startIdx > 0 else { return nil }
+        let before = series[startIdx - 1]
+
+        // The drop edge must itself be meaningfully high…
+        guard before.usedPercentage >= highWatermark else { return nil }
+        // …carry the SAME cycle anchor as the low run (if its anchor is
+        // earlier, the cycle rolled over → normal reset, not this)…
+        guard let beforeAnchor = before.resetsAt,
+              abs(beforeAnchor.timeIntervalSince(anchor)) <= anchorTolerance else { return nil }
+        // …and the high→low transition must have been seen live.
+        guard lowRun.first!.sampledAt.timeIntervalSince(before.sampledAt) <= maxDropGap else {
+            return nil
+        }
+
+        return Detection(
+            droppedFrom: before.usedPercentage,
+            droppedTo: newest.usedPercentage,
+            resetsAt: anchor,
+            confirmedAt: newest.sampledAt
+        )
+    }
+}

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -39,6 +39,13 @@ public enum PacerPreferenceKeys {
     /// moves forward). Useful for users who pace work around the 5-hour
     /// window — they can be told "OK, you can keep going."
     public static let notifyOnReset          = "pacer.notifications.reset"
+    /// Fire a banner when Anthropic resets rate limits *early* — an
+    /// off-schedule global reset where utilization collapses to near-zero
+    /// but the `resetsAt` cycle anchor does NOT move forward (distinct
+    /// from `notifyOnReset`, which is the on-schedule rollover). Pacer
+    /// confirms the drop holds across several minutes of polling before
+    /// firing so a transient blip doesn't trigger it. Opt-in.
+    public static let notifyGlobalReset      = "pacer.notifications.globalReset"
     /// Once-a-day "you spent X today" banner. Independent of the
     /// daily-cost ceiling above — that one fires when the threshold
     /// is exceeded; this one is purely informational at a chosen

--- a/PacerCore/Tests/PacerCoreTests/GlobalRateLimitResetTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/GlobalRateLimitResetTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("GlobalRateLimitReset.detect")
+struct GlobalRateLimitResetTests {
+
+    /// A fixed cycle anchor (the user's reset day) that stays put across
+    /// an early global reset. 8 days out so it's clearly distinct from
+    /// any rolled-forward anchor in the rollover tests.
+    private let anchor = Date(timeIntervalSince1970: 1_750_000_000)
+
+    /// Build an observation `minutesAgo` before a fixed "now" base, with
+    /// the given utilization and anchor. Negative time offsets keep the
+    /// series ordered oldest→newest as `minutesAgo` decreases.
+    private func obs(
+        minutesAgo: Double,
+        pct: Double,
+        anchor: Date?
+    ) -> GlobalRateLimitReset.Observation {
+        let base = Date(timeIntervalSince1970: 1_749_000_000)
+        return .init(
+            sampledAt: base.addingTimeInterval(-minutesAgo * 60),
+            usedPercentage: pct,
+            resetsAt: anchor
+        )
+    }
+
+    // MARK: - Positive: the real early-reset signature
+
+    @Test func detectsSustainedCollapseWithUnchangedAnchor() {
+        // 60% → 0% → 0% → 0%, anchor never moves, polls 5 min apart.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor),
+            obs(minutesAgo: 5, pct: 0, anchor: anchor),
+            obs(minutesAgo: 0, pct: 0, anchor: anchor),
+        ]
+        let d = GlobalRateLimitReset.detect(series)
+        #expect(d != nil)
+        #expect(d?.droppedFrom == 60)
+        #expect(d?.droppedTo == 0)
+        #expect(d?.resetsAt == anchor)
+    }
+
+    @Test func ignoresSampleOrder() {
+        // Same data shuffled — detect sorts internally.
+        let series = [
+            obs(minutesAgo: 0, pct: 0, anchor: anchor),
+            obs(minutesAgo: 15, pct: 55, anchor: anchor),
+            obs(minutesAgo: 5, pct: 1, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series)?.droppedFrom == 55)
+    }
+
+    // MARK: - Negative: the normal rollover (anchor advances)
+
+    @Test func rejectsNormalRolloverWhereAnchorAdvances() {
+        let nextAnchor = anchor.addingTimeInterval(7 * 24 * 3600)
+        // High on the OLD anchor, then low on the NEW (advanced) anchor —
+        // this is an ordinary rollover, handled elsewhere.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: nextAnchor),
+            obs(minutesAgo: 5, pct: 0, anchor: nextAnchor),
+            obs(minutesAgo: 0, pct: 0, anchor: nextAnchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    // MARK: - Negative: blips and weak signals
+
+    @Test func rejectsSingleLowSampleBlip() {
+        // One low reading sandwiched — not sustained.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor),
+            obs(minutesAgo: 5, pct: 58, anchor: anchor),
+            obs(minutesAgo: 0, pct: 61, anchor: anchor),
+        ]
+        // Newest sample is high → not a current collapse.
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func rejectsLowRunTooShortInTime() {
+        // Two low samples but only ~30s apart (a burst of statusline
+        // pushes), below minConfirmDuration — not confirmed.
+        let series = [
+            obs(minutesAgo: 6, pct: 60, anchor: anchor),
+            obs(minutesAgo: 0.5, pct: 0, anchor: anchor),
+            obs(minutesAgo: 0, pct: 0, anchor: anchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func rejectsWhenPriorUtilizationTooLow() {
+        // Dropped from only 12% — not a meaningful headroom event.
+        let series = [
+            obs(minutesAgo: 15, pct: 12, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor),
+            obs(minutesAgo: 5, pct: 0, anchor: anchor),
+            obs(minutesAgo: 0, pct: 0, anchor: anchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func rejectsDropAcrossLongGap() {
+        // High reading, then a multi-hour gap (app closed/asleep), then
+        // a sustained low. We can't say when in the gap the reset
+        // happened → suppress as stale.
+        let series = [
+            obs(minutesAgo: 200, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor),
+            obs(minutesAgo: 5, pct: 0, anchor: anchor),
+            obs(minutesAgo: 0, pct: 0, anchor: anchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func rejectsWhenNewestStillHigh() {
+        // Recovered/never-collapsed: newest is high.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor),
+            obs(minutesAgo: 5, pct: 0, anchor: anchor),
+            obs(minutesAgo: 0, pct: 40, anchor: anchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func rejectsWhenAnchorMissing() {
+        // No cycle anchor on the low samples — can't prove "anchor
+        // didn't move", so we don't claim an early reset.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: nil),
+            obs(minutesAgo: 5, pct: 0, anchor: nil),
+            obs(minutesAgo: 0, pct: 0, anchor: nil),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func rejectsTooFewSamples() {
+        let series = [
+            obs(minutesAgo: 5, pct: 60, anchor: anchor),
+            obs(minutesAgo: 0, pct: 0, anchor: anchor),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func absorbsSubMinuteAnchorJitter() {
+        // The anchor wobbles by a few seconds between polls (server
+        // rounding) — still the same cycle, should still detect.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: anchor.addingTimeInterval(3)),
+            obs(minutesAgo: 5, pct: 0, anchor: anchor.addingTimeInterval(-2)),
+            obs(minutesAgo: 0, pct: 0, anchor: anchor.addingTimeInterval(1)),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) != nil)
+    }
+}


### PR DESCRIPTION
Anthropic has, a handful of times, reset everyone's rate limits ahead of schedule — the 7-day window collapses to 0% but your personal reset day doesn't move. They tend to do this before announcing it, and it materially changes how much headroom you have, so it's worth surfacing.

This is the **mirror image** of the existing reset notification: that one fires on a normal rollover (utilization drops **and** `resetsAt` advances); this fires when utilization collapses while the `resetsAt` cycle anchor **stays put**. Mutually exclusive by construction.

**What's here:**
- `GlobalRateLimitReset.detect` (PacerCore): pure, source-agnostic detector. Requires a meaningfully-high drop edge, a sustained low run (≥2 samples spanning ≥4 min) on an unchanged anchor, and that the high→low transition was observed live (≤30 min gap) so a reset that happened while the app was closed/asleep isn't surfaced as stale. This "confirm it's not a blip" guard is the crux. **13 unit tests.**
- Detection runs **headless**, in `AppBackgroundService` off the OAuth poller's scan-cycle signal — *not* in `NotificationsHost` (which is window-scoped) — so the banner fires even when the dashboard is closed, which is the whole point. Scans only the authoritative OAuth source over a 6h window (~150 rows), gated on `rateLimitsChanged`.
- **Opt-in** via a second toggle in the existing "Reset notifications" Settings card; default off. Anchor-keyed dedup → one banner per cycle.

Full suite green (314 tests). Builds + installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)