### PR TITLE
feat(settings): Storage card in Settings → Data (+ storage breakdown research)

### DIFF
--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -43,6 +43,7 @@ struct SettingsView: View {
                 SettingsSection("Data") {
                     CostCalculationCard()
                     ProjectAliasesPointerCard()
+                    StorageCard()
                     DatabaseCard()
                     LogsCard()
                 }
@@ -1286,6 +1287,84 @@ private struct OAuthTokenOverrideCard: View {
 }
 
 // MARK: - Storage
+
+/// Disk footprint of the data Pacer touches. Measured off the main
+/// actor on appear (Claude's logs run to gigabytes) and rendered as a
+/// small breakdown. Read-only — it never writes or deletes anything,
+/// least of all Claude's transcripts.
+private struct StorageCard: View {
+    @State private var snapshot: StorageSnapshot?
+    @State private var didMeasure = false
+
+    var body: some View {
+        PacerCard("Storage", content: {
+            if let snapshot {
+                VStack(alignment: .leading, spacing: 10) {
+                    StorageRow(label: "Pacer database", bytes: snapshot.pacerDatabaseBytes)
+                    StorageRow(label: "Pacer logs", bytes: snapshot.pacerLogsBytes)
+                    Divider()
+                    StorageRow(
+                        label: "Claude Code logs",
+                        bytes: snapshot.claudeLogsBytes,
+                        detail: "\(snapshot.claudeLogFileCount.formatted()) file\(snapshot.claudeLogFileCount == 1 ? "" : "s")"
+                    )
+                }
+            } else if didMeasure {
+                Text("Couldn't measure storage.")
+                    .foregroundStyle(.secondary)
+            } else {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Measuring…").foregroundStyle(.secondary)
+                }
+            }
+        }, footer: {
+            Text("Pacer's database is the usage history it derives from Claude Code's logs — both stay on your Mac. The Claude Code logs are the raw transcripts Pacer reads; it never modifies or deletes them.")
+        })
+        .task {
+            // Re-measure each time the Settings tab appears — sizes drift
+            // as you keep using Claude Code, and this is cheap (it stats
+            // files, never reads them).
+            let storeURL = try? PacerStore.storeURL()
+            let logsDir = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Logs/Pacer")
+            let claudeDirs = (try? ClaudePathResolver().resolve())?
+                .map(\.projectsDirectory) ?? []
+            let snap = await Task.detached(priority: .utility) {
+                StorageInspector.snapshot(
+                    storeURL: storeURL,
+                    logsDirectory: logsDir,
+                    claudeProjectsDirectories: claudeDirs
+                )
+            }.value
+            snapshot = snap
+            didMeasure = true
+        }
+    }
+}
+
+/// One "label … size" line in the Storage card. Optional `detail` sits
+/// quietly after the label (e.g. a file count).
+private struct StorageRow: View {
+    let label: String
+    let bytes: Int64
+    var detail: String? = nil
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(label).foregroundStyle(.primary)
+            if let detail {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 16)
+            Text(pacerBytes(bytes))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+    }
+}
 
 private struct DatabaseCard: View {
     private var storeURL: URL? { try? PacerStore.storeURL() }

--- a/PacerCore/Sources/PacerCore/Stats/StorageInspector.swift
+++ b/PacerCore/Sources/PacerCore/Stats/StorageInspector.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// On-disk footprint of the data Pacer touches: its own derived store
+/// and logs, plus the raw Claude Code JSONL transcripts it reads from.
+/// All sizes are *allocated* bytes (on-disk blocks, what Finder/`du`
+/// report) rather than logical length, so the numbers match what a user
+/// sees elsewhere.
+public struct StorageSnapshot: Sendable, Equatable {
+    /// `pacer.sqlite` + its `-wal` / `-shm` sidecars.
+    public let pacerDatabaseBytes: Int64
+    /// Everything under `~/Library/Logs/Pacer`.
+    public let pacerLogsBytes: Int64
+    /// Sum of `*.jsonl` under Claude Code's `projects/` dir(s). This is
+    /// Claude's data, shown for context — Pacer reads it, never writes
+    /// or deletes it.
+    public let claudeLogsBytes: Int64
+    /// How many `*.jsonl` files that sum covered.
+    public let claudeLogFileCount: Int
+
+    /// What Pacer itself is responsible for on disk.
+    public var pacerTotalBytes: Int64 { pacerDatabaseBytes + pacerLogsBytes }
+
+    public init(
+        pacerDatabaseBytes: Int64,
+        pacerLogsBytes: Int64,
+        claudeLogsBytes: Int64,
+        claudeLogFileCount: Int
+    ) {
+        self.pacerDatabaseBytes = pacerDatabaseBytes
+        self.pacerLogsBytes = pacerLogsBytes
+        self.claudeLogsBytes = claudeLogsBytes
+        self.claudeLogFileCount = claudeLogFileCount
+    }
+}
+
+/// Measures the on-disk size of files and directory trees. The size
+/// helpers are pure file-system reads (no SwiftData, no app state) so
+/// they unit-test against a temp dir; the resolving `snapshot(...)`
+/// orchestration takes already-resolved URLs from the caller for the
+/// same reason. All of it is synchronous and can walk a large tree
+/// (Claude's logs run to gigabytes) — call it off the main actor.
+public enum StorageInspector {
+
+    /// Allocated on-disk size of a single file, or 0 if it's missing /
+    /// unreadable. Prefers `totalFileAllocatedSize` (includes resource
+    /// forks / metadata blocks) and falls back to `fileAllocatedSize`.
+    public static func fileAllocatedSize(_ url: URL) -> Int64 {
+        let values = try? url.resourceValues(
+            forKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
+        )
+        return Int64(values?.totalFileAllocatedSize ?? values?.fileAllocatedSize ?? 0)
+    }
+
+    /// Recursively sum the allocated size of regular files under
+    /// `directory` whose URL passes `include`, and count how many
+    /// matched. A missing directory yields `(0, 0)`. The `include`
+    /// predicate is applied per file so callers can scope to e.g. one
+    /// extension without a second walk.
+    public static func directoryAllocatedSize(
+        _ directory: URL,
+        include: (URL) -> Bool = { _ in true }
+    ) -> (bytes: Int64, count: Int) {
+        let keys: [URLResourceKey] = [
+            .isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey,
+        ]
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return (0, 0)
+        }
+
+        var bytes: Int64 = 0
+        var count = 0
+        for case let url as URL in enumerator {
+            let values = try? url.resourceValues(forKeys: Set(keys))
+            guard values?.isRegularFile == true, include(url) else { continue }
+            bytes += Int64(values?.totalFileAllocatedSize ?? values?.fileAllocatedSize ?? 0)
+            count += 1
+        }
+        return (bytes, count)
+    }
+
+    /// Build a full snapshot from already-resolved locations. The caller
+    /// owns resolution (`PacerStore.storeURL()`, the logs path, the
+    /// Claude roots) so this stays a pure measurement step.
+    ///
+    /// - Parameters:
+    ///   - storeURL: the live `pacer.sqlite`. nil → database reported as
+    ///     0 (App Group container unavailable).
+    ///   - logsDirectory: `~/Library/Logs/Pacer`.
+    ///   - claudeProjectsDirectories: each resolved Claude `projects/`
+    ///     dir; their `*.jsonl` are summed across all of them.
+    public static func snapshot(
+        storeURL: URL?,
+        logsDirectory: URL,
+        claudeProjectsDirectories: [URL]
+    ) -> StorageSnapshot {
+        var databaseBytes: Int64 = 0
+        if let storeURL {
+            // The WAL/SHM sidecars are `pacer.sqlite-wal` / `-shm` —
+            // a suffix on the whole filename, not a path extension.
+            databaseBytes += fileAllocatedSize(storeURL)
+            databaseBytes += fileAllocatedSize(URL(fileURLWithPath: storeURL.path + "-wal"))
+            databaseBytes += fileAllocatedSize(URL(fileURLWithPath: storeURL.path + "-shm"))
+        }
+
+        let logs = directoryAllocatedSize(logsDirectory)
+
+        var claudeBytes: Int64 = 0
+        var claudeCount = 0
+        for dir in claudeProjectsDirectories {
+            let result = directoryAllocatedSize(dir) { $0.pathExtension == "jsonl" }
+            claudeBytes += result.bytes
+            claudeCount += result.count
+        }
+
+        return StorageSnapshot(
+            pacerDatabaseBytes: databaseBytes,
+            pacerLogsBytes: logs.bytes,
+            claudeLogsBytes: claudeBytes,
+            claudeLogFileCount: claudeCount
+        )
+    }
+}

--- a/PacerCore/Sources/PacerUI/Formatters.swift
+++ b/PacerCore/Sources/PacerUI/Formatters.swift
@@ -154,6 +154,19 @@ public func pacerTokensExact(_ count: Int64) -> String {
     count.formatted(.number)
 }
 
+// MARK: - Bytes
+
+/// Human-readable on-disk size that matches what Finder shows ("97 MB",
+/// "1.1 GB"). Uses `ByteCountFormatter` with the `.file` count style —
+/// macOS's decimal (1000-based) convention — so Pacer's storage figures
+/// line up with what the user sees in Finder rather than diverging by
+/// the binary-vs-decimal factor. Negative inputs clamp to 0.
+public func pacerBytes(_ bytes: Int64) -> String {
+    let formatter = ByteCountFormatter()
+    formatter.countStyle = .file
+    return formatter.string(fromByteCount: max(0, bytes))
+}
+
 // MARK: - Strings
 
 /// Strip provider prefixes like `anthropic/` so model labels stay tight.

--- a/PacerCore/Tests/PacerCoreTests/StorageInspectorTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/StorageInspectorTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("StorageInspector")
+struct StorageInspectorTests {
+
+    /// Make a unique temp directory; caller removes it.
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pacer-storage-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func write(_ bytes: Int, to url: URL) throws {
+        try Data(repeating: 0xAB, count: bytes).write(to: url)
+    }
+
+    @Test func sumsAndCountsMatchingFilesRecursively() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sub = root.appendingPathComponent("project-a")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+
+        try write(1000, to: root.appendingPathComponent("a.jsonl"))
+        try write(2000, to: sub.appendingPathComponent("b.jsonl"))
+        try write(500, to: sub.appendingPathComponent("notes.txt")) // excluded by filter
+
+        let result = StorageInspector.directoryAllocatedSize(root) {
+            $0.pathExtension == "jsonl"
+        }
+
+        // Two .jsonl files, recursively. Allocated size is block-rounded
+        // (≥ logical), so assert the count exactly and the bytes as a
+        // lower bound.
+        #expect(result.count == 2)
+        #expect(result.bytes >= 3000)
+    }
+
+    @Test func unfilteredWalkCountsEverything() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try write(10, to: root.appendingPathComponent("a.jsonl"))
+        try write(10, to: root.appendingPathComponent("b.txt"))
+
+        let result = StorageInspector.directoryAllocatedSize(root)
+        #expect(result.count == 2)
+    }
+
+    @Test func missingDirectoryIsZero() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pacer-does-not-exist-\(UUID().uuidString)")
+        let result = StorageInspector.directoryAllocatedSize(missing)
+        #expect(result.bytes == 0)
+        #expect(result.count == 0)
+    }
+
+    @Test func missingFileIsZero() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nope-\(UUID().uuidString).sqlite")
+        #expect(StorageInspector.fileAllocatedSize(missing) == 0)
+    }
+
+    @Test func snapshotSumsDatabaseSidecarsAndClaudeLogs() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Fake store + WAL/SHM sidecars.
+        let store = root.appendingPathComponent("pacer.sqlite")
+        try write(4000, to: store)
+        try write(1000, to: URL(fileURLWithPath: store.path + "-wal"))
+        try write(100, to: URL(fileURLWithPath: store.path + "-shm"))
+
+        // Fake logs dir.
+        let logs = root.appendingPathComponent("Logs")
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        try write(2000, to: logs.appendingPathComponent("pacer.log"))
+
+        // Fake Claude projects dir with one jsonl + one non-jsonl.
+        let claude = root.appendingPathComponent("projects")
+        try FileManager.default.createDirectory(at: claude, withIntermediateDirectories: true)
+        try write(5000, to: claude.appendingPathComponent("session.jsonl"))
+        try write(9999, to: claude.appendingPathComponent("ignore.bin"))
+
+        let snap = StorageInspector.snapshot(
+            storeURL: store,
+            logsDirectory: logs,
+            claudeProjectsDirectories: [claude]
+        )
+
+        #expect(snap.pacerDatabaseBytes >= 5100)        // store + wal + shm
+        #expect(snap.pacerLogsBytes >= 2000)
+        #expect(snap.claudeLogsBytes >= 5000)
+        #expect(snap.claudeLogFileCount == 1)           // only the .jsonl
+        #expect(snap.pacerTotalBytes == snap.pacerDatabaseBytes + snap.pacerLogsBytes)
+    }
+
+    @Test func snapshotWithNilStoreReportsZeroDatabase() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logs = root.appendingPathComponent("Logs")
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+
+        let snap = StorageInspector.snapshot(
+            storeURL: nil,
+            logsDirectory: logs,
+            claudeProjectsDirectories: []
+        )
+        #expect(snap.pacerDatabaseBytes == 0)
+        #expect(snap.claudeLogFileCount == 0)
+    }
+}

--- a/docs/research/storage-duckdb-vs-sqlite.md
+++ b/docs/research/storage-duckdb-vs-sqlite.md
@@ -1,10 +1,11 @@
 # Storage visibility + DuckDB vs SQLite
 
-> Status: **research queued, not started.** Two parts: (1) a small
-> in-app feature surfacing how much disk the data uses, and (2) a
-> research question — would DuckDB save meaningful at-rest space or query
-> time vs SQLite (the SwiftData backing store), especially under a future
-> Rust/Go core. Part 2 is curiosity-driven; don't let it block anything.
+> Status: **Part 1 (in-app storage visibility) shipped** — a "Storage"
+> card in Settings → Data, backed by `StorageInspector` in PacerCore.
+> **Part 2 (DuckDB vs SQLite research) still open** — would DuckDB save
+> meaningful at-rest space or query time vs SQLite (the SwiftData backing
+> store), especially under a future Rust/Go core? Curiosity-driven; don't
+> let it block anything.
 
 ## Baseline measurements (this machine, 2026-06-10)
 
@@ -14,7 +15,7 @@ Real numbers to anchor the research — captured with `du` / `find`:
 |---|---|---|
 | **Claude Code JSONL logs** (`~/.claude/projects`) | **1.1 GB** | 1,143 `*.jsonl` files; ~1.115 GB raw bytes. This is the *source* data Pacer parses — Pacer doesn't own it and shouldn't delete it, but it's the dominant footprint and users will want to see it. |
 | **Pacer SwiftData store** (active) | **~97 MB** | `Library/Group Containers/YZXWMJ5VBY.com.ericandrechek.pacer/pacer.sqlite` (+3 MB WAL, 32 KB shm). The team-prefixed container — the signed app's. |
-| **Pacer SwiftData store** (other) | 17 MB | `Library/Group Containers/group.com.ericandrechek.pacer/pacer.sqlite` (+2 MB WAL). ⚠️ **Investigate** — a second container exists. Likely a dev/unsigned/`.standard`-fallback store from earlier builds. Confirm which one `PacerStore.appGroupIdentifier` actually opens; the visibility feature must report the live one, and we may have an orphaned ~17 MB store to clean up. |
+| **Pacer SwiftData store** (legacy) | 17 MB | `Library/Group Containers/group.com.ericandrechek.pacer/pacer.sqlite` (+2 MB WAL). The pre-rename `group.`-prefixed container documented in `PacerStore.swift` (`legacyAppGroupIdentifier`) — `bin/dev-install.sh` migrates *from* it. Not the live store; the in-app Storage card reports the live TeamID-prefixed one via `PacerStore.storeURL()`. Safe to delete once you've confirmed your data is in the live container (it is). |
 | **Pacer logs** (`~/Library/Logs/Pacer`) | 28 MB | stderr redirect from the in-process service. Already rotatable. |
 
 **Key ratio:** Pacer's *derived* store (~97 MB) is ~9% of the raw JSONL
@@ -23,7 +24,15 @@ Real numbers to anchor the research — captured with `du` / `find`:
 alone adds ~2 `RateLimitSample` rows / 5 min ≈ 200k rows/year (see the
 note in `RateLimitSample.swift`).
 
-## Part 1 — in-app storage visibility (the feature)
+## Part 1 — in-app storage visibility (the feature) ✅ shipped
+
+**Shipped:** a "Storage" card in Settings → Data showing Pacer database
+(sqlite + WAL + shm), Pacer logs, and Claude Code logs (bytes + file
+count). Backed by `PacerCore/.../Stats/StorageInspector.swift` (pure,
+allocated-size measurement, unit-tested) + a `pacerBytes` formatter;
+measured off-main on appear. Row counts (below) were left out of v1 —
+add later if "what's in here" proves useful. Original plan, for the
+record:
 
 Surface, somewhere unobtrusive (Settings → Data, or the existing
 Help/"Show Database in Finder" area):
@@ -42,6 +51,38 @@ result, and never touch/delete Claude's data. Reuse the compact/exact
 formatter pattern (`pacerBytes`? — add one) per `docs/ux-backlog.md`.
 
 ## Part 2 — DuckDB vs SQLite (the research question)
+
+### First findings — where the 94 MB actually goes (2026-06-10, sqlite side)
+
+Before touching DuckDB, broke the live store down with `dbstat` +
+`COUNT(*)`. This reframed the whole question. Total **94.2 MB / 22,995
+pages**:
+
+| Segment | Size | Notes |
+|---|---|---|
+| `ZTOKENSAMPLE` (data) | **32.7 MB** | 104,300 rows — the actual usage samples. |
+| Indexes on TokenSample | **~25 MB** | dedupKey 7.7 + projectPath 6.5 + sessionId 5.2 + datemodel 3.9 + sampledAt 1.8. ~76% of the data size, in indexes. |
+| **Core Data history** (`ACHANGE` + `ATRANSACTION` + their indexes) | **~30 MB** | `ACHANGE` 13.5, `ACHANGE_ZTRANSACTIONID_INDEX` 7.3, `ATRANSACTION` 4.0 + ~6.7 of transaction indexes. |
+| `ZRATELIMITSAMPLE` + aggregates | small | 13,732 rate-limit rows; 759 hourly / 98 daily / 153 project-daily aggregate rows. |
+
+**The headline: ~⅓ of the store (~30 MB) is SwiftData/Core Data
+persistent-history change-tracking, not user data.** That's a concrete,
+*no-new-dependency* win that outranks anything DuckDB would buy:
+
+1. **Prune persistent history.** Core Data's `NSPersistentHistoryToken`
+   transaction log (`ATRANSACTION`/`ACHANGE`) accrues because something
+   enabled history tracking (the App Group + widget cross-process setup
+   often does). If no consumer actually *reads* history tokens, it can be
+   capped/pruned (`deletePersistentHistory(before:)`) or disabled —
+   reclaiming ~30 MB and bounding future growth. **Verify a consumer
+   needs it before disabling.** This is the first thing to chase.
+2. **Audit the 5 TokenSample indexes (~25 MB).** Each maps to a hot
+   predicate (see `RateLimitSample.swift`/`TokenSample.swift` index
+   docs), but at ~25 MB for ~33 MB of data it's worth confirming all
+   five still earn their keep, especially `dedupKey` (7.7 MB).
+
+These two together could roughly halve the store with zero columnar
+rewrite — and they're worth doing regardless of the DuckDB question.
 
 ### Frame it honestly
 


### PR DESCRIPTION
Picks up TODO #4 — both parts.

## Part 1 — the feature (shipped here)
A new **Storage** card in Settings → Data showing how much disk Pacer's data uses, which wasn't visible anywhere before:
- **Pacer database** (sqlite + WAL + shm)
- **Pacer logs**
- **Claude Code logs** (size + file count) — shown for context; Pacer reads but never writes it

`StorageInspector` (PacerCore) does allocated-size measurement (matches Finder/`du`) over files and trees, with a resolving snapshot — pure FS reads, **6 unit tests**. New `pacerBytes` formatter uses `ByteCountFormatter`. The card measures off the main actor on appear (Claude's logs run to gigabytes; it stats files, never reads them).

Rendered with real data (Pacer DB 103.8 MB · Pacer logs 29.1 MB · Claude logs 1.12 GB / 1,144 files) — verified before merge.

## Part 2 — the research (findings recorded in the doc)
Before reaching for DuckDB, broke the live 94 MB store down with `dbstat`, which reframed the question:
- `ZTOKENSAMPLE` data: **32.7 MB** (104,300 rows)
- TokenSample indexes: **~25 MB**
- **Core Data persistent history (`ACHANGE`/`ATRANSACTION`): ~30 MB — roughly a third of the store is change-tracking overhead, not user data**

So the highest-value storage win is pruning persistent history + auditing indexes (could ~halve the store, no columnar rewrite) — ahead of DuckDB. Recorded in `docs/research/storage-duckdb-vs-sqlite.md`, along with correcting the "orphan container" note (it's the documented legacy pre-rename App Group). The actual DuckDB size/query benchmark still needs `duckdb` installed — left as the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)