### PR TITLE
feat(store): bound SwiftData persistent-history growth (gentle backstop)

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -49,6 +49,11 @@ final class AppBackgroundService {
     /// entangling them would make the scan path responsible for
     /// network/CDN fallibility.
     private var pricingRefreshTask: Task<Void, Never>?
+    /// Gentle backstop that trims unused SwiftData persistent history so
+    /// the `ATRANSACTION`/`ACHANGE` log can't grow unbounded over years.
+    /// Deliberately infrequent (weekly) with a generous 30-day retention
+    /// — the data is small, so this is housekeeping, not management.
+    private var historyPruneTask: Task<Void, Never>?
 
     init(container: ModelContainer) {
         self.container = container
@@ -92,6 +97,7 @@ final class AppBackgroundService {
         installGlobalResetObserver()
         widgetRefreshCoordinator.start()
         startPricingRefreshTask()
+        startHistoryPruneTask()
     }
 
     func stop() async {
@@ -114,6 +120,8 @@ final class AppBackgroundService {
         widgetRefreshCoordinator.stop()
         pricingRefreshTask?.cancel()
         pricingRefreshTask = nil
+        historyPruneTask?.cancel()
+        historyPruneTask = nil
     }
 
     // MARK: - Pricing refresh
@@ -186,6 +194,34 @@ final class AppBackgroundService {
                 do {
                     try await Task.sleep(
                         nanoseconds: UInt64(delay * 1_000_000_000)
+                    )
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - History prune
+
+    /// Weekly cadence. With a 30-day retention window, pruning weekly
+    /// means the log never holds more than ~37 days of history — plenty
+    /// of headroom, and idle enough to read as housekeeping.
+    private static let historyPruneInterval: TimeInterval = 7 * 24 * 3600
+
+    /// Prune unused persistent history at launch, then weekly. Runs on
+    /// the main actor (`StoreMaintenance.pruneHistory` is `@MainActor`);
+    /// `deleteHistory` is a cheap metadata operation, so doing it inline
+    /// on the first tick during launch is fine.
+    private func startHistoryPruneTask() {
+        guard historyPruneTask == nil else { return }
+        let container = self.container
+        historyPruneTask = Task { @MainActor in
+            while !Task.isCancelled {
+                StoreMaintenance.pruneHistory(container: container)
+                do {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(Self.historyPruneInterval * 1_000_000_000)
                     )
                 } catch {
                     return

--- a/PacerCore/Sources/PacerCore/Persistence/StoreMaintenance.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/StoreMaintenance.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftData
+
+/// Housekeeping for the on-disk SwiftData store.
+///
+/// SwiftData turns Core Data **persistent-history tracking** on by
+/// default for a SQLite store, so every write appends to a transaction
+/// log (`ATRANSACTION` / `ACHANGE`). That log is meant to be pruned once
+/// every reader has caught up — but Pacer never reads history tokens
+/// (widgets refresh off the explicit `pacerScanCycleDidComplete`
+/// notification, not history), so nothing ever prunes it and it grows
+/// unbounded. At Pacer's data scale this isn't urgent — it's a backstop
+/// against pathological multi-year accumulation, not active management,
+/// so the defaults are intentionally gentle.
+public enum StoreMaintenance {
+
+    /// Keep this much history. 30 days is ~two orders of magnitude more
+    /// than SwiftData's own cross-context `@Query` catch-up ever needs
+    /// (hours at most), so pruning older than this can't disturb any
+    /// live context — it only ever trims truly stale entries. Generous
+    /// on purpose: the goal is bounding worst-case growth, not reclaiming
+    /// space (the data is small).
+    public static let historyRetention: TimeInterval = 30 * 24 * 60 * 60
+
+    /// Delete persistent-history transactions older than `retention`.
+    /// Best-effort: logs and returns on failure rather than throwing, so
+    /// a housekeeping hiccup never affects the data path. Note this frees
+    /// pages *inside* the SQLite file (reused by future writes) but does
+    /// not shrink the file on disk — that would need a VACUUM, which we
+    /// deliberately don't do here.
+    @MainActor
+    public static func pruneHistory(
+        container: ModelContainer,
+        olderThan retention: TimeInterval = historyRetention,
+        now: Date = Date()
+    ) {
+        let cutoff = now.addingTimeInterval(-retention)
+        let context = ModelContext(container)
+        do {
+            let descriptor = HistoryDescriptor<DefaultHistoryTransaction>(
+                predicate: #Predicate { $0.timestamp < cutoff }
+            )
+            try context.deleteHistory(descriptor)
+            Log.write("StoreMaintenance", "pruned persistent history older than \(Int(retention / 86_400))d")
+        } catch {
+            Log.write("StoreMaintenance", "history prune failed: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
Follow-on from the #4 storage research. SwiftData defaults Core Data persistent-history tracking **on** for a SQLite store, so every write appends to an `ATRANSACTION`/`ACHANGE` log — and Pacer never reads history tokens (widgets refresh off the explicit `pacerScanCycleDidComplete` notification), so nothing ever pruned it. It grew unbounded: **~30 MB** and climbing with every poll.

At Pacer's data scale this isn't urgent, so the fix is **deliberately gentle — a backstop, not active management**:

- `StoreMaintenance.pruneHistory` (PacerCore): `deleteHistory` of transactions older than a generous **30-day** window — ~100× more than SwiftData's own cross-context `@Query` catch-up ever needs, so it can't disturb any live context. Best-effort (logs + returns on failure).
- `AppBackgroundService` runs it **at launch + weekly**, so the log never holds more than ~37 days.
- **No VACUUM** — freed pages get reused by future writes rather than shrinking the file. Reclaiming disk *now* isn't worth the exclusive-access risk at this scale; bounding growth is the point.

**Verified on the live store:** 30.2 MB → 24.0 MB on first run; oldest transaction moved 2026-05-06 → 2026-05-11 (the 30-day cutoff); `[StoreMaintenance] pruned persistent history older than 30d` confirms it fired.

No CI test: exercising `deleteHistory` needs an on-disk store with aged history, impractical to accumulate in the suite (consistent with the rest of `AppBackgroundService`'s task glue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)