### PR TITLE
feat(notifications): burn-rate (slope) warning for the 5-hour window

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -292,7 +292,9 @@ final class AppBackgroundService {
                 (note.object as? ScanCycleSummary)?.rateLimitsChanged ?? false
             guard rateLimitsChanged else { return }
             Task { @MainActor [weak self] in
-                await self?.checkForGlobalReset()
+                guard let self else { return }
+                await self.checkForGlobalReset()
+                await self.checkBurnRateWarning()
             }
         }
     }
@@ -330,5 +332,44 @@ final class AppBackgroundService {
                 context: context
             )
         }
+    }
+
+    // MARK: - Burn-rate (slope) warning
+
+    /// Run `BurnRate.project` over the recent 5-hour OAuth samples and let
+    /// the coordinator decide whether to warn that the current *rate* will
+    /// blow the cap before reset. 5-hour only: the window is short enough
+    /// that burn rate is actionable, whereas a 90-minute slope on the
+    /// 7-day window would project alarming nonsense from a busy hour. (7d
+    /// burn-rate waits for the smarter estimator in the predictions work.)
+    private func checkBurnRateWarning() async {
+        let context = ModelContext(container)
+        let oauthSource = RateLimitSource.oauth
+        let window = RateLimitWindowName.fiveHour
+        // 2h comfortably covers BurnRate's 90-minute lookback.
+        let cutoff = Date().addingTimeInterval(-2 * 3600)
+
+        let descriptor = FetchDescriptor<RateLimitSample>(
+            predicate: #Predicate {
+                $0.source == oauthSource
+                    && $0.window == window
+                    && $0.sampledAt >= cutoff
+            },
+            sortBy: [SortDescriptor(\.sampledAt, order: .forward)]
+        )
+        guard let rows = try? context.fetch(descriptor), let latest = rows.last else { return }
+        let samples = rows.map {
+            BurnRate.Sample(sampledAt: $0.sampledAt, usedPercentage: $0.usedPercentage)
+        }
+        guard let projection = BurnRate.project(samples: samples, resetsAt: latest.resetsAt) else {
+            return
+        }
+        await NotificationCoordinator.shared.handleBurnRateWarning(
+            window: window,
+            projection: projection,
+            resetsAt: latest.resetsAt,
+            usedPct: latest.usedPercentage,
+            context: context
+        )
     }
 }

--- a/App/Notifications/NotificationCoordinator.swift
+++ b/App/Notifications/NotificationCoordinator.swift
@@ -303,6 +303,52 @@ public final class NotificationCoordinator {
         return f.localizedString(for: date, relativeTo: Date())
     }
 
+    /// Burn-rate (slope) warning. Fires when, at the current consumption
+    /// *rate*, the window's linear projection hits 100% before it resets —
+    /// the "slow down" signal the fixed-percentage threshold alerts can't
+    /// give (those only see how full it is, not how fast it's filling).
+    /// The trigger decision lives in `BurnRate.warrantsWarning`; this just
+    /// gates on settings, dedups per cycle, and formats the banner.
+    ///
+    /// Dedup is keyed on the cycle anchor so it fires at most once per
+    /// window cycle even as the rate keeps tripping the condition.
+    public func handleBurnRateWarning(
+        window: String,
+        projection: BurnRate.Projection,
+        resetsAt: Date?,
+        usedPct: Double,
+        context: ModelContext
+    ) async {
+        let defaults = PacerSettings.store
+        guard defaults.bool(forKey: PacerSettings.Key.notificationsEnabled) else { return }
+        guard defaults.bool(forKey: PacerSettings.Key.notifyBurnRate) else { return }
+        guard BurnRate.warrantsWarning(projection, usedPct: usedPct) else { return }
+        guard let projectedFullAt = projection.projectedFullAt else { return }
+
+        let anchorKey = resetsAt.map { ISO8601DateFormatter().string(from: $0) } ?? "noreset"
+        let cycleKey = "notif.burnrate.\(window).\(anchorKey)"
+        if alreadyNotified(key: cycleKey, in: context) {
+            return
+        }
+
+        await requestAuthorizationIfNeeded()
+        let content = UNMutableNotificationContent()
+        let label: String = window == "five_hour" ? "5-hour" : "7-day"
+        content.title = "Pacer \(label) burn-rate warning"
+        let hit = Self.formatRelative(projectedFullAt)
+        if let resetsAt {
+            content.body = "At your current rate you'll hit the \(label) limit \(hit) — before it resets \(Self.formatRelative(resetsAt)). You're at \(Int(usedPct.rounded()))%."
+        } else {
+            content.body = "At your current rate you'll hit the \(label) limit \(hit). You're at \(Int(usedPct.rounded()))%."
+        }
+        content.sound = .default
+        content.interruptionLevel = .timeSensitive
+
+        let request = UNNotificationRequest(identifier: cycleKey, content: content, trigger: nil)
+        try? await center.add(request)
+        markNotified(key: cycleKey, in: context)
+    }
+
     /// "Anthropic reset your limits early" detection. Distinct from
     /// `handleRateLimitReset`: that one fires on the on-schedule rollover
     /// (the anchor advances); this fires on an *off-schedule* global

--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -127,6 +127,7 @@ public enum PacerSettings {
         public static let dailyCostThresholdUSD  = PacerPreferenceKeys.dailyCostThresholdUSD
         public static let notifyOnReset          = PacerPreferenceKeys.notifyOnReset
         public static let notifyGlobalReset      = PacerPreferenceKeys.notifyGlobalReset
+        public static let notifyBurnRate         = PacerPreferenceKeys.notifyBurnRate
         public static let notifyDailySummary     = PacerPreferenceKeys.notifyDailySummary
         public static let dailySummaryHour       = PacerPreferenceKeys.dailySummaryHour
         public static let costMode               = PacerPreferenceKeys.costMode
@@ -158,6 +159,7 @@ public enum PacerSettings {
         // enabled notifications at all should hear about it without
         // having to find this toggle. Still gated by notificationsEnabled.
         Key.notifyGlobalReset:     true,
+        Key.notifyBurnRate:        false,
         Key.notifyDailySummary:    false,
         Key.dailySummaryHour:      21,
         Key.costMode:              "auto",

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -30,6 +30,7 @@ struct SettingsView: View {
                 }
                 SettingsSection("Notifications") {
                     RateLimitAlertsCard()
+                    BurnRateAlertCard()
                     DailyCostAlertCard()
                     ResetAlertCard()
                     CustomRulesCard()
@@ -763,6 +764,21 @@ private struct CustomRulesCard: View {
                 return pacerTokens(Int64(rule.thresholdValue))
             }
         }
+    }
+}
+
+// MARK: - Burn-rate warning
+
+private struct BurnRateAlertCard: View {
+    @AppStorage(PacerSettings.Key.notifyBurnRate, store: PacerSettings.store)
+    private var enabled: Bool = false
+
+    var body: some View {
+        PacerCard("Burn-rate warning", content: {
+            Toggle("Warn when my 5-hour rate will hit the limit before it resets", isOn: $enabled)
+        }, footer: {
+            Text("Watches how fast you're burning the 5-hour window — not just how full it is — and warns once per cycle when, at your current rate, you'll hit the cap before the window resets. Complements the fixed-percentage alerts above (which fire on level, this fires on slope).")
+        })
     }
 }
 

--- a/PacerCore/Sources/PacerCore/RateLimit/BurnRate.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/BurnRate.swift
@@ -164,4 +164,23 @@ public enum BurnRate {
             etaSeconds: projectedAt.timeIntervalSince(now)
         )
     }
+
+    /// Don't raise a burn-rate warning below this utilization. Early in a
+    /// window a brief burst projects an alarming slope that almost always
+    /// flattens out; gating on a floor keeps the warning from crying wolf
+    /// at, say, 15%. Distinct from the fixed-percentage threshold alerts —
+    /// those fire on *level*, this on *rate*.
+    public static let warningUsedFloor: Double = 50
+
+    /// Whether a projection warrants a "you'll hit the limit before it
+    /// resets" warning: the linear projection lands before the reset
+    /// boundary (`willHitLimitBeforeReset`) AND you're already past the
+    /// floor. Pure so the notification layer stays a thin caller.
+    public static func warrantsWarning(
+        _ projection: Projection,
+        usedPct: Double,
+        floor: Double = warningUsedFloor
+    ) -> Bool {
+        projection.willHitLimitBeforeReset && usedPct >= floor
+    }
 }

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -46,6 +46,11 @@ public enum PacerPreferenceKeys {
     /// confirms the drop holds across several minutes of polling before
     /// firing so a transient blip doesn't trigger it. Opt-in.
     public static let notifyGlobalReset      = "pacer.notifications.globalReset"
+    /// Warn when the *rate* you're burning the 5-hour window will hit the
+    /// limit before it resets — i.e. on slope, not just the fixed-percent
+    /// level the threshold alerts use. Fires at most once per 5-hour cycle.
+    /// Opt-in.
+    public static let notifyBurnRate         = "pacer.notifications.burnRate"
     /// Once-a-day "you spent X today" banner. Independent of the
     /// daily-cost ceiling above — that one fires when the threshold
     /// is exceeded; this one is purely informational at a chosen

--- a/PacerCore/Tests/PacerCoreTests/BurnRateTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/BurnRateTests.swift
@@ -152,4 +152,34 @@ struct BurnRateTests {
         #expect(result.slopePercentPerHour > 0)
         #expect(result.projectedFullAt == nil)
     }
+
+    // MARK: - warrantsWarning
+
+    /// Build a projection that hits the limit before reset (or not) without
+    /// going through `project` — `warrantsWarning` only reads the two fields.
+    private func projection(hitsBeforeReset: Bool) -> BurnRate.Projection {
+        BurnRate.Projection(
+            slopePercentPerHour: 10,
+            projectedFullAt: hitsBeforeReset ? Date() : nil,
+            etaSeconds: hitsBeforeReset ? 3600 : nil
+        )
+    }
+
+    @Test func warnsWhenHittingLimitAndPastFloor() {
+        #expect(BurnRate.warrantsWarning(projection(hitsBeforeReset: true), usedPct: 60) == true)
+    }
+
+    @Test func doesNotWarnBelowFloorEvenIfHitting() {
+        // Steep early-window slope, but only 30% used — suppress as noise.
+        #expect(BurnRate.warrantsWarning(projection(hitsBeforeReset: true), usedPct: 30) == false)
+    }
+
+    @Test func doesNotWarnWhenResetComesFirst() {
+        // High usage but the window resets before the projection lands.
+        #expect(BurnRate.warrantsWarning(projection(hitsBeforeReset: false), usedPct: 90) == false)
+    }
+
+    @Test func warnsExactlyAtFloor() {
+        #expect(BurnRate.warrantsWarning(projection(hitsBeforeReset: true), usedPct: 50) == true)
+    }
 }


### PR DESCRIPTION
Pulls the "warn on slope, not just pace" idea out of the predictions TODO (#3) as a standalone, simple feature — it rides entirely on the existing `BurnRate` math, no estimator rewrite.

Where the fixed-percentage threshold alerts fire on **level** (how full the window is), this fires on **rate**: when, at your current burn, the linear projection hits 100% **before the window resets**.

- **`BurnRate.warrantsWarning`** (PacerCore): pure trigger — `willHitLimitBeforeReset` AND used% past a 50% floor (the floor kills early-window noise, where a brief burst projects an alarming slope that then flattens). **4 unit tests** (325 total green).
- **`NotificationCoordinator.handleBurnRateWarning`**: settings gate + per-cycle dedup; banner reads e.g. *"At your current rate you'll hit the 5-hour limit in 40 minutes — before it resets in 3 hours. You're at 62%."*
- **`AppBackgroundService`** runs it **headless** off the same rate-limit scan-cycle signal as the early-reset check, so it fires with the window closed.
- **Opt-in** toggle in Settings → Notifications, default off.

**5-hour only for v1:** a 90-minute slope on the 7-day window would project alarming nonsense from one busy hour. 7-day burn-rate waits for the smarter (damped-acceleration) estimator in the predictions work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)