### PR TITLE
feat(forecast): BurnTrajectory — curve-fit tournament for rate-limit forward curves

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Forward-trajectory forecasting for a rate-limit window's usage curve — the
+/// model layer behind the dashed projection overlaid on the 5h/7d pace charts.
+///
+/// Unlike the end-of-period *total* ensemble (which returns a scalar), a burn
+/// surface wants the whole forward *curve*: usage% at every future instant
+/// from now to the window reset, so it can be drawn against the actual line.
+/// Same tournament idea though — several curve fits compete, scored by how
+/// well they predicted the *remainder* of the user's past cycles, and the
+/// per-window winner's trajectory is what we plot.
+///
+/// On real data there's no universal winner (recency-weighted tracks the 5h
+/// window best; plain linear-over-a-recent-window tracks the 7d best), which
+/// is exactly why this is a backtest-selected ensemble rather than one
+/// hardcoded fit.
+public enum BurnTrajectory {
+
+    /// One usage observation in a cycle.
+    public struct Sample: Sendable, Equatable {
+        public let at: Date
+        public let usedPercentage: Double
+        public init(at: Date, usedPercentage: Double) {
+            self.at = at
+            self.usedPercentage = usedPercentage
+        }
+    }
+
+    /// A cycle's samples plus its boundaries. `now` is the projection origin
+    /// (the latest real sample for the live chart; a past cut for backtests).
+    public struct PartialCycle: Sendable {
+        public let samples: [Sample]      // within [cycleStart, now], time-ordered
+        public let now: Date
+        public let cycleStart: Date
+        public let resetsAt: Date
+        public init(samples: [Sample], now: Date, cycleStart: Date, resetsAt: Date) {
+            self.samples = samples.filter { $0.at <= now }.sorted { $0.at < $1.at }
+            self.now = now
+            self.cycleStart = cycleStart
+            self.resetsAt = resetsAt
+        }
+        public var durationHours: Double { resetsAt.timeIntervalSince(cycleStart) / 3600 }
+        public var nowHours: Double { now.timeIntervalSince(cycleStart) / 3600 }
+        func hours(_ date: Date) -> Double { date.timeIntervalSince(cycleStart) / 3600 }
+        public var usedNow: Double { samples.last?.usedPercentage ?? 0 }
+    }
+
+    /// A complete past cycle, used for backtesting.
+    public struct Cycle: Sendable {
+        public let samples: [Sample]
+        public let cycleStart: Date
+        public let resetsAt: Date
+        public init(samples: [Sample], cycleStart: Date, resetsAt: Date) {
+            self.samples = samples.sorted { $0.at < $1.at }
+            self.cycleStart = cycleStart
+            self.resetsAt = resetsAt
+        }
+    }
+
+    /// A curve-fit candidate. `fit` returns a closure giving projected usage%
+    /// at any future date, or nil when it can't fit the cycle-so-far.
+    public protocol Model: Sendable {
+        var id: String { get }
+        var complexity: Int { get }
+        func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)?
+    }
+
+    /// The selected fit's forward trajectory, sampled for plotting.
+    public struct Trajectory: Sendable, Equatable {
+        public let modelId: String
+        /// Points from `now` to `resetsAt`, inclusive, clamped to 0…100 for display.
+        public let points: [Sample]
+        /// First future instant the (unclamped) projection reaches 100%, if any.
+        public let crossesFullAt: Date?
+    }
+
+    /// Default roster. Quadratic is deliberately excluded — it reliably
+    /// explodes on real cycles and was the worst fit in every backtest.
+    public static var defaultModels: [any Model] {
+        [
+            LinearRecent(),
+            RecencyWeighted(),
+            DampedAcceleration(),
+            Saturating(),
+        ]
+    }
+
+    // MARK: - Backtest + selection
+
+    /// Score each model by how well it predicted the *remainder* of past
+    /// cycles, reusing the ensemble's `Backtester.Score` so the shared
+    /// `ForecastSelector` can pick the winner. Error is median absolute
+    /// percentage-*points* over the unseen tail of each cycle.
+    public static func score(
+        models: [any Model],
+        cycles: [Cycle],
+        cutFractions: [Double] = [0.5, 0.6, 0.7]
+    ) -> [Backtester.Score] {
+        models.map { model in
+            var errors: [Double] = []
+            var attempts = 0
+            for cycle in cycles {
+                let duration = cycle.resetsAt.timeIntervalSince(cycle.cycleStart)
+                for cf in cutFractions {
+                    let now = cycle.cycleStart.addingTimeInterval(duration * cf)
+                    let seen = cycle.samples.filter { $0.at <= now }
+                    let future = cycle.samples.filter { $0.at > now }
+                    guard seen.count >= 3, future.count >= 2 else { continue }
+                    attempts += 1
+                    let partial = PartialCycle(samples: seen, now: now,
+                                               cycleStart: cycle.cycleStart, resetsAt: cycle.resetsAt)
+                    guard let projection = model.fit(partial) else { continue }
+                    let absErrors = future.map { abs(projection($0.at) - $0.usedPercentage) }
+                    errors.append(absErrors.sorted()[absErrors.count / 2])  // per-cycle median
+                }
+            }
+            let coverage = attempts == 0 ? 0 : Double(errors.count) / Double(attempts)
+            return Backtester.Score(
+                id: model.id, complexity: model.complexity,
+                medianAbsPctError: median(errors),
+                meanAbsPctError: errors.isEmpty ? .infinity : errors.reduce(0, +) / Double(errors.count),
+                coverage: coverage, scoredCount: errors.count)
+        }
+    }
+
+    /// Backtest-select the best model for `history`, fit it to the current
+    /// cycle, and return its forward trajectory sampled `sampleCount` times
+    /// from now to reset. Falls back to the first model that can fit when the
+    /// backtest is inconclusive (too little history). `nil` if nothing fits.
+    public static func bestTrajectory(
+        current: PartialCycle,
+        history: [Cycle],
+        models: [any Model] = defaultModels,
+        selectionPolicy: ForecastSelector.Policy = .init(minScoredCases: 6, minCoverage: 0.5),
+        sampleCount: Int = 48
+    ) -> Trajectory? {
+        let scores = score(models: models, cycles: history)
+        let pick = ForecastSelector.select(scores: scores, policy: selectionPolicy)
+        let chosen = models.first { $0.id == pick.id }
+            ?? models.first { $0.fit(current) != nil }
+        guard let model = chosen, let projection = model.fit(current) else { return nil }
+
+        let span = current.resetsAt.timeIntervalSince(current.now)
+        guard span > 0 else { return nil }
+        var points: [Sample] = []
+        var crossing: Date?
+        for i in 0...sampleCount {
+            let date = current.now.addingTimeInterval(span * Double(i) / Double(sampleCount))
+            let raw = projection(date)
+            if crossing == nil, raw >= 100 { crossing = date }
+            points.append(Sample(at: date, usedPercentage: min(100, max(0, raw))))
+        }
+        return Trajectory(modelId: model.id, points: points, crossesFullAt: crossing)
+    }
+
+    static func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return .infinity }
+        let s = xs.sorted(); let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectoryModels.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectoryModels.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// The curve-fit candidates for `BurnTrajectory`. Each fits the cycle-so-far
+/// and returns a closure projecting usage% at any future date. Ordered by
+/// `complexity` (the selector's tie-breaker), simplest first — which matches
+/// the real-data finding that plain linear is hard to beat.
+extension BurnTrajectory {
+
+    /// Least-squares line over a recent window (a fraction of the cycle).
+    /// Reacts to the current rate; the 7-day window's best fit on real data.
+    public struct LinearRecent: Model {
+        public let id = "linear-recent"
+        public let complexity = 1
+        /// Recent window as a fraction of the cycle duration.
+        public let lookbackFraction: Double
+        public init(lookbackFraction: Double = 0.3) { self.lookbackFraction = lookbackFraction }
+
+        public func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)? {
+            let cutoff = cycle.nowHours - cycle.durationHours * lookbackFraction
+            let pts = cycle.samples.filter { cycle.hours($0.at) >= cutoff }
+            let used = pts.count >= 2 ? pts : cycle.samples
+            guard used.count >= 2,
+                  let line = Self.line(used.map { (cycle.hours($0.at), $0.usedPercentage) })
+            else { return nil }
+            let cycleStart = cycle.cycleStart
+            return { date in line.slope * (date.timeIntervalSince(cycleStart) / 3600) + line.intercept }
+        }
+
+        static func line(_ points: [(Double, Double)]) -> (slope: Double, intercept: Double)? {
+            let n = Double(points.count)
+            let sx = points.reduce(0) { $0 + $1.0 }, sy = points.reduce(0) { $0 + $1.1 }
+            let sxx = points.reduce(0) { $0 + $1.0 * $1.0 }, sxy = points.reduce(0) { $0 + $1.0 * $1.1 }
+            let det = n * sxx - sx * sx
+            guard abs(det) > 1e-9 else { return nil }
+            return ((n * sxy - sx * sy) / det, (sy * sxx - sx * sxy) / det)
+        }
+    }
+
+    /// Recency-weighted linear via `TrendEstimator` (acceleration off). Smooths
+    /// out a single busy hour; the 5-hour window's best fit on real data.
+    public struct RecencyWeighted: Model {
+        public let id = "recency-weighted"
+        public let complexity = 2
+        public init() {}
+        public func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)? {
+            guard let estimate = TrendEstimator.fit(
+                samples: cycle.samples.map { .init(at: $0.at, value: $0.usedPercentage) },
+                parameters: .init(
+                    now: cycle.now, minSamples: 3,
+                    minSpanSeconds: max(300, cycle.durationHours * 3600 * 0.05),
+                    recencyHalfLifeSeconds: cycle.durationHours * 3600 * 0.15,
+                    dampingTauSeconds: 3600, maxAccelSlopeFraction: 0))
+            else { return nil }
+            let now = cycle.now
+            return { date in estimate.projectedValue(at: date, now: now) }
+        }
+    }
+
+    /// Recency-weighted with a damped acceleration term — lets the projection
+    /// bend when the recent curve is genuinely accelerating, bounded so it
+    /// can't run away (see `TrendEstimator`).
+    public struct DampedAcceleration: Model {
+        public let id = "damped-acceleration"
+        public let complexity = 4
+        public init() {}
+        public func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)? {
+            let remaining = max(3600, cycle.resetsAt.timeIntervalSince(cycle.now))
+            guard let estimate = TrendEstimator.fit(
+                samples: cycle.samples.map { .init(at: $0.at, value: $0.usedPercentage) },
+                parameters: .init(
+                    now: cycle.now, minSamples: 4,
+                    minSpanSeconds: max(300, cycle.durationHours * 3600 * 0.05),
+                    recencyHalfLifeSeconds: cycle.durationHours * 3600 * 0.15,
+                    dampingTauSeconds: remaining, maxAccelSlopeFraction: 1))
+            else { return nil }
+            let now = cycle.now
+            return { date in estimate.projectedValue(at: date, now: now) }
+        }
+    }
+
+    /// Saturating exponential `L·(1 − e^(−k·s))` — captures usage that
+    /// decelerates as a window fills or rolls old usage off. Fit by a grid over
+    /// the ceiling `L` with a closed-form `k` per `L` (linear through the
+    /// origin in `−ln(1 − y/L)` vs `s`), picking the lowest original-space SSE.
+    public struct Saturating: Model {
+        public let id = "saturating"
+        public let complexity = 3
+        public init() {}
+
+        public func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)? {
+            let s = cycle.samples.map { cycle.hours($0.at) }
+            let y = cycle.samples.map { $0.usedPercentage }
+            guard s.count >= 3, let yMax = y.max(), yMax > 0 else { return nil }
+
+            var best: (sse: Double, L: Double, k: Double)?
+            var ceiling = 1.05
+            while ceiling <= 2.5 {
+                let L = max(yMax * ceiling, yMax + 1)
+                var sk = 0.0, ss = 0.0
+                for i in s.indices where y[i] > 0 && y[i] < L * 0.999 {
+                    let z = -log(1 - y[i] / L)
+                    sk += s[i] * z; ss += s[i] * s[i]
+                }
+                if ss > 1e-9 {
+                    let k = sk / ss
+                    if k > 0 {
+                        var sse = 0.0
+                        for i in s.indices {
+                            let pred = L * (1 - exp(-k * s[i]))
+                            sse += (pred - y[i]) * (pred - y[i])
+                        }
+                        if best == nil || sse < best!.sse { best = (sse, L, k) }
+                    }
+                }
+                ceiling += 0.05
+            }
+            guard let fit = best else { return nil }
+            let cycleStart = cycle.cycleStart
+            return { date in
+                let s = date.timeIntervalSince(cycleStart) / 3600
+                return fit.L * (1 - exp(-fit.k * s))
+            }
+        }
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("BurnTrajectory")
+struct BurnTrajectoryTests {
+
+    private let start = Date(timeIntervalSince1970: 1_780_000_000)
+    private func at(_ hours: Double) -> Date { start.addingTimeInterval(hours * 3600) }
+
+    /// A cycle of `duration` hours, sampled every `stepMin`, pct = f(hours).
+    private func cycle(durationHours: Double, stepMin: Double = 15, _ f: (Double) -> Double) -> BurnTrajectory.Cycle {
+        var samples: [BurnTrajectory.Sample] = []
+        var h = 0.0
+        while h <= durationHours + 1e-6 {
+            samples.append(.init(at: at(h), usedPercentage: max(0, min(100, f(h)))))
+            h += stepMin / 60
+        }
+        return .init(samples: samples, cycleStart: start, resetsAt: at(durationHours))
+    }
+
+    private func partial(_ c: BurnTrajectory.Cycle, throughHours: Double) -> BurnTrajectory.PartialCycle {
+        .init(samples: c.samples, now: at(throughHours), cycleStart: c.cycleStart, resetsAt: c.resetsAt)
+    }
+
+    @Test func linearRecentRecoversTheSlope() throws {
+        let c = cycle(durationHours: 5) { 10 + 15 * $0 }   // +15%/hr
+        let p = partial(c, throughHours: 2.5)
+        let project = try #require(BurnTrajectory.LinearRecent().fit(p))
+        // 1 hour ahead → ~15% higher.
+        let nowVal = project(at(2.5))
+        let aheadVal = project(at(3.5))
+        #expect(abs((aheadVal - nowVal) - 15) < 1.0)
+    }
+
+    @Test func saturatingFitsADeceleratingCurveBelowTheCap() throws {
+        // Genuine saturation toward 80%: never reaches 100.
+        let L = 80.0, k = 0.6
+        let c = cycle(durationHours: 7 * 24, stepMin: 120) { L * (1 - exp(-k * $0 / 24)) }
+        let p = partial(c, throughHours: 7 * 24 * 0.6)
+        let project = try #require(BurnTrajectory.Saturating().fit(p))
+        let atReset = project(c.resetsAt)
+        #expect(atReset < 100)                 // saturating, not blowing past the cap
+        #expect(atReset > 60)                  // but near its ceiling
+    }
+
+    @Test func bestTrajectorySpansNowToResetAndFlagsCrossing() throws {
+        // Steep riser that crosses 100 before reset.
+        let c = cycle(durationHours: 5) { 25 * $0 }     // hits 100 at h=4
+        let history = (0..<4).map { _ in cycle(durationHours: 5) { 25 * $0 } }
+        let p = partial(c, throughHours: 2.5)
+        let traj = try #require(BurnTrajectory.bestTrajectory(current: p, history: history))
+
+        #expect(traj.points.first?.at == at(2.5))
+        #expect(abs(traj.points.last!.at.timeIntervalSince(c.resetsAt)) < 1)
+        #expect(traj.points.allSatisfy { $0.usedPercentage >= 0 && $0.usedPercentage <= 100 })
+        let crossing = try #require(traj.crossesFullAt)
+        #expect(abs(crossing.timeIntervalSince(at(4))) < 3600)   // ~h=4
+    }
+
+    @Test func flatCycleProjectsNoCrossing() throws {
+        let c = cycle(durationHours: 5) { _ in 40 }      // dead flat at 40%
+        let history = (0..<4).map { _ in cycle(durationHours: 5) { _ in 40 } }
+        let traj = try #require(BurnTrajectory.bestTrajectory(
+            current: partial(c, throughHours: 3), history: history))
+        #expect(traj.crossesFullAt == nil)
+    }
+
+    @Test func backtestSelectsTheModelThatTracksTheData() {
+        // Linear cycles → a linear/recency fit should win (low error); the
+        // selector should return a non-nil pick with enough cycles.
+        let cycles = (0..<5).map { i in cycle(durationHours: 5) { 10 + (12 + Double(i)) * $0 } }
+        let scores = BurnTrajectory.score(models: BurnTrajectory.defaultModels, cycles: cycles)
+        let pick = ForecastSelector.select(scores: scores, policy: .init(minScoredCases: 6, minCoverage: 0.5))
+        #expect(pick.id != nil)
+        // The linear-family fits should score well under (low error) on linear data.
+        let linear = scores.first { $0.id == "linear-recent" }!
+        #expect(linear.medianAbsPctError < 10)
+    }
+}


### PR DESCRIPTION
## What

The model layer behind the dashed **projection overlay** coming to the 5h/7d pace charts. A burn surface needs the whole forward *curve* (usage% over future time), not just an ETA — so it can be drawn against the actual line.

Same tournament idea as the totals ensemble: several curve fits compete, scored by how well they predicted the **remainder** of the user's past cycles, and the per-window winner's trajectory is what gets plotted.

## Models (pure)

- `linear-recent` — least-squares line over a recent window
- `recency-weighted` — `TrendEstimator`, acceleration off
- `damped-acceleration` — `TrendEstimator`, acceleration on (bounded)
- `saturating` — `L·(1 − e^(−k·s))`, grid over the ceiling with closed-form `k`

Quadratic deliberately excluded (explodes; worst in every backtest). Reuses `Backtester.Score` + `ForecastSelector` so scoring/selection stay DRY. `bestTrajectory` backtest-selects per window, fits the current cycle, and samples the forward trajectory now→reset with a 100%-crossing flag.

## Validation (real store)

```
5-hour (17 cycles):  recency 4.3pp, damped 5.2, linear 5.3, saturating 6.0
   → SELECTED linear-recent  (prefer-simpler: within 2pp of recency, simpler)
7-day (5 cycles):    damped 10.3pp, recency 11.8, linear 13.3, saturating 35.5
   → SELECTED recency-weighted  (prefer-simpler over damped; linear too far back)
```

Sensible per-window picks; prefer-simpler breaks near-ties toward simpler fits; saturating correctly deprioritized.

## Tests

+5 (slope recovery, saturating-below-cap, trajectory spans now→reset + crossing flag, flat→no crossing, backtest selection). Full suite green (379). **Nothing displayed yet** — the `PaceChartView` overlay + a rendered before/after for sign-off is the next, gated step (it's a shared view used by widgets + ShareCard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)