### PR TITLE
feat(notifications): default the early-reset alert on

### DIFF
--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -153,7 +153,11 @@ public enum PacerSettings {
         Key.notifyOnDailyCost:     false,
         Key.dailyCostThresholdUSD: 50.0,
         Key.notifyOnReset:         false,
-        Key.notifyGlobalReset:     false,
+        // On by default: an off-schedule global reset is rare and
+        // high-value (fires at most once per cycle), so anyone who's
+        // enabled notifications at all should hear about it without
+        // having to find this toggle. Still gated by notificationsEnabled.
+        Key.notifyGlobalReset:     true,
         Key.notifyDailySummary:    false,
         Key.dailySummaryHour:      21,
         Key.costMode:              "auto",

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -772,7 +772,7 @@ private struct ResetAlertCard: View {
     private var resetEnabled: Bool = false
 
     @AppStorage(PacerSettings.Key.notifyGlobalReset, store: PacerSettings.store)
-    private var globalResetEnabled: Bool = false
+    private var globalResetEnabled: Bool = true
 
     var body: some View {
         PacerCard("Reset notifications", content: {


### PR DESCRIPTION
Follow-up to #38/#39. Defaults the **early global-reset** alert (`notifyGlobalReset`) to **on**.

It's a rare, high-value, low-noise event — fires at most once per cycle and only on a genuine off-schedule reset — so anyone who's already enabled notifications should hear about it without having to find a separate toggle. Still gated by the master `notificationsEnabled` switch, so it stays silent for users who haven't turned notifications on at all. The routine on-schedule rollover alert (`notifyOnReset`) stays opt-in.

Flips the `registerDefaults` value and the `@AppStorage` fallback to match. The feature only landed on `main` (unreleased), so no existing user has the key persisted — the new default applies cleanly to everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)