### PR TITLE
feat(dashboard): projection overlay on the 5h/7d pace charts

### DIFF
--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -13,6 +13,16 @@ struct PaceChartCard: View {
     /// — pre-bucketed by window in `bucketed` so neither column does
     /// its own filter pass.
     @Query private var samples: [RateLimitSample]
+    @Query(PaceChartCard.scanMetaProbe) private var scanMeta: [ClaudeCodeMeta]
+
+    /// Forecast trajectory per window, recomputed on the scan tick (the
+    /// backtest is cheap but not per-render cheap). Keyed by window string.
+    @State private var projections: [String: WindowProjection] = [:]
+
+    struct WindowProjection: Equatable {
+        var points: [PaceChartView.Data.Point]
+        var crossesFullAt: Date?
+    }
 
     init() {
         let cutoff = Date().addingTimeInterval(-8 * 86400)
@@ -21,6 +31,36 @@ struct PaceChartCard: View {
             sort: \.sampledAt,
             order: .reverse
         )
+    }
+
+    private static let scanMetaProbe: FetchDescriptor<ClaudeCodeMeta> = {
+        let key = ClaudeCodeMetaKey.lastIncrementalScanAt
+        return FetchDescriptor<ClaudeCodeMeta>(
+            predicate: #Predicate<ClaudeCodeMeta> { $0.key == key }
+        )
+    }()
+
+    /// Backtest-select a curve fit per window and sample its forward
+    /// trajectory. Cheap fits, but the backtest loops past cycles — so it runs
+    /// on the scan tick, not every render.
+    private func refreshProjections() {
+        let now = Date()
+        var next: [String: WindowProjection] = [:]
+        for (window, duration) in [(RateLimitWindowName.fiveHour, 5.0 * 3600),
+                                    (RateLimitWindowName.sevenDay, 7.0 * 86400)] {
+            let tuples = samples.compactMap { s -> (at: Date, usedPercentage: Double, resetsAt: Date)? in
+                guard s.window == window, let resets = s.resetsAt else { return nil }
+                return (s.sampledAt, s.usedPercentage, resets)
+            }
+            let (current, history) = BurnTrajectory.segment(samples: tuples, duration: duration, now: now)
+            guard let current,
+                  let traj = BurnTrajectory.bestTrajectory(current: current, history: history)
+            else { continue }
+            next[window] = WindowProjection(
+                points: traj.points.map { .init(time: $0.at, value: $0.usedPercentage) },
+                crossesFullAt: traj.crossesFullAt)
+        }
+        projections = next
     }
 
     private struct Bucketed {
@@ -53,18 +93,22 @@ struct PaceChartCard: View {
                     PaceChartColumn(
                         title: "5-hour",
                         duration: 5 * 3600,
-                        windowSamples: b.fiveHour
+                        windowSamples: b.fiveHour,
+                        projection: projections[RateLimitWindowName.fiveHour]
                     )
                     Divider()
                         .frame(height: 110)
                     PaceChartColumn(
                         title: "7-day",
                         duration: 7 * 86400,
-                        windowSamples: b.sevenDay
+                        windowSamples: b.sevenDay,
+                        projection: projections[RateLimitWindowName.sevenDay]
                     )
                 }
             }
         }
+        .onAppear { refreshProjections() }
+        .onChange(of: scanMeta.first?.value) { _, _ in refreshProjections() }
     }
 
     @ViewBuilder
@@ -122,6 +166,9 @@ private struct PaceChartColumn: View {
     /// Already filtered to this column's window and pre-sorted reverse-
     /// chronological by the parent.
     let windowSamples: [RateLimitSample]
+    /// Forecast trajectory for this window (nil when unavailable). Drawn only
+    /// on the live dashboard chart — deliberately not on the shared image.
+    var projection: PaceChartCard.WindowProjection?
 
     /// Share affordance state. `hovering` reveals the share button only
     /// while the cursor is over the column (Linear/Things idiom, keeps
@@ -163,6 +210,23 @@ private struct PaceChartColumn: View {
             durationSeconds: duration,
             points: points,
             usedPct: latest.usedPercentage
+        )
+    }
+
+    /// `chartData` plus the forecast overlay — used only by the live dashboard
+    /// chart. `chartData` itself stays projection-free so the shared image
+    /// (which renders from it) is unchanged.
+    private var liveChartData: PaceChartView.Data? {
+        guard let base = chartData else { return nil }
+        guard let projection else { return base }
+        return PaceChartView.Data(
+            cycleStart: base.cycleStart,
+            resetsAt: base.resetsAt,
+            durationSeconds: base.durationSeconds,
+            points: base.points,
+            usedPct: base.usedPct,
+            projection: projection.points,
+            projectionCrossesFullAt: projection.crossesFullAt
         )
     }
 
@@ -239,8 +303,8 @@ private struct PaceChartColumn: View {
             }
             .frame(maxWidth: .infinity, alignment: .topLeading)
             .frame(height: 96, alignment: .topLeading)
-        } else if let chartData {
-            PaceChartView(data: chartData, style: .detailed)
+        } else if let liveChartData {
+            PaceChartView(data: liveChartData, style: .detailed)
                 .frame(height: 96)
         } else {
             Text("collecting…")

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
@@ -153,6 +153,41 @@ public enum BurnTrajectory {
         return Trajectory(modelId: model.id, points: points, crossesFullAt: crossing)
     }
 
+    /// Segment a flat run of samples (each carrying its window's `resetsAt`)
+    /// into the current partial cycle and the prior complete cycles, by
+    /// grouping on the reset boundary. The group whose reset is latest is the
+    /// current cycle; the rest are history for the backtest. `duration` is the
+    /// window length (5h or 7d). Order-agnostic.
+    public static func segment(
+        samples: [(at: Date, usedPercentage: Double, resetsAt: Date)],
+        duration: TimeInterval,
+        now: Date
+    ) -> (current: PartialCycle?, history: [Cycle]) {
+        let sorted = samples.sorted { $0.at < $1.at }
+        var groups: [Date: [(at: Date, usedPercentage: Double, resetsAt: Date)]] = [:]
+        // Bucket by reset rounded to the minute so jitter doesn't split a cycle.
+        for s in sorted {
+            let key = Date(timeIntervalSince1970: (s.resetsAt.timeIntervalSince1970 / 60).rounded() * 60)
+            groups[key, default: []].append(s)
+        }
+        guard let currentReset = groups.keys.max() else { return (nil, []) }
+
+        var history: [Cycle] = []
+        var current: PartialCycle?
+        for (key, rows) in groups {
+            // Use the real reset from the readings, not the rounded group key.
+            let reset = rows.map { $0.resetsAt }.max() ?? key
+            let cycleStart = reset.addingTimeInterval(-duration)
+            let samples = rows.map { Sample(at: $0.at, usedPercentage: $0.usedPercentage) }
+            if key == currentReset {
+                current = PartialCycle(samples: samples, now: now, cycleStart: cycleStart, resetsAt: reset)
+            } else {
+                history.append(Cycle(samples: samples, cycleStart: cycleStart, resetsAt: reset))
+            }
+        }
+        return (current, history.sorted { $0.cycleStart < $1.cycleStart })
+    }
+
     static func median(_ xs: [Double]) -> Double {
         guard !xs.isEmpty else { return .infinity }
         let s = xs.sorted(); let n = s.count

--- a/PacerCore/Sources/PacerUI/PaceChartView.swift
+++ b/PacerCore/Sources/PacerUI/PaceChartView.swift
@@ -29,6 +29,14 @@ public struct PaceChartView: View {
         public let durationSeconds: TimeInterval
         public let points: [Point]
         public let usedPct: Double
+        /// Optional forecast: the projected usage trajectory from "now" to the
+        /// reset, drawn as a faint dashed line so you can see where the curve
+        /// is heading vs. where it's been. `nil` (the default) draws nothing —
+        /// so widgets and the share card are unaffected unless they opt in.
+        public let projection: [Point]?
+        /// First instant the projection reaches 100% within the window, if
+        /// any — marked on the chart as the forecast limit-hit.
+        public let projectionCrossesFullAt: Date?
 
         public struct Point: Equatable, Identifiable {
             public let time: Date
@@ -46,13 +54,17 @@ public struct PaceChartView: View {
             resetsAt: Date,
             durationSeconds: TimeInterval,
             points: [Point],
-            usedPct: Double
+            usedPct: Double,
+            projection: [Point]? = nil,
+            projectionCrossesFullAt: Date? = nil
         ) {
             self.cycleStart = cycleStart
             self.resetsAt = resetsAt
             self.durationSeconds = durationSeconds
             self.points = points
             self.usedPct = usedPct
+            self.projection = projection
+            self.projectionCrossesFullAt = projectionCrossesFullAt
         }
     }
 
@@ -176,6 +188,31 @@ public struct PaceChartView: View {
                     .foregroundStyle(run.band.color)
                     .lineStyle(StrokeStyle(lineWidth: style.lineWidth, lineCap: .round))
                     .interpolationMethod(.monotone)
+                }
+            }
+
+            // Forecast trajectory: a faint dashed continuation from "now" to
+            // the reset. Drawn under the tail dot, distinct from the gray
+            // pace line, so it reads as "where this is heading" without
+            // pretending to be observed data. Red-tinted when it's projected
+            // to hit the cap before the window resets.
+            if let projection = data.projection, projection.count >= 2 {
+                let crosses = data.projectionCrossesFullAt != nil
+                ForEach(projection) { pt in
+                    LineMark(
+                        x: .value("time", pt.time),
+                        y: .value("pct", pt.value),
+                        series: .value("series", "projection")
+                    )
+                    .foregroundStyle((crosses ? Color.red : Color.primary).opacity(0.4))
+                    .lineStyle(StrokeStyle(lineWidth: style.lineWidth * 0.85, dash: [5, 4]))
+                    .interpolationMethod(.monotone)
+                }
+                if let crossAt = data.projectionCrossesFullAt {
+                    PointMark(x: .value("time", crossAt), y: .value("pct", 100.0))
+                        .foregroundStyle(Color.red.opacity(0.6))
+                        .symbolSize(style.tailSymbolSize * 0.7)
+                        .symbol(.circle)
                 }
             }
 

--- a/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
@@ -66,6 +66,24 @@ struct BurnTrajectoryTests {
         #expect(traj.crossesFullAt == nil)
     }
 
+    @Test func segmentSplitsCurrentCycleFromHistory() throws {
+        // Three back-to-back 5h cycles resetting at 5h, 10h, 15h.
+        var rows: [(at: Date, usedPercentage: Double, resetsAt: Date)] = []
+        for c in 0..<3 {
+            let reset = at(Double((c + 1) * 5))
+            var h = Double(c * 5)
+            while h < Double((c + 1) * 5) {
+                rows.append((at(h), 10 + (h - Double(c * 5)) * 15, reset))
+                h += 0.5
+            }
+        }
+        let (current, history) = BurnTrajectory.segment(samples: rows, duration: 5 * 3600, now: at(13))
+        #expect(history.count == 2)                           // first two cycles
+        let cur = try #require(current)
+        #expect(abs(cur.resetsAt.timeIntervalSince(at(15))) < 1) // latest reset is current
+        #expect(cur.samples.allSatisfy { $0.at <= at(13) })   // only up to now
+    }
+
     @Test func backtestSelectsTheModelThatTracksTheData() {
         // Linear cycles → a linear/recency fit should win (low error); the
         // selector should return a non-nil pick with enough cycles.


### PR DESCRIPTION
Draws the backtest-selected curve fit's forward trajectory as a **faint dashed line** from now to the window reset on the live pace charts. Red + dot at the crossing when projected to hit 100% before reset; gray otherwise.

- `PaceChartView.Data.projection` is optional, nil by default → **widgets and the share image are unchanged**.
- `PaceChartCard` computes the per-window trajectory on the scan tick and passes it only to the live chart.
- `BurnTrajectory.segment` splits samples into current + prior cycles.

Verified live on real data (signed off): 7-day ~68% → red projection crossing 100% before reset; 5-hour (low usage) → faint flat line. Full suite green (380); installed + verified on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)