### PR TITLE
docs: queue predictions redesign (#3) + storage/DuckDB research (#4)

### DIFF
--- a/docs/predictions-redesign.md
+++ b/docs/predictions-redesign.md
@@ -1,0 +1,113 @@
+# Predictions redesign — slope/acceleration warnings + 2nd-derivative estimates
+
+> Status: **planned, not started.** Parked here so a fresh session can
+> pick it up cold. Owner decision still open (see "Open decision").
+> Originating idea: Pacer's projections feel less sensible than Claude
+> God's because they extrapolate the *current slope* only; Claude God's
+> daily-total estimates look better because they account for the second
+> derivative (acceleration), and ideally would self-learn on personal
+> usage patterns.
+
+## Why now
+
+Every projection Pacer shows today is a naive first-derivative
+extrapolation. Each is individually reasonable but they share the same
+blind spot — they assume the most recent rate continues flat, so they
+overshoot during a ramp-up and undershoot during a wind-down, and none
+of them know that you don't code at 3am or on Sundays.
+
+The three live surfaces:
+
+| Surface | Where | Current math | Failure mode |
+|---|---|---|---|
+| **End-of-day cost** | `App/Views/LiveActivityCard.swift` → `projectedEndOfDay` (~line 132) | `todaySoFar + costLastHour × hoursLeftInDay` | Mid-ramp it multiplies a hot last hour across the whole evening → wild overshoot. After you stop, last-hour rate ≈ 0 so it collapses to "today so far" (OK-ish). Ignores time-of-day shape. |
+| **Rate-limit ETA** | `PacerCore/.../RateLimit/BurnRate.swift` → `BurnRate.project` | First-to-last linear slope over a 90-min lookback → time to 100% | An early spike in the 90-min window tilts the whole slope; no recency weighting; no acceleration term, so a ramp reads too slow and a taper too fast. Consumed by `HeroStripCard` + pace widgets. |
+| **Monthly total** | `PacerCore/.../Forecast/MonthlyForecast.swift` → `compute` | `monthSoFar + avgDailyCost × daysRemaining` (avg over days-with-data) | Flat average ignores trend and weekday/weekend shape; a heavy first week projects a heavy month even if you always taper. Consumed by `MonthlyForecastCard`. |
+
+## The plan
+
+Build **one** pure, tested estimator in `PacerCore` and feed it to both
+a new warning and (after sign-off) the three projections. Don't fork the
+math per surface — one source of truth, same way `PaceBand`/`BurnRate`
+are shared today.
+
+### 1. Shared trend estimator (the foundation)
+
+A pure function over a `(time, value)` series that returns **level,
+recency-weighted slope, and a damped acceleration term**:
+
+- **Recency-weighted slope** — weight recent samples more (EWMA of slope,
+  or weighted least-squares with an exponential kernel). This alone fixes
+  most of the "an old spike distorts the line" problem and implicitly
+  bends the projection toward what's happening *now*.
+- **Damped acceleration (the 2nd derivative)** — estimate Δslope and
+  extrapolate with it, but **decay the acceleration over the horizon** so
+  a quadratic doesn't explode ("at this acceleration you'll spend $40k by
+  midnight"). Concretely: project with `slope(t) = slope₀ + accel₀ ·
+  e^(−t/τ)` style damping, or cap the acceleration's contribution to a
+  fraction of the linear term. The damping constant τ is the main knob to
+  tune against real data.
+
+Keep it source-agnostic and `Date`-free internally (take `now` as a
+param) so it unit-tests like `BurnRate`/`MonthlyForecast` do. Put it in
+`PacerCore/Sources/PacerCore/Forecast/` (or `RateLimit/` if it ends up
+rate-limit-shaped). Mirror the `BurnRate.Sample` value-type pattern.
+
+### 2. Acceleration warning (new feature — lower risk)
+
+A new alert that fires on the **second derivative**, not the level:
+"you're not just ahead of pace, you're *accelerating* toward the cap."
+Distinct from the existing `PaceBand` (which is level-vs-linear-pace).
+Trigger when acceleration is strongly positive AND the damped projection
+crosses the limit before the window resets. This is genuinely new
+surface, so it has more latitude than changing displayed numbers — but
+still agree thresholds before shipping. Wire through
+`NotificationCoordinator` + a `PacerSettings` opt-in, same shape as the
+other alerts (and the new `notifyGlobalReset`).
+
+### 3. Personal pattern shaping (optional, "self-learning lite")
+
+For end-of-day and monthly, weight *remaining time* by the user's own
+empirical **hour-of-day** and **day-of-week** activity profiles built
+from `HourlyAggregate` / `DailyAggregate` history — e.g. "you typically
+do 70% of a day's spend by noon" scales the remaining-day projection
+instead of flat clock-hours-left. This is the "self-learning on patterns"
+ask in a simple, debuggable, non-ML form. Real on-device ML (Core ML)
+stays a *later* step — empirical profiles get ~90% of the value with none
+of the model-lifecycle cost.
+
+## Constraints / process
+
+- **Predictions are a shared, displayed surface.** Per the standing rule
+  (see `memory/feedback_show_evidence_protect_shared_views.md`): do NOT
+  silently swap the displayed projection math. Prototype new-vs-old **on
+  real data, render before/after**, and get sign-off before changing
+  `HeroStripCard` / `LiveActivityCard` / `MonthlyForecastCard` / widgets.
+- The estimator + acceleration warning can be built and proven first
+  (they don't alter existing displayed numbers); swap the displayed
+  projections in a second, sign-off-gated step.
+- Reuse, don't duplicate: `BurnRate` already owns lookback/slope plumbing
+  and has tests — the new estimator should likely subsume or sit beside
+  it, not parallel it.
+
+## Open decision (asked, deferred)
+
+How far to go in the first pass:
+
+1. **Damped 2nd-deriv estimator + warning + swap all three projections**
+   (recommended — the direct "2nd derivative now" path).
+2. Same, **plus** personal time-of-day/day-of-week shaping.
+3. Estimator + warning **only**; leave displayed projections untouched
+   until the estimator is proven in the wild.
+
+Owner deferred the choice to the session that picks this up. Default
+recommendation if still unspecified: option 1, with the before/after
+shown before the displayed swap.
+
+## Files to touch
+
+- New: `PacerCore/Sources/PacerCore/Forecast/TrendEstimator.swift` (+ tests).
+- `PacerCore/.../RateLimit/BurnRate.swift` — fold into / call the estimator.
+- `PacerCore/.../Forecast/MonthlyForecast.swift` — use the estimator + optional pattern shaping.
+- `App/Views/LiveActivityCard.swift` — `projectedEndOfDay` → estimator.
+- `App/Notifications/NotificationCoordinator.swift` + `App/Views/SettingsView.swift` + `PacerCore/.../Settings/PacerPreferenceKeys.swift` — acceleration-warning opt-in (mirror `notifyGlobalReset`).

--- a/docs/research/storage-duckdb-vs-sqlite.md
+++ b/docs/research/storage-duckdb-vs-sqlite.md
@@ -1,0 +1,107 @@
+# Storage visibility + DuckDB vs SQLite
+
+> Status: **research queued, not started.** Two parts: (1) a small
+> in-app feature surfacing how much disk the data uses, and (2) a
+> research question — would DuckDB save meaningful at-rest space or query
+> time vs SQLite (the SwiftData backing store), especially under a future
+> Rust/Go core. Part 2 is curiosity-driven; don't let it block anything.
+
+## Baseline measurements (this machine, 2026-06-10)
+
+Real numbers to anchor the research — captured with `du` / `find`:
+
+| What | Size | Notes |
+|---|---|---|
+| **Claude Code JSONL logs** (`~/.claude/projects`) | **1.1 GB** | 1,143 `*.jsonl` files; ~1.115 GB raw bytes. This is the *source* data Pacer parses — Pacer doesn't own it and shouldn't delete it, but it's the dominant footprint and users will want to see it. |
+| **Pacer SwiftData store** (active) | **~97 MB** | `Library/Group Containers/YZXWMJ5VBY.com.ericandrechek.pacer/pacer.sqlite` (+3 MB WAL, 32 KB shm). The team-prefixed container — the signed app's. |
+| **Pacer SwiftData store** (other) | 17 MB | `Library/Group Containers/group.com.ericandrechek.pacer/pacer.sqlite` (+2 MB WAL). ⚠️ **Investigate** — a second container exists. Likely a dev/unsigned/`.standard`-fallback store from earlier builds. Confirm which one `PacerStore.appGroupIdentifier` actually opens; the visibility feature must report the live one, and we may have an orphaned ~17 MB store to clean up. |
+| **Pacer logs** (`~/Library/Logs/Pacer`) | 28 MB | stderr redirect from the in-process service. Already rotatable. |
+
+**Key ratio:** Pacer's *derived* store (~97 MB) is ~9% of the raw JSONL
+(1.1 GB). The derived store is row-oriented SwiftData (`TokenSample` +
+`RateLimitSample` + hourly/daily/project aggregates). The OAuth poller
+alone adds ~2 `RateLimitSample` rows / 5 min ≈ 200k rows/year (see the
+note in `RateLimitSample.swift`).
+
+## Part 1 — in-app storage visibility (the feature)
+
+Surface, somewhere unobtrusive (Settings → Data, or the existing
+Help/"Show Database in Finder" area):
+
+- **Pacer's own footprint**: live store + WAL + shm + logs, via
+  `PacerStore.storeURL()` and the logs dir. Cheap: `FileManager`
+  `resourceValues(forKeys: [.fileSizeKey])` (or `.totalFileAllocatedSize`).
+- **Claude Code's JSONL footprint**: sum of `*.jsonl` under the resolved
+  Claude projects dir (`ClaudePathResolver`). Optionally per-project, to
+  reuse in the Projects tab.
+- Row counts per model (`TokenSample`, `RateLimitSample`, aggregates) for
+  a "what's in here" breakdown.
+
+Watch-outs: must stay off the main thread (1 GB tree walk), cache the
+result, and never touch/delete Claude's data. Reuse the compact/exact
+formatter pattern (`pacerBytes`? — add one) per `docs/ux-backlog.md`.
+
+## Part 2 — DuckDB vs SQLite (the research question)
+
+### Frame it honestly
+
+SQLite (via SwiftData) is doing fine today: ~97 MB, and perf was already
+tuned hard (`docs/perf-tuning.md`, p50 1500ms→103ms) with indexes on the
+hot `RateLimitSample` / aggregate predicates. So this is **not** a
+"we have a problem" investigation — it's "is there a better fit if/when
+we move to a Rust/Go core, and would columnar storage shrink the
+at-rest size or speed up the analytical scans (heatmaps, 6-month
+history, per-model rollups)?"
+
+### What to actually measure
+
+1. **At-rest size.** Load the same `TokenSample`/aggregate data into a
+   DuckDB file and compare on-disk size. DuckDB is columnar with
+   per-column compression (dictionary/RLE/FSST) — for highly repetitive
+   columns (model name, project path, date strings, source) it should
+   compress *dramatically* better than SQLite's row pages. Hypothesis:
+   the 97 MB store could be a small fraction of that in DuckDB. **Verify.**
+2. **Query time.** Benchmark the genuinely analytical reads — the
+   6-month heatmap, monthly rollups, per-model/-project aggregation over
+   the full history — SQLite-with-indexes vs DuckDB. DuckDB wins big on
+   full-scan aggregation; SQLite wins on tiny indexed point lookups
+   (the "latest N samples" hot path). Pacer does both, so the answer is
+   probably "mixed," which matters for the recommendation.
+3. **Write path.** Pacer writes small batches frequently (scan cycles,
+   5-min poll). DuckDB is optimized for bulk/append, not many tiny
+   transactions — measure whether the frequent-small-write pattern is a
+   problem or whether an append-only + periodic-compaction design fits.
+
+### Open questions to resolve before any adoption
+
+- **Swift/embedding story.** SwiftData is native; DuckDB would be a C/C++
+  library via a C API (no first-class Swift binding — confirm current
+  state). Under a **Rust/Go core** (the TODO that makes this interesting)
+  the binding story is much better: `duckdb-rs` / Go `go-duckdb` are
+  mature. So this question is really coupled to the
+  multi-platform-core TODO — evaluate them together, not in isolation.
+- **Migration / dual-write.** SwiftData owns the schema + the reactive
+  `@Query` UI today. A DuckDB move means either (a) DuckDB as an
+  *analytics sidecar* (SwiftData stays the system of record, DuckDB is a
+  derived read-optimized copy for heavy scans) or (b) a full backing-store
+  swap (large, ties into the Rust/Go core). (a) is the low-risk
+  experiment; (b) is the strategic bet.
+- **Does the win clear the bar?** At 97 MB, even a 10× at-rest reduction
+  saves ~87 MB — nice but not user-visible-painful. The query-time win on
+  history/heatmap views is the more likely real payoff. Decide what
+  result would actually justify the dependency.
+
+### Suggested first step (cheap, decisive)
+
+Export the current `TokenSample` + aggregates to Parquet/CSV, load into a
+standalone DuckDB file, and just **measure size + run the heatmap/rollup
+queries both ways**. One afternoon, real numbers, no app changes. That
+result (plus the Rust/Go-core timing) decides whether this is worth more
+than a curiosity.
+
+## Related
+
+- `docs/perf-tuning.md` — why SQLite is already fast enough today.
+- The "multi-platform Rust/Go core" TODO — the context that makes DuckDB
+  actually attractive; evaluate jointly.
+- `memory/project_overnight_perf_loop.md`.


### PR DESCRIPTION
Two planning docs so a fresh session can start either deferred TODO cold — no code changes.

**`docs/predictions-redesign.md`** — the slope/acceleration + 2nd-derivative work. Captures the three current naive first-derivative projections (end-of-day, rate-limit ETA, monthly) with file refs, the proposed shared damped-acceleration estimator, the new acceleration warning, optional empirical time-of-day/day-of-week shaping, the shared-surface sign-off constraint, and the still-open scope decision.

**`docs/research/storage-duckdb-vs-sqlite.md`** — the storage-visibility feature + DuckDB-vs-SQLite question, anchored on real measurements from this machine:
- Claude Code JSONL: **1.1 GB** across 1,143 files
- Pacer's SwiftData store: **~97 MB** (active, team-prefixed container)
- A flagged **~17 MB** second app-group container worth investigating (possible orphan)
- Logs: 28 MB

Framed as fit-for-a-future-Rust/Go-core rather than a current problem (SQLite is already tuned fine per `perf-tuning.md`), with a cheap, decisive first experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)