### PR TITLE
feat(forecast): monthly tournament roster + day-of-week candidate

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/MonthlyForecasters.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/MonthlyForecasters.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Day-of-week candidate for the **monthly** surface: scale month-so-far by
+/// the remaining days' weekday weights instead of a flat average, so a heavy
+/// weekday stretch elapsed with quiet weekends remaining doesn't over-project.
+/// Reuses the tested `ActivityProfile`; the shipped monthly method, now a
+/// tournament candidate.
+///
+/// The period-agnostic candidates (`AverageRateForecaster`,
+/// `RecencyWeightedSlopeForecaster`, the ML `RegressorForecaster`) work on the
+/// monthly surface unchanged — only this weekday method and the EOD
+/// hour-of-day method are surface-specific.
+public struct WeekdayWeightsForecaster: Forecaster {
+    public let id = "weekday-weights"
+    public let complexity = 2
+    public init() {}
+
+    public func projectTotal(_ input: ForecastInput) -> Double? {
+        // (weekday, cost) for every day across the prior complete months,
+        // including zero-cost days (a quiet weekend is signal, not a gap) —
+        // recovered by differencing each prior's daily cumulative series.
+        var dayCosts: [(weekday: Int, cost: Double)] = []
+        for prior in input.priorPeriods {
+            var previous = 0.0
+            for point in prior.points.sorted(by: { $0.at < $1.at }) {
+                let cost = max(0, point.cumulative - previous)
+                previous = point.cumulative
+                dayCosts.append((weekday: input.calendar.component(.weekday, from: point.at), cost: cost))
+            }
+        }
+        guard let weights = ActivityProfile.weekdayWeights(days: dayCosts) else { return nil }
+
+        // Weekdays of the current month's elapsed vs remaining days. The day
+        // containing `now` counts as elapsed (its spend is in soFar), matching
+        // MonthlyForecast.
+        var elapsed: [Int] = []
+        var remaining: [Int] = []
+        let nowDay = input.calendar.startOfDay(for: input.now)
+        var day = input.calendar.startOfDay(for: input.periodStart)
+        while day < input.periodEnd {
+            let weekday = input.calendar.component(.weekday, from: day)
+            if day <= nowDay { elapsed.append(weekday) } else { remaining.append(weekday) }
+            guard let next = input.calendar.date(byAdding: .day, value: 1, to: day) else { break }
+            day = next
+        }
+        guard !elapsed.isEmpty else { return nil }
+
+        let naive = input.elapsedFraction > 0.02 ? input.soFar / input.elapsedFraction : input.soFar
+        return ActivityProfile.projectedMonthTotal(
+            monthSoFar: input.soFar,
+            elapsedWeekdays: elapsed,
+            remainingWeekdays: remaining,
+            weights: weights,
+            naive: naive
+        )
+    }
+}
+
+/// Canonical candidate rosters per surface. The period-agnostic methods appear
+/// in both; the shape methods are surface-specific. The ML candidate is added
+/// separately by the caller (it needs a trained predictor).
+public enum ForecastRoster {
+    /// End-of-day cost candidates.
+    public static func endOfDay() -> [any Forecaster] {
+        [
+            AverageRateForecaster(),
+            RecentRateForecaster(),
+            RecencyWeightedSlopeForecaster(),
+            HourOfDayShapeForecaster(),
+        ]
+    }
+
+    /// Monthly total candidates.
+    public static func monthly() -> [any Forecaster] {
+        [
+            AverageRateForecaster(),
+            RecencyWeightedSlopeForecaster(),
+            WeekdayWeightsForecaster(),
+        ]
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/MonthlyForecasterTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/MonthlyForecasterTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Monthly forecast candidate")
+struct MonthlyForecasterTests {
+
+    private var utc: Calendar { var c = Calendar(identifier: .gregorian); c.timeZone = TimeZone(identifier: "UTC")!; return c }
+    private func date(_ y: Int, _ m: Int, _ d: Int, _ h: Int = 0) -> Date {
+        var dc = DateComponents(); dc.year = y; dc.month = m; dc.day = d; dc.hour = h
+        return utc.date(from: dc)!
+    }
+
+    /// A month as daily cumulative points, cost per day from `dailyCost(weekday)`.
+    private func month(_ y: Int, _ m: Int, dailyCost: (Int) -> Double) -> ForecastInput.PriorPeriod {
+        let start = date(y, m, 1)
+        let dim = utc.range(of: .day, in: .month, for: start)!.count
+        var cum = 0.0
+        let points = (1...dim).map { d -> ForecastInput.Point in
+            let dt = date(y, m, d, 12)
+            cum += dailyCost(utc.component(.weekday, from: dt))
+            return .init(at: dt, cumulative: cum)
+        }
+        return .init(start: start, points: points)
+    }
+
+    // Heavy weekdays (Mon–Fri = 2…6), light weekends (1, 7).
+    private func heavyWeekdays(_ wd: Int) -> Double { (2...6).contains(wd) ? 100 : 10 }
+
+    private func currentMonthInput(throughDay: Int) -> ForecastInput {
+        let priors = [month(2026, 4, dailyCost: heavyWeekdays), month(2026, 5, dailyCost: heavyWeekdays)]
+        var cum = 0.0
+        let elapsed = (1...throughDay).map { d -> ForecastInput.Point in
+            cum += heavyWeekdays(utc.component(.weekday, from: date(2026, 6, d, 12)))
+            return .init(at: date(2026, 6, d, 12), cumulative: cum)
+        }
+        return ForecastInput(
+            now: date(2026, 6, throughDay, 18), periodStart: date(2026, 6, 1), periodEnd: date(2026, 7, 1),
+            calendar: utc, elapsed: elapsed, priorPeriods: priors)
+    }
+
+    @Test func weekdayWeightsProjectsAndReshapesVsPace() throws {
+        let input = currentMonthInput(throughDay: 12)
+        let weekday = try #require(WeekdayWeightsForecaster().projectTotal(input))
+        let pace = try #require(AverageRateForecaster().projectTotal(input))
+
+        #expect(weekday > input.soFar)        // still growing
+        #expect(weekday.isFinite)
+        #expect(abs(weekday - pace) > 1e-6)    // genuinely reshapes the projection
+    }
+
+    @Test func weekdayWeightsNeedsPriorMonths() {
+        let input = ForecastInput(
+            now: date(2026, 6, 12, 18), periodStart: date(2026, 6, 1), periodEnd: date(2026, 7, 1),
+            calendar: utc, elapsed: [.init(at: date(2026, 6, 1, 12), cumulative: 100)], priorPeriods: [])
+        #expect(WeekdayWeightsForecaster().projectTotal(input) == nil)
+    }
+
+    @Test func rostersExposeTheExpectedCandidates() {
+        #expect(Set(ForecastRoster.endOfDay().map(\.id)) ==
+                ["average-rate", "recent-rate", "recency-slope", "hour-of-day-shape"])
+        #expect(Set(ForecastRoster.monthly().map(\.id)) ==
+                ["average-rate", "recency-slope", "weekday-weights"])
+    }
+}


### PR DESCRIPTION
## What

Extends the forecast tournament to the **monthly** surface.

- The period-agnostic candidates (`average-rate`, `recency-slope`, ML) already work on any cumulative series.
- Adds the surface-specific **`WeekdayWeightsForecaster`** — the shipped #48 day-of-week method, now a tournament candidate (wraps `ActivityProfile`).
- Adds **`ForecastRoster`** with the canonical per-surface candidate lists.

## Offline validation (real store, May with April priors)

```
weekday-weights  median 15.8%
average-rate     median 16.2%   (clock-linear pace, incl. zero days)
recency-slope    median 32.8%
SELECTED → none: insufficient backtest data (6 < 8 cases)
```

Two correct behaviors surfaced:
1. With only ~2 complete months, the selector **abstains** (min-data guard) → caller falls back to the shipped method. Conservative and correct.
2. The tournament reveals the big monthly lever is **including zero-days** (both pace and weekday-weights capture it); the weekday adjustment on top is marginal. So `prefer-simpler` may pick plain pace once there's enough history — fine, and arguably better.

## Tests

+3 (weekday candidate reshapes vs pace, needs prior months, roster contents). Full suite green (374). Local install verified (notarization skipped — see note).

> Note: `make install` notarization failed (`pacer-notarization` credential profile not found in the environment right now — it worked earlier this session); build + signing succeeded, installed locally via `PACER_DEV_SKIP_NOTARIZE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)