### PR TITLE
feat(forecast): self-selecting forecast ensemble (tournament foundation)

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/Backtester.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/Backtester.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Scores forecasters by **out-of-sample forecast error** — walk-forward,
+/// not in-sample fit.
+///
+/// This is the crux of the tournament. A tempting-but-wrong score is how
+/// well a method fits the curve it already saw (R²): optimizing that picks
+/// the most *overfit* model, which forecasts worse. Instead each case is a
+/// past cut-point where the forecaster saw only the data up to then; we score
+/// its projection against what the period *actually* totalled. Same data the
+/// manual before/afters used this whole time, just systematized.
+public enum Backtester {
+
+    /// One backtest case: an input as it would have looked at some past
+    /// cut-point, paired with the period's realized total.
+    public struct Case: Sendable {
+        public let input: ForecastInput
+        public let truth: Double
+        public init(input: ForecastInput, truth: Double) {
+            self.input = input
+            self.truth = truth
+        }
+    }
+
+    /// A forecaster's aggregate performance over the cases.
+    public struct Score: Sendable, Equatable {
+        public let id: String
+        public let complexity: Int
+        /// Median absolute percentage error over cases it could project
+        /// (robust to the occasional wild miss). The primary ranking metric.
+        public let medianAbsPctError: Double
+        public let meanAbsPctError: Double
+        /// Fraction of cases the forecaster produced a (non-nil) projection
+        /// for. A method that only fires on 20% of cases isn't usable even if
+        /// it's accurate when it does.
+        public let coverage: Double
+        /// Number of cases it scored on.
+        public let scoredCount: Int
+    }
+
+    public static func score(forecasters: [any Forecaster], cases: [Case]) -> [Score] {
+        forecasters.map { forecaster in
+            var errors: [Double] = []
+            for c in cases {
+                guard c.truth > 0, let projection = forecaster.projectTotal(c.input) else { continue }
+                errors.append(abs(projection - c.truth) / c.truth * 100)
+            }
+            let coverage = cases.isEmpty ? 0 : Double(errors.count) / Double(cases.count)
+            return Score(
+                id: forecaster.id,
+                complexity: forecaster.complexity,
+                medianAbsPctError: median(errors),
+                meanAbsPctError: errors.isEmpty ? .infinity : errors.reduce(0, +) / Double(errors.count),
+                coverage: coverage,
+                scoredCount: errors.count
+            )
+        }
+    }
+
+    private static func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return .infinity }
+        let s = xs.sorted()
+        let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/EODForecasters.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/EODForecasters.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Candidate forecasters for end-of-period **total** surfaces (end-of-day
+/// cost, and later monthly). Each wraps a projection method Pacer already
+/// ships, behind the uniform `Forecaster` interface so the tournament can
+/// score them head-to-head. Ordered here by `complexity` (the selector's
+/// tie-breaker).
+
+/// Clock-linear pace: scale spend-so-far by how much of the period's
+/// wall-clock has elapsed. The simplest possible baseline — `soFar × total /
+/// elapsed`. Surprisingly hard to beat; it's the floor every other candidate
+/// has to clear.
+public struct AverageRateForecaster: Forecaster {
+    public let id = "average-rate"
+    public let complexity = 0
+    public init() {}
+
+    public func projectTotal(_ input: ForecastInput) -> Double? {
+        let f = input.elapsedFraction
+        guard f > 0.02 else { return nil }   // too early — pace is pure noise
+        return input.soFar / f
+    }
+}
+
+/// Recent run-rate × time left — the shape of Pacer's current naive
+/// end-of-day projection ("last hour's rate, carried to midnight"). Reacts
+/// fast; overshoots when the recent window happens to be hot.
+public struct RecentRateForecaster: Forecaster {
+    public let id = "recent-rate"
+    public let complexity = 1
+    /// How far back the "recent" rate is measured.
+    public let window: TimeInterval
+    public init(window: TimeInterval = 3600) { self.window = window }
+
+    public func projectTotal(_ input: ForecastInput) -> Double? {
+        guard let last = input.elapsed.last else { return nil }
+        let cutoff = input.now.addingTimeInterval(-window)
+        let earlier = input.elapsed.last(where: { $0.at <= cutoff }) ?? input.elapsed.first!
+        let dt = last.at.timeIntervalSince(earlier.at)
+        guard dt > 0 else { return input.soFar }
+        let rate = (last.cumulative - earlier.cumulative) / dt
+        return input.soFar + rate * input.remainingSeconds
+    }
+}
+
+/// Recency-weighted slope of the cumulative curve via `TrendEstimator`
+/// (acceleration off — it didn't help on real data). Smoother than the raw
+/// recent rate; an old spike inside the period can't tilt it.
+public struct RecencyWeightedSlopeForecaster: Forecaster {
+    public let id = "recency-slope"
+    public let complexity = 2
+    public init() {}
+
+    public func projectTotal(_ input: ForecastInput) -> Double? {
+        let samples = input.elapsed.map {
+            TrendEstimator.Sample(at: $0.at, value: $0.cumulative)
+        }
+        guard let fit = TrendEstimator.fit(samples: samples, parameters: .init(
+            now: input.now,
+            minSamples: 3,
+            minSpanSeconds: 30 * 60,
+            recencyHalfLifeSeconds: max(3600, input.totalSeconds * 0.15),
+            dampingTauSeconds: max(3600, input.remainingSeconds),
+            maxAccelSlopeFraction: 0
+        )) else { return nil }
+        return fit.projectedValue(at: input.periodEnd, now: input.now)
+    }
+}
+
+/// Hour-of-day shape (the shipped end-of-day method): scale spend-so-far by
+/// the typical cumulative fraction done by this hour, blended with the recent
+/// rate early in the day. Knows the evening tapers. Reuses the tested
+/// `ActivityProfile`; only applies to day-length periods.
+public struct HourOfDayShapeForecaster: Forecaster {
+    public let id = "hour-of-day-shape"
+    public let complexity = 2
+    public init() {}
+
+    public func projectTotal(_ input: ForecastInput) -> Double? {
+        let days = input.priorPeriods.compactMap {
+            Self.hourlyCosts(points: $0.points, start: $0.start, calendar: input.calendar)
+        }
+        guard let shape = ActivityProfile.hourOfDayShape(days: days) else { return nil }
+        let hour = input.calendar.component(.hour, from: input.now)
+        let naive = RecentRateForecaster().projectTotal(input) ?? input.soFar
+        return ActivityProfile.projectedEndOfDay(
+            soFar: input.soFar, throughHour: hour, shape: shape, naive: naive)
+    }
+
+    /// Reconstruct a day's 24 per-hour costs from its cumulative points by
+    /// differencing consecutive hour buckets.
+    static func hourlyCosts(points: [ForecastInput.Point], start: Date, calendar: Calendar) -> [Double]? {
+        guard !points.isEmpty else { return nil }
+        // Cumulative value at the end of each hour (carry forward the last
+        // seen cumulative through hours with no new point).
+        var cumByHour = [Double](repeating: 0, count: 24)
+        var lastSeen = 0.0
+        var idx = 0
+        let sorted = points.sorted { $0.at < $1.at }
+        for h in 0..<24 {
+            let hourEnd = calendar.date(byAdding: .hour, value: h + 1, to: start) ?? start
+            while idx < sorted.count, sorted[idx].at < hourEnd {
+                lastSeen = sorted[idx].cumulative
+                idx += 1
+            }
+            cumByHour[h] = lastSeen
+        }
+        // Difference into per-hour costs.
+        var costs = [Double](repeating: 0, count: 24)
+        var prev = 0.0
+        for h in 0..<24 {
+            costs[h] = max(0, cumByHour[h] - prev)
+            prev = cumByHour[h]
+        }
+        return costs
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/ForecastSelector.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/ForecastSelector.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Picks the current winning forecaster per surface from backtest scores,
+/// with the guardrails that keep the choice from chasing noise.
+///
+/// Three defenses, learned the hard way (the naive baseline is *strong*, and
+/// with limited per-user history the backtest itself is noisy):
+///
+/// 1. **Eligibility** — a candidate needs enough scored cases and enough
+///    coverage to be trusted at all.
+/// 2. **Prefer-simpler** — among candidates within `preferSimplerWithin` of
+///    the best error, take the *simplest* (lowest `complexity`). A 0.3-point
+///    edge isn't worth a more complex, more overfit-prone model.
+/// 3. **Hysteresis** — don't switch away from the incumbent unless a
+///    challenger beats it by `switchMargin`. Stops the selection flapping
+///    week to week.
+public enum ForecastSelector {
+
+    public struct Selection: Sendable, Equatable {
+        /// Chosen forecaster id, or nil when nothing is eligible (caller
+        /// should fall back to its hardcoded default).
+        public let id: String?
+        /// Human-readable rationale (for logging / a "projection method: …"
+        /// affordance in the UI).
+        public let reason: String
+    }
+
+    public struct Policy: Sendable {
+        public var minScoredCases: Int
+        public var minCoverage: Double
+        /// Error gap (percentage points) within which a simpler model is
+        /// preferred over a more accurate-but-complex one.
+        public var preferSimplerWithin: Double
+        /// Error gap a challenger must beat the incumbent by to switch.
+        public var switchMargin: Double
+
+        public init(
+            minScoredCases: Int = 8,
+            minCoverage: Double = 0.6,
+            preferSimplerWithin: Double = 2.0,
+            switchMargin: Double = 2.0
+        ) {
+            self.minScoredCases = minScoredCases
+            self.minCoverage = minCoverage
+            self.preferSimplerWithin = preferSimplerWithin
+            self.switchMargin = switchMargin
+        }
+    }
+
+    public static func select(
+        scores: [Backtester.Score],
+        incumbentId: String? = nil,
+        policy: Policy = Policy()
+    ) -> Selection {
+        let eligible = scores.filter {
+            $0.scoredCount >= policy.minScoredCases
+                && $0.coverage >= policy.minCoverage
+                && $0.medianAbsPctError.isFinite
+        }
+        guard let best = eligible.min(by: { $0.medianAbsPctError < $1.medianAbsPctError }) else {
+            return Selection(id: nil, reason: "no eligible forecaster (insufficient backtest data)")
+        }
+
+        // Prefer-simpler: cheapest model within the error margin of the best.
+        let nearBest = eligible.filter { $0.medianAbsPctError <= best.medianAbsPctError + policy.preferSimplerWithin }
+        let candidate = nearBest.min {
+            ($0.complexity, $0.medianAbsPctError) < ($1.complexity, $1.medianAbsPctError)
+        } ?? best
+
+        // Hysteresis: keep the incumbent unless the candidate clears it by the
+        // switch margin.
+        if let incumbentId,
+           let incumbent = eligible.first(where: { $0.id == incumbentId }),
+           candidate.id != incumbent.id,
+           candidate.medianAbsPctError > incumbent.medianAbsPctError - policy.switchMargin {
+            return Selection(
+                id: incumbent.id,
+                reason: String(format: "kept %@ (%.1f%%); %@ (%.1f%%) didn't beat it by %.0f pts",
+                               incumbent.id, incumbent.medianAbsPctError,
+                               candidate.id, candidate.medianAbsPctError, policy.switchMargin)
+            )
+        }
+
+        let simplerNote = candidate.id == best.id ? "" : String(format: " over %@ (%.1f%%)", best.id, best.medianAbsPctError)
+        return Selection(
+            id: candidate.id,
+            reason: String(format: "%@ (%.1f%% median err, %.0f%% coverage)%@",
+                           candidate.id, candidate.medianAbsPctError, candidate.coverage * 100, simplerNote)
+        )
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/Forecaster.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/Forecaster.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// A candidate predictor in the forecast tournament.
+///
+/// The lesson from the predictions redesign (`docs/predictions-redesign.md`):
+/// no single projection method wins everywhere — naive beat the fancy
+/// estimator for end-of-day/monthly, profiles beat naive, the estimator beat
+/// linear for the 7-day window. Rather than hand-pick one method per surface,
+/// the ensemble runs *every* candidate against the user's own realized
+/// history (`Backtester`) and lets `ForecastSelector` pick the current winner
+/// per surface — automatically, per-user, and re-evaluated as behavior drifts.
+///
+/// A `Forecaster` is a pure function from a `ForecastInput` (the period so far
+/// + prior complete periods) to a projected end-of-period total. Keeping it
+/// pure and value-typed means the whole tournament unit-tests like the rest
+/// of `Forecast/`, and a future on-device ML model (Create ML / Core ML) can
+/// join as just another candidate that only gets used if it *wins* the
+/// backtest — so ML can only ever help, never regress a user's numbers.
+public protocol Forecaster: Sendable {
+    /// Stable identifier, persisted as the selected method per surface.
+    var id: String { get }
+    /// Lower = simpler. The selector breaks near-ties toward the simpler
+    /// model (Occam's selection — a strong defense against overfitting the
+    /// choice to backtest noise).
+    var complexity: Int { get }
+    /// Project the end-of-period total, or `nil` when this method can't run on
+    /// the given input (too few samples, no prior periods, etc.). Returning
+    /// `nil` lowers the forecaster's *coverage* in the backtest rather than
+    /// scoring a bogus value.
+    func projectTotal(_ input: ForecastInput) -> Double?
+}
+
+/// Everything a forecaster might need to project one period's total: the
+/// current (partial) period as a cumulative series, plus prior *complete*
+/// periods for the methods that learn a shape/seasonality. Value-agnostic —
+/// `cumulative` is dollars for cost forecasts, but the math doesn't care.
+public struct ForecastInput: Sendable {
+    /// One cumulative observation within a period.
+    public struct Point: Sendable, Equatable {
+        public let at: Date
+        /// Cumulative value since the period's start.
+        public let cumulative: Double
+        public init(at: Date, cumulative: Double) {
+            self.at = at
+            self.cumulative = cumulative
+        }
+    }
+
+    /// A prior, complete period — its cumulative series and when it began.
+    /// Assumed the same nominal length as the current period.
+    public struct PriorPeriod: Sendable {
+        public let start: Date
+        public let points: [Point]
+        public init(start: Date, points: [Point]) {
+            self.start = start
+            self.points = points
+        }
+        /// The period's realized total (last cumulative point).
+        public var total: Double { points.last?.cumulative ?? 0 }
+    }
+
+    public let now: Date
+    public let periodStart: Date
+    public let periodEnd: Date
+    public let calendar: Calendar
+    /// Cumulative observations in the current period, time-ordered, last ≤ now.
+    public let elapsed: [Point]
+    /// Prior complete periods, oldest → newest.
+    public let priorPeriods: [PriorPeriod]
+
+    public init(
+        now: Date,
+        periodStart: Date,
+        periodEnd: Date,
+        calendar: Calendar = .current,
+        elapsed: [Point],
+        priorPeriods: [PriorPeriod]
+    ) {
+        self.now = now
+        self.periodStart = periodStart
+        self.periodEnd = periodEnd
+        self.calendar = calendar
+        self.elapsed = elapsed
+        self.priorPeriods = priorPeriods
+    }
+
+    /// Cumulative value so far this period.
+    public var soFar: Double { elapsed.last?.cumulative ?? 0 }
+    public var elapsedSeconds: TimeInterval { now.timeIntervalSince(periodStart) }
+    public var totalSeconds: TimeInterval { periodEnd.timeIntervalSince(periodStart) }
+    public var remainingSeconds: TimeInterval { max(0, periodEnd.timeIntervalSince(now)) }
+    /// Fraction of the period's wall-clock elapsed (0…1).
+    public var elapsedFraction: Double {
+        totalSeconds > 0 ? min(1, max(0, elapsedSeconds / totalSeconds)) : 1
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/ForecastEnsembleTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ForecastEnsembleTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Forecast ensemble")
+struct ForecastEnsembleTests {
+
+    private var utc: Calendar { var c = Calendar(identifier: .gregorian); c.timeZone = TimeZone(identifier: "UTC")!; return c }
+    private func day(_ ymd: String, _ h: Int = 0) -> Date {
+        let p = ymd.split(separator: "-").compactMap { Int($0) }
+        var dc = DateComponents(); dc.year = p[0]; dc.month = p[1]; dc.day = p[2]; dc.hour = h
+        return utc.date(from: dc)!
+    }
+
+    /// Build a day's cumulative points from per-hour costs (cumulative at the
+    /// end of each hour 0…23).
+    private func cumulativePoints(dayStr: String, hourlyCosts: [Double]) -> [ForecastInput.Point] {
+        var cum = 0.0
+        return (0..<24).map { h in
+            cum += hourlyCosts[h]
+            return .init(at: day(dayStr, h).addingTimeInterval(3599), cumulative: cum)
+        }
+    }
+
+    // A "daytime worker": all spend in hours 9–17, $10/hr → $90/day.
+    private func daytimeDay(_ ymd: String) -> ForecastInput.PriorPeriod {
+        let costs = (0..<24).map { (9...17).contains($0) ? 10.0 : 0.0 }
+        return .init(start: day(ymd), points: cumulativePoints(dayStr: ymd, hourlyCosts: costs))
+    }
+
+    // MARK: - Forecasters
+
+    @Test func averageRateIsClockLinearPace() throws {
+        // Half the day elapsed, $30 so far → pace projects $60.
+        let elapsed = cumulativePoints(dayStr: "2026-05-10", hourlyCosts: (0..<24).map { $0 < 12 ? 2.5 : 0 })
+            .filter { $0.at <= day("2026-05-10", 12) }
+        let input = ForecastInput(
+            now: day("2026-05-10", 12), periodStart: day("2026-05-10"), periodEnd: day("2026-05-11"),
+            calendar: utc, elapsed: elapsed, priorPeriods: [])
+        let p = try #require(AverageRateForecaster().projectTotal(input))
+        #expect(abs(p - 60) < 1.0)
+    }
+
+    @Test func hourOfDayShapeBeatsPaceOnATaperingDay() throws {
+        // Prior history: daytime workers. Today mirrors it — $80 done by 6pm
+        // of a ~$90 day. Pace (clock-linear) badly under/over-projects; the
+        // shape knows the evening is quiet.
+        let priors = (1...10).map { daytimeDay(String(format: "2026-05-%02d", $0)) }
+        let todayCosts = (0..<24).map { (9...17).contains($0) ? 10.0 : 0.0 }
+        let elapsed = cumulativePoints(dayStr: "2026-05-15", hourlyCosts: todayCosts)
+            .filter { $0.at <= day("2026-05-15", 18) }
+        let input = ForecastInput(
+            now: day("2026-05-15", 18), periodStart: day("2026-05-15"), periodEnd: day("2026-05-16"),
+            calendar: utc, elapsed: elapsed, priorPeriods: priors)
+
+        let shape = try #require(HourOfDayShapeForecaster().projectTotal(input))
+        let truth = 90.0
+        #expect(abs(shape - truth) < 15)  // shape lands near the real total
+    }
+
+    @Test func forecasterReturnsNilWithoutEnoughSignal() {
+        let input = ForecastInput(
+            now: day("2026-05-10"), periodStart: day("2026-05-10"), periodEnd: day("2026-05-11"),
+            calendar: utc, elapsed: [], priorPeriods: [])
+        #expect(AverageRateForecaster().projectTotal(input) == nil)       // 0% elapsed
+        #expect(RecencyWeightedSlopeForecaster().projectTotal(input) == nil) // no samples
+        #expect(HourOfDayShapeForecaster().projectTotal(input) == nil)     // no priors
+    }
+
+    // MARK: - Backtester
+
+    @Test func backtesterScoresOutOfSampleError() {
+        // Two synthetic forecasters: one always exactly right, one always 50% high.
+        struct Perfect: Forecaster { let id = "perfect"; let complexity = 0
+            func projectTotal(_ i: ForecastInput) -> Double? { i.priorPeriods.first?.total } }
+        struct Over: Forecaster { let id = "over"; let complexity = 0
+            func projectTotal(_ i: ForecastInput) -> Double? { (i.priorPeriods.first?.total ?? 0) * 1.5 } }
+
+        let prior = daytimeDay("2026-05-01")  // total 90
+        let cases = (0..<10).map { _ in
+            Backtester.Case(input: ForecastInput(
+                now: day("2026-05-10", 12), periodStart: day("2026-05-10"), periodEnd: day("2026-05-11"),
+                calendar: utc, elapsed: [], priorPeriods: [prior]), truth: 90)
+        }
+        let scores = Backtester.score(forecasters: [Perfect(), Over()], cases: cases)
+        let perfect = scores.first { $0.id == "perfect" }!
+        let over = scores.first { $0.id == "over" }!
+        #expect(perfect.medianAbsPctError < 0.01)
+        #expect(abs(over.medianAbsPctError - 50) < 0.01)
+        #expect(perfect.coverage == 1.0)
+    }
+
+    // MARK: - Selector
+
+    private func score(_ id: String, _ complexity: Int, _ err: Double, coverage: Double = 1, n: Int = 30) -> Backtester.Score {
+        .init(id: id, complexity: complexity, medianAbsPctError: err, meanAbsPctError: err, coverage: coverage, scoredCount: n)
+    }
+
+    @Test func selectorPicksLowestErrorEligible() {
+        let pick = ForecastSelector.select(scores: [
+            score("a", 0, 30), score("b", 2, 18), score("c", 1, 25),
+        ])
+        #expect(pick.id == "b")
+    }
+
+    @Test func selectorPrefersSimplerWithinMargin() {
+        // "simple" (complexity 0) is only 1 pt worse than "complex" → prefer simple.
+        let pick = ForecastSelector.select(scores: [
+            score("simple", 0, 19), score("complex", 3, 18),
+        ])
+        #expect(pick.id == "simple")
+    }
+
+    @Test func selectorHysteresisKeepsIncumbent() {
+        // Challenger only 1 pt better than the incumbent (< 2-pt switch margin).
+        let pick = ForecastSelector.select(
+            scores: [score("incumbent", 1, 20), score("challenger", 1, 19)],
+            incumbentId: "incumbent")
+        #expect(pick.id == "incumbent")
+        // But a decisive challenger does switch.
+        let pick2 = ForecastSelector.select(
+            scores: [score("incumbent", 1, 20), score("challenger", 1, 12)],
+            incumbentId: "incumbent")
+        #expect(pick2.id == "challenger")
+    }
+
+    @Test func selectorReturnsNilWithoutEnoughData() {
+        let pick = ForecastSelector.select(scores: [score("a", 0, 10, coverage: 1, n: 3)])  // < minScoredCases
+        #expect(pick.id == nil)
+    }
+}

--- a/docs/forecast-ensemble.md
+++ b/docs/forecast-ensemble.md
@@ -1,0 +1,77 @@
+# Forecast ensemble — a self-selecting tournament of predictors
+
+> Status: **foundation landed (pure, tested, offline-validated); not yet
+> wired to any displayed surface.** Originating idea (Eric): instead of
+> hand-picking one projection method, keep a set of algorithms, score each,
+> and use whichever is performing best — swapping dynamically as one starts
+> outperforming the others. This note records the design + what's built.
+
+## Why
+
+The predictions redesign (`docs/predictions-redesign.md`) proved that **no
+single projection method wins everywhere** — naive beat the 2nd-derivative
+estimator for end-of-day/monthly, profiles beat naive, the estimator beat
+linear for the 7-day window. Those choices were made by hand, by backtesting
+on Eric's real store. The ensemble *systematizes and automates* that: run
+every candidate against the user's own realized history and let the data pick
+the winner, per surface, per user, re-evaluated as behavior drifts.
+
+## The one subtlety: score out-of-sample, not in-sample fit
+
+The natural-but-wrong score is "which method fits the curve best" (R²).
+Optimizing in-sample fit picks the most *overfit* model, which forecasts
+worse. The tournament instead scores **walk-forward forecast error**: at each
+past cut-point a forecaster sees only the data up to then, projects, and is
+graded against what the period *actually* totalled (robust median absolute %
+error). Same data the manual before/afters used — just systematized.
+
+## Pieces (PacerCore/Forecast/Ensemble/)
+
+- **`Forecaster`** — protocol: `projectTotal(ForecastInput) -> Double?`, plus
+  an `id` and a `complexity` rank. Pure value types.
+- **`ForecastInput`** — the current partial period as a cumulative series +
+  prior complete periods + calendar. Value-agnostic.
+- **Candidates** (end-of-day roster, each wrapping a shipped method):
+  `average-rate` (clock-linear pace, complexity 0), `recent-rate`
+  (current naive, 1), `recency-slope` (`TrendEstimator`, 2),
+  `hour-of-day-shape` (`ActivityProfile` blend, 2).
+- **`Backtester`** — scores forecasters over `Case`s (input + realized truth):
+  median/mean abs % error + *coverage* (fraction of cases it could project).
+- **`ForecastSelector`** — picks the winner with three guardrails:
+  **eligibility** (enough cases + coverage), **prefer-simpler** (take the
+  simplest model within a small error margin of the best — Occam's selection,
+  the main defense against overfitting the *choice*), and **hysteresis**
+  (don't switch off the incumbent unless a challenger beats it by a margin).
+
+## Offline validation
+
+Run over the real store's end-of-day data (165 backtest cases), the selector
+**independently picked `hour-of-day-shape`** — the exact method hand-selected
+and shipped in #48:
+
+```
+hour-of-day-shape  median 16.5%   (selected)
+recent-rate        median 18.8%
+average-rate       median 21.0%
+recency-slope      median 28.3%
+```
+
+So the tournament reproduces the right choice with no human in the loop.
+
+## Next steps (not done)
+
+1. **Monthly roster** — add a day-of-week-weights candidate; reuse the same
+   framework with a month-length period.
+2. **Wire it in (gated)** — have the cards read "the selected forecaster for
+   this surface" instead of a hardcoded method. Run the selector *offline /
+   logging-only* first to confirm its live picks beat the hardcoded ones,
+   then swap (displayed change → before/after + sign-off, as always). Since
+   the selector currently picks the already-shipped method, the first wire-in
+   is a no-op on the displayed numbers — it just moves the *choice* into data.
+3. **On-device ML candidate** — featurize (hour-of-day, day-of-week, recent
+   rate, time-into-period) into a Create ML `MLBoostedTreeRegressor` (or the
+   Create ML Components time-series forecaster), trained on-device, entered as
+   *just another candidate*. It only gets used for a user if it wins the
+   backtest — so ML can only help, never regress a user's numbers.
+4. **Uncertainty** — the spread of candidate predictions is a cheap interval
+   ("$10.5k–$12k"), more honest than a single point.


### PR DESCRIPTION
## What

Builds the architecture from the conversation: instead of hand-picking one projection method per surface, keep a **set of candidate predictors, score each against the user's own realized history, and use whichever performs best** — swapping dynamically as one outperforms the others.

**Pure + tested + offline-validated. Not yet wired to any displayed surface** (that's the next, gated step). Design note: `docs/forecast-ensemble.md`.

## Pieces (`PacerCore/Forecast/Ensemble/`)

- **`Forecaster`** protocol + **`ForecastInput`** — uniform `projectTotal(input) -> Double?` over a partial period + prior complete periods.
- **Candidates** (end-of-day roster, each wrapping a shipped method): `average-rate` (clock-linear pace), `recent-rate` (current naive), `recency-slope` (`TrendEstimator`), `hour-of-day-shape` (`ActivityProfile` blend).
- **`Backtester`** — scores **out-of-sample** forecast error (walk-forward median abs % error + coverage). Deliberately **not** in-sample R²: optimizing fit-to-past picks the most overfit model, which forecasts worse.
- **`ForecastSelector`** — picks the winner with **eligibility**, **prefer-simpler** (Occam's selection within an error margin), and **hysteresis** (don't flap off the incumbent) guardrails.

## Offline validation (real store, 165 EOD cases)

The selector **independently picked `hour-of-day-shape`** — the exact method hand-selected in #48 — with no human in the loop:

```
hour-of-day-shape  median 16.5%   ← selected
recent-rate        median 18.8%
average-rate       median 21.0%
recency-slope      median 28.3%
```

## Why this shape

- Robust to the session's finding that no single model wins everywhere.
- Per-user, adaptive, interpretable (each candidate is a debuggable pure function).
- A future **on-device ML** model (Create ML `MLBoostedTreeRegressor` / Create ML Components time-series forecaster) joins as *just another candidate* that's only used if it wins the backtest — so ML can only help, never regress a user's numbers.

## Tests

+8 Swift Testing cases (forecaster behavior, backtester out-of-sample scoring, selector lowest-error / prefer-simpler / hysteresis / min-data). Full suite green (367). App builds + installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)