### PR TITLE
fix(notifications): surface an early reset even when it landed while away

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -226,11 +226,18 @@ final class AppBackgroundService {
 
     // MARK: - Global rate-limit reset detection
 
-    /// How far back to look for the pre-reset high + the confirming low
-    /// run. Bounded to the authoritative OAuth source (~12 rows/hour/
-    /// window), so even 6 hours is ~150 rows total — cheap to scan on
-    /// the ~5-minute cadence the OAuth poller writes rate-limit rows.
-    private static let globalResetLookback: TimeInterval = 6 * 3600
+    /// How far back to fetch samples when checking for an early reset on
+    /// a given window. We look across the *whole current cycle* (one
+    /// window-duration + 1h slack) rather than a fixed short window: an
+    /// early reset leaves the anchor unchanged, so the pre-reset high we
+    /// compare against necessarily sits within one window-duration of
+    /// now — and a reset that happened while the Mac was asleep/closed
+    /// must still find that high on next launch. Bounded to the
+    /// authoritative OAuth source (~12 rows/hour), so even the 7-day
+    /// window is ~2k rows scanned once per ~5-min poll — trivial.
+    private func globalResetLookback(forWindow window: String) -> TimeInterval {
+        (PaceMath.windowDuration(for: window) ?? (72 * 3600)) + 3600
+    }
 
     /// Observe scan-cycle completions and, when one carries fresh
     /// rate-limit rows, check whether Anthropic just reset limits early.
@@ -260,10 +267,10 @@ final class AppBackgroundService {
     /// coordinator handles the settings gate and per-cycle dedup.
     private func checkForGlobalReset() async {
         let context = ModelContext(container)
-        let cutoff = Date().addingTimeInterval(-Self.globalResetLookback)
         let oauthSource = RateLimitSource.oauth
 
         for window in [RateLimitWindowName.fiveHour, RateLimitWindowName.sevenDay] {
+            let cutoff = Date().addingTimeInterval(-globalResetLookback(forWindow: window))
             let descriptor = FetchDescriptor<RateLimitSample>(
                 predicate: #Predicate {
                     $0.source == oauthSource

--- a/PacerCore/Sources/PacerCore/RateLimit/GlobalRateLimitReset.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/GlobalRateLimitReset.swift
@@ -20,6 +20,15 @@ import Foundation
 /// `Observation` values and hand them over in any order; `detect` sorts
 /// internally. The function reads only the observations' own
 /// timestamps, never the wall clock, so it's deterministic.
+///
+/// Detection deliberately does NOT require the high→low transition to be
+/// recent: a reset that landed while the Mac was asleep or the app was
+/// closed is still worth surfacing the moment Pacer sees a sustained low
+/// on the unchanged anchor (the headroom persists until the real reset
+/// day). The caller's only obligation is to feed observations spanning
+/// the current cycle so the pre-reset high is present to compare against
+/// — which, since the anchor hasn't rolled, is always within one
+/// window-duration of now.
 public enum GlobalRateLimitReset {
 
     /// One window observation, source-agnostic. Maps from a
@@ -79,13 +88,6 @@ public enum GlobalRateLimitReset {
     /// genuinely persists fires the alert — the user's "confirm it's not
     /// just a blip" requirement.
     public static let minConfirmDuration: TimeInterval = 4 * 60
-    /// The drop must be observed *live*: the gap between the last high
-    /// reading and the first low reading must be no larger than this.
-    /// A multi-hour gap means the app was closed / asleep across the
-    /// transition, so we can't say when in that gap the reset happened
-    /// and it's probably stale — suppress rather than fire a banner
-    /// about something from this morning.
-    public static let maxDropGap: TimeInterval = 30 * 60
 
     /// Returns a `Detection` if the most recent observations show a
     /// sustained, anchor-stable collapse to near-zero preceded by a
@@ -129,14 +131,14 @@ public enum GlobalRateLimitReset {
 
         // The drop edge must itself be meaningfully high…
         guard before.usedPercentage >= highWatermark else { return nil }
-        // …carry the SAME cycle anchor as the low run (if its anchor is
-        // earlier, the cycle rolled over → normal reset, not this)…
+        // …and carry the SAME cycle anchor as the low run. If its anchor
+        // is earlier, the cycle rolled over → normal reset, not this.
+        // (This is also what keeps a long gap honest: a drop edge from
+        // before a normal rollover carries the old anchor and is
+        // rejected here, so we never mistake a rollover for an early
+        // reset no matter how far back we look.)
         guard let beforeAnchor = before.resetsAt,
               abs(beforeAnchor.timeIntervalSince(anchor)) <= anchorTolerance else { return nil }
-        // …and the high→low transition must have been seen live.
-        guard lowRun.first!.sampledAt.timeIntervalSince(before.sampledAt) <= maxDropGap else {
-            return nil
-        }
 
         return Detection(
             droppedFrom: before.usedPercentage,

--- a/PacerCore/Tests/PacerCoreTests/GlobalRateLimitResetTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/GlobalRateLimitResetTests.swift
@@ -105,15 +105,32 @@ struct GlobalRateLimitResetTests {
         #expect(GlobalRateLimitReset.detect(series) == nil)
     }
 
-    @Test func rejectsDropAcrossLongGap() {
-        // High reading, then a multi-hour gap (app closed/asleep), then
-        // a sustained low. We can't say when in the gap the reset
-        // happened → suppress as stale.
+    @Test func detectsDropAcrossLongGap() {
+        // High reading, then a multi-hour gap (Mac asleep / app closed),
+        // then a sustained low on the SAME anchor. The headroom is real
+        // and persists, so we surface it once a sustained low confirms —
+        // the gap is fine because the anchor didn't roll.
         let series = [
             obs(minutesAgo: 200, pct: 60, anchor: anchor),
             obs(minutesAgo: 10, pct: 0, anchor: anchor),
             obs(minutesAgo: 5, pct: 0, anchor: anchor),
             obs(minutesAgo: 0, pct: 0, anchor: anchor),
+        ]
+        let d = GlobalRateLimitReset.detect(series)
+        #expect(d != nil)
+        #expect(d?.droppedFrom == 60)
+    }
+
+    @Test func rejectsRolloverEvenAcrossLongGap() {
+        // Same long gap, but the anchor advanced across it → ordinary
+        // rollover, not an early reset. Must still be rejected no matter
+        // how far back the high sits.
+        let nextAnchor = anchor.addingTimeInterval(7 * 24 * 3600)
+        let series = [
+            obs(minutesAgo: 200, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: nextAnchor),
+            obs(minutesAgo: 5, pct: 0, anchor: nextAnchor),
+            obs(minutesAgo: 0, pct: 0, anchor: nextAnchor),
         ]
         #expect(GlobalRateLimitReset.detect(series) == nil)
     }


### PR DESCRIPTION
Follow-up to #38. As shipped, the early-reset detector suppressed itself unless the high→low transition was seen **live** (a ≤30-min sample gap) and only queried the last **6 hours** of samples. Both are wrong for the exact case the feature exists for: your Mac is asleep / Pacer is closed when Anthropic resets limits early, and you find out hours later when you come back.

An early global reset **doesn't expire** — the headroom persists until your real reset day — so it's worth surfacing whenever Pacer next sees a sustained low on the **unchanged anchor**, however long ago the drop happened. The detector already requires the *current* reading to still be low, so if you'd climbed back up since, it correctly won't fire.

**Changes**
- Drop the `maxDropGap` "must be observed live" guard. The anchor-equality check is what keeps a long gap honest — a drop edge from before a normal rollover carries the *old* anchor and is rejected, so a rollover is never mistaken for an early reset no matter how far back we look.
- Widen the detection fetch from a fixed 6h to the **whole current cycle** (one window-duration + 1h) per window. Since the anchor hasn't rolled, the pre-reset high necessarily lies within one window-duration of now — exact, not a heuristic. ~2k OAuth rows for the 7-day window, trivial at the 5-min poll cadence.

Sustained-low confirmation (≥2 samples over ≥4 min) is unchanged, so a blip still won't fire — on a cold boot the banner lands once the second poll confirms (~5–10 min after launch). Tests: the long-gap case now asserts **detection**; added a rollover-across-a-gap case proving the anchor check still rejects it. **315 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)