### PR TITLE
feat(dashboard): 7-day pace tile uses the recency-weighted estimator (matches the warning)

### DIFF
--- a/App/Views/HeroStripCard.swift
+++ b/App/Views/HeroStripCard.swift
@@ -48,6 +48,24 @@ struct HeroStripCard: View {
                 $0.date >= weekAgoString && $0.date <= todayString
             }
         )
+        // 7-day burn uses the recency-weighted estimator (like the 7-day
+        // warning), which needs a multi-day lookback — not the ~2h the
+        // 48-row `recentRateLimits` query holds. Fetch a generous 3 days of
+        // 7-day OAuth samples (the same source the warning reads); the
+        // estimator trims to its own 48h lookback at compute time, so a
+        // little staleness in this init-computed cutoff is harmless.
+        let sevenDayCutoff = Calendar.current.date(byAdding: .day, value: -3, to: Date()) ?? Date()
+        let sevenDayWindow = RateLimitWindowName.sevenDay
+        let oauthSource = RateLimitSource.oauth
+        _sevenDayHistory = Query(
+            filter: #Predicate<RateLimitSample> {
+                $0.window == sevenDayWindow
+                    && $0.source == oauthSource
+                    && $0.sampledAt >= sevenDayCutoff
+            },
+            sort: \.sampledAt,
+            order: .forward
+        )
     }
 
     /// All today's per-model rollups. ≤ a handful of rows; iterating in
@@ -62,6 +80,10 @@ struct HeroStripCard: View {
     /// covers ~2 hours of both windows together with headroom for
     /// status-line bursts that bypass the 5-min cadence.
     @Query(HeroStripCard.recentRateLimits) private var rateLimits: [RateLimitSample]
+    /// ~3 days of 7-day-window OAuth samples for the recency-weighted burn
+    /// projection shown in the 7-day tile — matching the 7-day warning's
+    /// data + math so the displayed ETA and the notification can't disagree.
+    @Query private var sevenDayHistory: [RateLimitSample]
     /// Most-recent `extra_usage` sample. Only meaningful for Max-plan
     /// users who can exceed quota; nil for everyone else. fetchLimit
     /// = 1 keeps the materialization bounded.
@@ -151,8 +173,11 @@ struct HeroStripCard: View {
                 resetsAt: s.resetsAt
             )
         }
+        // 5-hour: first-to-last linear slope (actionable on a short window).
         next.fiveHourBurn = projection(forWindow: "five_hour")
-        next.sevenDayBurn = projection(forWindow: "seven_day")
+        // 7-day: recency-weighted estimator over a multi-day lookback — the
+        // same projection the 7-day warning uses, so tile and notification agree.
+        next.sevenDayBurn = sevenDayProjection()
         if let latest = extraUsages.first {
             next.extraUsageUSD = latest.amountUSD
         }
@@ -177,14 +202,26 @@ struct HeroStripCard: View {
         return (todayCost / avg, active.count)
     }
 
-    /// One-window burn-rate projection. Same algorithm as before,
-    /// just moved out of the body so we can cache it.
+    /// One-window first-to-last linear burn-rate projection (the 5-hour
+    /// tile). Cached out of the body.
     private func projection(forWindow window: String) -> BurnRate.Projection? {
         let samples = rateLimits
             .filter { $0.window == window }
             .map { BurnRate.Sample(sampledAt: $0.sampledAt, usedPercentage: $0.usedPercentage) }
         let resetsAt = rateLimits.first { $0.window == window }?.resetsAt
         return BurnRate.project(samples: samples, resetsAt: resetsAt)
+    }
+
+    /// 7-day burn projection via the recency-weighted estimator over the
+    /// multi-day `sevenDayHistory`, matching the 7-day warning so the
+    /// displayed ETA and the notification stay consistent.
+    private func sevenDayProjection() -> BurnRate.Projection? {
+        let samples = sevenDayHistory.map {
+            BurnRate.Sample(sampledAt: $0.sampledAt, usedPercentage: $0.usedPercentage)
+        }
+        // Forward-sorted, so the most recent sample (its reset) is last.
+        let resetsAt = sevenDayHistory.last?.resetsAt
+        return BurnRate.projectRecencyWeighted(samples: samples, resetsAt: resetsAt)
     }
 
     var body: some View {


### PR DESCRIPTION
## What

Aligns the **displayed 7-day pace tile** (Hero strip) with the **7-day burn warning** (#47): both now use `BurnRate.projectRecencyWeighted` over the same data, so the tile's ETA and the notification can't disagree.

Before, the tile used the linear `BurnRate.project` over a 90-minute lookback — meaningless for a weekly trajectory (it swings on a single busy hour). The 5-hour tile keeps the linear projection (actionable on a short window; no benefit from the estimator there on real data).

## How

- New scoped `@Query` for ~3 days of 7-day OAuth samples (the estimator trims to its own 48h lookback); cached on the scan tick like every other derived value in this view, so the body still reads only `cached`.

## Before/after (real data, 66% used, reset ~106h out)

| | slope | hits 100% |
|---|---|---|
| OLD linear (90-min) | +1.3%/hr | 25.2h |
| NEW estimator (48h) | +1.7%/hr | 21.2h |

Close at this instant, but stable over 48h instead of swinging on the last 90 minutes — and now consistent with the warning.

App builds, installs, runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)