### PR TITLE
feat(dashboard): "Compare models" projection detail view

### DIFF
--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -175,6 +175,7 @@ private struct PaceChartColumn: View {
     /// the card clean); `sharing` drives the preview popover.
     @State private var hovering = false
     @State private var sharing = false
+    @State private var showingDetail = false
 
     private var latest: RateLimitSample? { windowSamples.first }
 
@@ -235,9 +236,49 @@ private struct PaceChartColumn: View {
             header
             heroLine
             chartSlot
+            compareButton
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onHover { hovering = $0 }
+        .sheet(isPresented: $showingDetail) { detailSheet }
+    }
+
+    /// "Compare models" — opens the all-models projection detail. Shown only
+    /// when there's an active cycle with a chart to compare against.
+    @ViewBuilder
+    private var compareButton: some View {
+        if cycle?.isAwaiting == false, chartData != nil {
+            Button { showingDetail = true } label: {
+                Label("Compare models", systemImage: "chart.xyaxis.line")
+                    .font(.system(size: 10, weight: .medium))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("See every forecast model's projection and its fit accuracy")
+        }
+    }
+
+    /// Builds the detail sheet on demand: fit all candidate models to the
+    /// current cycle and score them against past cycles.
+    @ViewBuilder
+    private var detailSheet: some View {
+        let now = Date()
+        let tuples = windowSamples.compactMap { s -> (at: Date, usedPercentage: Double, resetsAt: Date)? in
+            guard let resets = s.resetsAt else { return nil }
+            return (s.sampledAt, s.usedPercentage, resets)
+        }
+        let segmented = BurnTrajectory.segment(samples: tuples, duration: duration, now: now)
+        if let current = segmented.current, let data = chartData {
+            ProjectionDetailView(
+                title: "\(title) projection",
+                cycleStart: data.cycleStart,
+                resetsAt: data.resetsAt,
+                durationSeconds: duration,
+                actual: data.points,
+                trajectories: BurnTrajectory.allTrajectories(current: current, history: segmented.history))
+        } else {
+            Text("Not enough data to compare models yet.").padding(40)
+        }
     }
 
     /// Everything the share sheet needs to render and name this window's

--- a/App/Views/ProjectionDetailView.swift
+++ b/App/Views/ProjectionDetailView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+import Charts
+import PacerCore
+import PacerUI
+
+/// "Compare models" detail sheet for one rate-limit window: the actual usage
+/// curve with **every** candidate forecaster's projection overlaid and
+/// labelled, plus each model's backtest accuracy. Opened from the little
+/// button under each 5h/7d pace chart, for when you want to see the whole
+/// tournament rather than just the winner the dashboard draws.
+struct ProjectionDetailView: View {
+    let title: String
+    let cycleStart: Date
+    let resetsAt: Date
+    let durationSeconds: TimeInterval
+    let actual: [PaceChartView.Data.Point]
+    let trajectories: [BurnTrajectory.ScoredTrajectory]
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// Stable per-model colors for the lines and the legend swatches.
+    private static let palette: [String: Color] = [
+        "linear-recent": .blue,
+        "recency-weighted": .green,
+        "damped-acceleration": .purple,
+        "saturating": .orange,
+    ]
+    private func color(_ id: String) -> Color { Self.palette[id] ?? .gray }
+
+    /// Models sorted best-accuracy first (selected, then lowest error).
+    private var ranked: [BurnTrajectory.ScoredTrajectory] {
+        trajectories.sorted {
+            if $0.isSelected != $1.isSelected { return $0.isSelected }
+            return $0.medianAbsError < $1.medianAbsError
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text(title).font(.title3.weight(.semibold))
+                Spacer()
+                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction)
+            }
+            chart.frame(height: 240)
+            accuracyTable
+            Text("Projections are fit on this cycle so far. “Fit error” is each model’s median absolute error (percentage points) over the remainder of your past cycles — lower is better; the selected model is what the dashboard draws.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(24)
+        .frame(width: 620)
+    }
+
+    private var chart: some View {
+        Chart {
+            paceMarks
+            actualMarks
+            trajectoryMarks
+        }
+        .chartXScale(domain: cycleStart...resetsAt)
+        .chartYScale(domain: 0...105)
+        .chartYAxis { AxisMarks(values: [0, 50, 100]) { AxisGridLine(); AxisValueLabel() } }
+    }
+
+    @ChartContentBuilder private var paceMarks: some ChartContent {
+        LineMark(x: .value("t", cycleStart), y: .value("pct", 0.0), series: .value("s", "pace"))
+        LineMark(x: .value("t", resetsAt), y: .value("pct", 100.0), series: .value("s", "pace"))
+            .foregroundStyle(.secondary.opacity(0.35))
+            .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+        RuleMark(y: .value("full", 100))
+            .foregroundStyle(.secondary.opacity(0.25))
+            .lineStyle(StrokeStyle(lineWidth: 1, dash: [2, 4]))
+    }
+
+    @ChartContentBuilder private var actualMarks: some ChartContent {
+        ForEach(actual) { p in
+            LineMark(x: .value("t", p.time), y: .value("pct", p.value), series: .value("s", "actual"))
+                .foregroundStyle(.primary)
+                .lineStyle(StrokeStyle(lineWidth: 2.4, lineCap: .round))
+                .interpolationMethod(.monotone)
+        }
+    }
+
+    /// Pre-resolved styling so the chart builder stays trivial (the inline
+    /// ternaries overwhelmed the type-checker).
+    private struct StyledLine: Identifiable {
+        let id: String
+        let points: [BurnTrajectory.Sample]
+        let color: Color
+        let width: CGFloat
+        let dash: [CGFloat]
+    }
+    private var styledLines: [StyledLine] {
+        trajectories.map { st in
+            StyledLine(
+                id: st.modelId,
+                points: st.trajectory.points,
+                color: color(st.modelId).opacity(st.isSelected ? 0.95 : 0.5),
+                width: st.isSelected ? 2.4 : 1.4,
+                dash: st.isSelected ? [6, 3] : [4, 4])
+        }
+    }
+
+    @ChartContentBuilder private var trajectoryMarks: some ChartContent {
+        ForEach(styledLines) { line in
+            ForEach(line.points, id: \.at) { p in
+                LineMark(x: .value("t", p.at), y: .value("pct", p.usedPercentage),
+                         series: .value("s", "m-\(line.id)"))
+                    .foregroundStyle(line.color)
+                    .lineStyle(StrokeStyle(lineWidth: line.width, dash: line.dash))
+                    .interpolationMethod(.monotone)
+            }
+        }
+    }
+
+    private var accuracyTable: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(ranked) { st in
+                HStack(spacing: 10) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(color(st.modelId))
+                        .frame(width: 14, height: 4)
+                    Text(BurnTrajectory.displayName(st.modelId))
+                        .font(.system(size: 13, weight: st.isSelected ? .semibold : .regular))
+                    if st.isSelected {
+                        Text("selected").font(.system(size: 10, weight: .semibold))
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Capsule().fill(color(st.modelId).opacity(0.18)))
+                            .foregroundStyle(color(st.modelId))
+                    }
+                    Spacer()
+                    if let crossAt = st.trajectory.crossesFullAt {
+                        Text("hits 100% \(pacerRelative(crossAt, style: .short))")
+                            .font(.system(size: 11)).foregroundStyle(.red.opacity(0.8))
+                    }
+                    Text(st.medianAbsError.isFinite ? String(format: "fit ±%.1f pp", st.medianAbsError) : "no history yet")
+                        .font(.system(size: 12).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
@@ -188,6 +188,66 @@ public enum BurnTrajectory {
         return (current, history.sorted { $0.cycleStart < $1.cycleStart })
     }
 
+    /// One model's forward trajectory plus its backtest accuracy — for the
+    /// "show all models" detail view.
+    public struct ScoredTrajectory: Sendable, Identifiable {
+        public let modelId: String
+        public let complexity: Int
+        public let trajectory: Trajectory
+        /// Median absolute error (percentage points) over the remainder of
+        /// past cycles. `.infinity` when there wasn't enough history to score.
+        public let medianAbsError: Double
+        public let coverage: Double
+        public let isSelected: Bool
+        public var id: String { modelId }
+    }
+
+    /// Fit *every* model to the current cycle and pair each trajectory with
+    /// its backtest accuracy, flagging the one the selector would pick. Powers
+    /// the detail view that plots all candidates side by side.
+    public static func allTrajectories(
+        current: PartialCycle,
+        history: [Cycle],
+        models: [any Model] = defaultModels,
+        selectionPolicy: ForecastSelector.Policy = .init(minScoredCases: 6, minCoverage: 0.5),
+        sampleCount: Int = 48
+    ) -> [ScoredTrajectory] {
+        let scores = score(models: models, cycles: history)
+        let selectedId = ForecastSelector.select(scores: scores, policy: selectionPolicy).id
+        let span = current.resetsAt.timeIntervalSince(current.now)
+        guard span > 0 else { return [] }
+
+        return models.compactMap { model -> ScoredTrajectory? in
+            guard let projection = model.fit(current) else { return nil }
+            var points: [Sample] = []
+            var crossing: Date?
+            for i in 0...sampleCount {
+                let date = current.now.addingTimeInterval(span * Double(i) / Double(sampleCount))
+                let raw = projection(date)
+                if crossing == nil, raw >= 100 { crossing = date }
+                points.append(Sample(at: date, usedPercentage: min(100, max(0, raw))))
+            }
+            let s = scores.first { $0.id == model.id }
+            return ScoredTrajectory(
+                modelId: model.id, complexity: model.complexity,
+                trajectory: Trajectory(modelId: model.id, points: points, crossesFullAt: crossing),
+                medianAbsError: s?.medianAbsPctError ?? .infinity,
+                coverage: s?.coverage ?? 0,
+                isSelected: model.id == selectedId)
+        }
+    }
+
+    /// Friendly display name for a model id.
+    public static func displayName(_ modelId: String) -> String {
+        switch modelId {
+        case "linear-recent": return "Linear (recent)"
+        case "recency-weighted": return "Recency-weighted"
+        case "damped-acceleration": return "Damped acceleration"
+        case "saturating": return "Saturating"
+        default: return modelId
+        }
+    }
+
     static func median(_ xs: [Double]) -> Double {
         guard !xs.isEmpty else { return .infinity }
         let s = xs.sorted(); let n = s.count


### PR DESCRIPTION
A small **Compare models** button under each 5h/7d pace chart opens a sheet plotting **every** candidate forecaster's projection (labelled, colored, the selected one bold) over the actual usage curve, with a per-model accuracy table — median fit error (pp) over past cycles, projected 100%-crossing, and the selected badge.

- `BurnTrajectory.allTrajectories` fits every model + pairs each with its backtest score and the selector's pick; `displayName` for friendly labels.
- `ProjectionDetailView` — the sheet (chart marks split into `@ChartContentBuilder` helpers + pre-resolved styling so the type-checker copes).
- `PaceChartColumn` — the button, building the sheet on demand.

New view; doesn't touch the existing displayed numbers. Full suite green (380); installed + verified rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)