### PR TITLE
feat(forecast): on-device Create ML candidate for the tournament

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/CreateMLTrainer.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/CreateMLTrainer.swift
@@ -1,0 +1,57 @@
+#if canImport(CreateML)
+import Foundation
+import TabularData
+import CreateML
+
+/// On-device training for the ML forecast candidate, using Apple's Create ML
+/// (`MLBoostedTreeRegressor`). macOS only — guarded by `canImport(CreateML)`,
+/// so on any platform without it the roster simply has no ML candidate and
+/// nothing breaks.
+///
+/// Training happens off the render path (on the scan tick); the result is a
+/// pure `(features) -> Double?` closure handed to a `RegressorForecaster`, so
+/// the rest of the ensemble never sees a Create ML type. The selector decides
+/// whether the trained model actually earns a spot — it only gets used if it
+/// beats the simple methods in the backtest.
+public enum CreateMLTrainer {
+
+    /// Train a boosted-tree regressor on `(features, target)` rows and return
+    /// a prediction closure, or `nil` if there's too little data or training
+    /// throws. `minRows` guards against fitting noise on a thin history.
+    public static func trainedPredictor(
+        rows: [(features: [String: Double], target: Double)],
+        minRows: Int = 30
+    ) -> (@Sendable ([String: Double]) -> Double?)? {
+        guard rows.count >= minRows else { return nil }
+
+        var training = DataFrame()
+        for key in MLFeatures.featureKeys {
+            training.append(column: Column(name: key, contents: rows.map { $0.features[key] ?? 0 }))
+        }
+        training.append(column: Column(name: MLFeatures.targetKey, contents: rows.map { $0.target }))
+
+        guard let regressor = try? MLBoostedTreeRegressor(
+            trainingData: training, targetColumn: MLFeatures.targetKey
+        ) else { return nil }
+
+        // CreateML/CoreML models aren't Sendable, but inference is read-only
+        // and we call it serially (on the scan tick / cached selection), so an
+        // unchecked box is a sound, pragmatic way to satisfy the Sendable
+        // `Forecaster`.
+        let box = RegressorBox(regressor)
+        return { features in
+            var row = DataFrame()
+            for key in MLFeatures.featureKeys {
+                row.append(column: Column(name: key, contents: [features[key] ?? 0]))
+            }
+            guard let predictions = try? box.regressor.predictions(from: row) else { return nil }
+            return predictions.assumingType(Double.self).first ?? nil
+        }
+    }
+}
+
+private final class RegressorBox: @unchecked Sendable {
+    let regressor: MLBoostedTreeRegressor
+    init(_ regressor: MLBoostedTreeRegressor) { self.regressor = regressor }
+}
+#endif

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/MLForecaster.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/MLForecaster.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Feature engineering for the machine-learning forecast candidate, and the
+/// candidate itself. Both are pure and `CreateML`-free so they unit-test like
+/// the rest of the ensemble; the actual on-device training lives behind
+/// `#if canImport(CreateML)` in `CreateMLTrainer` and is injected as a
+/// prediction closure.
+///
+/// The whole point of routing ML through the tournament: the trained model is
+/// *just another candidate*. It only gets used for a user if it beats the
+/// simple methods in the backtest — so ML can only help, never regress a
+/// user's displayed numbers.
+public enum MLFeatures {
+    /// The model maps these features → the period total. Kept as an ordered
+    /// list so training columns and prediction rows can't drift.
+    public static let featureKeys = [
+        "soFar",             // cumulative so far this period
+        "elapsedFraction",   // 0…1 of the period's wall-clock elapsed
+        "hourOfDay",         // 0…23 (intraday rhythm)
+        "weekday",           // 1…7 (weekly rhythm)
+        "recentRate",        // recent slope of the cumulative curve (per second)
+        "avgRateProjection", // soFar / elapsedFraction — the pace baseline, handed
+                             // to the model directly so a tree can correct it
+    ]
+    public static let targetKey = "total"
+
+    /// Featurize one input for prediction.
+    public static func features(for input: ForecastInput, recentWindow: TimeInterval = 3600) -> [String: Double] {
+        let f = input.elapsedFraction
+        let hour = Double(input.calendar.component(.hour, from: input.now))
+        let weekday = Double(input.calendar.component(.weekday, from: input.now))
+        let avgProj = f > 0.02 ? input.soFar / f : input.soFar
+        return [
+            "soFar": input.soFar,
+            "elapsedFraction": f,
+            "hourOfDay": hour,
+            "weekday": weekday,
+            "recentRate": recentRate(input, window: recentWindow),
+            "avgRateProjection": avgProj,
+        ]
+    }
+
+    /// Recent slope of the cumulative curve, value-units per second.
+    static func recentRate(_ input: ForecastInput, window: TimeInterval) -> Double {
+        guard let last = input.elapsed.last else { return 0 }
+        let cutoff = input.now.addingTimeInterval(-window)
+        let earlier = input.elapsed.last(where: { $0.at <= cutoff }) ?? input.elapsed.first
+        guard let earlier, last.at > earlier.at else { return 0 }
+        return (last.cumulative - earlier.cumulative) / last.at.timeIntervalSince(earlier.at)
+    }
+
+    /// Build `(features, target)` training rows by replaying each prior
+    /// complete period at several cut fractions — so the model learns "given
+    /// this much done by this point, the period totalled that." Each row's
+    /// features see only the data up to its cut; the target is the realized
+    /// total. This is what makes the learned model an out-of-sample forecaster.
+    public static func trainingRows(
+        from priors: [ForecastInput.PriorPeriod],
+        periodLength: TimeInterval,
+        cutFractions: [Double] = [0.3, 0.45, 0.6, 0.75, 0.9],
+        calendar: Calendar
+    ) -> [(features: [String: Double], target: Double)] {
+        var rows: [(features: [String: Double], target: Double)] = []
+        for prior in priors {
+            let total = prior.total
+            guard total > 0 else { continue }
+            let end = prior.start.addingTimeInterval(periodLength)
+            for cf in cutFractions {
+                let now = prior.start.addingTimeInterval(periodLength * cf)
+                let elapsed = prior.points.filter { $0.at <= now }
+                guard !elapsed.isEmpty else { continue }
+                let input = ForecastInput(
+                    now: now, periodStart: prior.start, periodEnd: end,
+                    calendar: calendar, elapsed: elapsed, priorPeriods: [])
+                rows.append((features(for: input), total))
+            }
+        }
+        return rows
+    }
+}
+
+/// A forecaster backed by a trained regression model, supplied as a pure
+/// prediction closure. The closure is injected (by `CreateMLTrainer` in
+/// production, or a stub in tests), keeping this type free of any ML
+/// framework so it stays pure and testable. Highest `complexity` in the
+/// roster — the selector's prefer-simpler rule means it has to *clearly* win
+/// to be chosen.
+public struct RegressorForecaster: Forecaster {
+    public let id: String
+    public let complexity: Int
+    private let predict: @Sendable ([String: Double]) -> Double?
+
+    public init(
+        id: String = "ml-regressor",
+        complexity: Int = 5,
+        predict: @escaping @Sendable ([String: Double]) -> Double?
+    ) {
+        self.id = id
+        self.complexity = complexity
+        self.predict = predict
+    }
+
+    public func projectTotal(_ input: ForecastInput) -> Double? {
+        guard let value = predict(MLFeatures.features(for: input)) else { return nil }
+        // A regression tree can extrapolate to nonsense on out-of-distribution
+        // inputs; never project below what's already spent.
+        return max(value, input.soFar)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/MLForecasterTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/MLForecasterTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("ML forecast candidate")
+struct MLForecasterTests {
+
+    private var utc: Calendar { var c = Calendar(identifier: .gregorian); c.timeZone = TimeZone(identifier: "UTC")!; return c }
+    private func day(_ ymd: String, _ h: Int = 0) -> Date {
+        let p = ymd.split(separator: "-").compactMap { Int($0) }
+        var dc = DateComponents(); dc.year = p[0]; dc.month = p[1]; dc.day = p[2]; dc.hour = h
+        return utc.date(from: dc)!
+    }
+    private func cumulativePoints(_ ymd: String, hourly: [Double]) -> [ForecastInput.Point] {
+        var cum = 0.0
+        return (0..<24).map { h in cum += hourly[h]; return .init(at: day(ymd, h).addingTimeInterval(3599), cumulative: cum) }
+    }
+    private func daytime(_ ymd: String) -> ForecastInput.PriorPeriod {
+        .init(start: day(ymd), points: cumulativePoints(ymd, hourly: (0..<24).map { (9...17).contains($0) ? 10 : 0 }))
+    }
+
+    // MARK: - Featurization (pure)
+
+    @Test func featuresCoverTheNamedKeys() {
+        let input = ForecastInput(
+            now: day("2026-05-15", 12), periodStart: day("2026-05-15"), periodEnd: day("2026-05-16"),
+            calendar: utc, elapsed: cumulativePoints("2026-05-15", hourly: (0..<24).map { $0 < 12 ? 5 : 0 }).filter { $0.at <= day("2026-05-15", 12) },
+            priorPeriods: [])
+        let f = MLFeatures.features(for: input)
+        for key in MLFeatures.featureKeys { #expect(f[key] != nil) }
+        #expect(f["hourOfDay"] == 12)
+        #expect(abs(f["elapsedFraction"]! - 0.5) < 0.01)
+        #expect(f["soFar"]! > 0)
+    }
+
+    @Test func trainingRowsReplayEachPriorAtCutPoints() {
+        let priors = (1...4).map { daytime(String(format: "2026-05-%02d", $0)) }
+        let rows = MLFeatures.trainingRows(from: priors, periodLength: 86400, cutFractions: [0.3, 0.6, 0.9], calendar: utc)
+        #expect(rows.count == 12)                 // 4 priors × 3 cuts
+        for r in rows { #expect(abs(r.target - 90) < 0.01) }  // each daytime day totals $90
+    }
+
+    // MARK: - RegressorForecaster (pure, stubbed predictor)
+
+    @Test func regressorForecasterCallsPredictorAndClampsToSoFar() throws {
+        let elapsed = cumulativePoints("2026-05-15", hourly: (0..<24).map { (9...17).contains($0) ? 10 : 0 })
+            .filter { $0.at <= day("2026-05-15", 15) }
+        let input = ForecastInput(
+            now: day("2026-05-15", 15), periodStart: day("2026-05-15"), periodEnd: day("2026-05-16"),
+            calendar: utc, elapsed: elapsed, priorPeriods: [])
+
+        // Stub returns the soFar feature × 1.1.
+        let f = RegressorForecaster { feats in (feats["soFar"] ?? 0) * 1.1 }
+        let p = try #require(f.projectTotal(input))
+        #expect(abs(p - input.soFar * 1.1) < 1e-6)
+
+        // A predictor that lowballs below soFar gets clamped up to soFar.
+        let low = RegressorForecaster { _ in 1.0 }
+        #expect(low.projectTotal(input) == input.soFar)
+
+        // nil predictor → nil projection.
+        let none = RegressorForecaster { _ in nil }
+        #expect(none.projectTotal(input) == nil)
+    }
+
+    // MARK: - End-to-end on-device training (Create ML)
+
+    #if canImport(CreateML)
+    @Test func createMLTrainerLearnsAndPredicts() throws {
+        // Learnable signal: total = soFar / elapsedFraction (pure pace). The
+        // tree should recover roughly that from enough replayed rows.
+        var priors: [ForecastInput.PriorPeriod] = []
+        for d in 1...20 {
+            let perHour = Double(d)   // varies the daily total across days
+            let hourly = (0..<24).map { (9...17).contains($0) ? perHour : 0 }
+            priors.append(.init(start: day(String(format: "2026-05-%02d", d)),
+                                points: cumulativePoints(String(format: "2026-05-%02d", d), hourly: hourly)))
+        }
+        let rows = MLFeatures.trainingRows(from: priors, periodLength: 86400, calendar: utc)
+        let predictor = try #require(CreateMLTrainer.trainedPredictor(rows: rows))
+
+        // New day at $X by 6pm of a daytime pattern → should predict near the
+        // day's true total, comfortably above soFar.
+        let testHourly = (0..<24).map { (9...17).contains($0) ? 12.0 : 0.0 }  // $108/day
+        let elapsed = cumulativePoints("2026-06-01", hourly: testHourly).filter { $0.at <= day("2026-06-01", 18) }
+        let input = ForecastInput(
+            now: day("2026-06-01", 18), periodStart: day("2026-06-01"), periodEnd: day("2026-06-02"),
+            calendar: utc, elapsed: elapsed, priorPeriods: priors)
+        let forecaster = RegressorForecaster(predict: predictor)
+        let projection = try #require(forecaster.projectTotal(input))
+        #expect(projection >= input.soFar)        // never below spend-so-far
+        #expect(projection > 80 && projection < 140) // in the neighbourhood of $108
+    }
+    #endif
+}

--- a/docs/forecast-ensemble.md
+++ b/docs/forecast-ensemble.md
@@ -68,10 +68,17 @@ So the tournament reproduces the right choice with no human in the loop.
    then swap (displayed change → before/after + sign-off, as always). Since
    the selector currently picks the already-shipped method, the first wire-in
    is a no-op on the displayed numbers — it just moves the *choice* into data.
-3. **On-device ML candidate** — featurize (hour-of-day, day-of-week, recent
-   rate, time-into-period) into a Create ML `MLBoostedTreeRegressor` (or the
-   Create ML Components time-series forecaster), trained on-device, entered as
-   *just another candidate*. It only gets used for a user if it wins the
-   backtest — so ML can only help, never regress a user's numbers.
+3. **On-device ML candidate — built (#53).** `MLFeatures` featurizes
+   (soFar, elapsed-fraction, hour-of-day, weekday, recent rate, pace
+   baseline) → training rows replayed from prior periods; `CreateMLTrainer`
+   (guarded `#if canImport(CreateML)`) trains an `MLBoostedTreeRegressor`
+   on-device and hands back a pure prediction closure; `RegressorForecaster`
+   enters it as *just another candidate*. Validated on the real store
+   (out-of-sample, 79 cases): the model trains fine but **loses** to
+   `hour-of-day-shape` (37.6% vs 14.5% median) on ~28 days of training data,
+   so the selector correctly doesn't pick it — exactly the de-risk: ML can
+   only help, never regress. It'll be selected automatically if it starts
+   winning (more history, or better features — stacking the simple
+   forecasters' outputs as features is the obvious next lever).
 4. **Uncertainty** — the spread of candidate predictions is a cheap interval
    ("$10.5k–$12k"), more honest than a single point.


### PR DESCRIPTION
## What

Adds a **machine-learning forecaster as just-another-candidate** in the ensemble — the synthesis of the two ideas from the conversation (on-device ML *and* a self-selecting set of algorithms). It only gets used if it wins the backtest, so **ML can only help, never regress** a displayed number.

## Pieces

- **`MLFeatures`** (pure) — featurize a `ForecastInput` (soFar, elapsed-fraction, hour-of-day, weekday, recent rate, pace baseline) and replay prior periods into `(features, target)` training rows.
- **`CreateMLTrainer`** (`#if canImport(CreateML)`, macOS) — trains an `MLBoostedTreeRegressor` **on-device** via the modern `TabularData.DataFrame` API; returns a pure `(features) -> Double?` closure. Runs off the render path.
- **`RegressorForecaster`** — wraps the injected closure behind the `Forecaster` interface (clamped to never project below spend-so-far). Highest `complexity`, so prefer-simpler makes it earn its slot.

## Honest validation (real store, out-of-sample, 79 cases)

```
hour-of-day-shape  median 14.5%   ← selected
recent-rate        median 16.8%
average-rate       median 21.0%
recency-slope      median 28.3%
ml-regressor       median 37.6%   ← competed, lost, correctly not picked
```

The model trains fine but loses on ~28 days of training data — so the selector correctly doesn't use it. That's the de-risk working: it'll be selected automatically if it starts winning (more history, or stacking the simple forecasters' outputs as features — the obvious next lever).

## Tests

+4 (featurization, training rows, RegressorForecaster clamp/stub, and a real on-device `MLBoostedTreeRegressor` training run). Full suite green (371). App builds + installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)