### PR TITLE
feat(forecast): completed-cycle scoring + scoreboard (feedback-loop foundation)

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
@@ -237,6 +237,59 @@ public enum BurnTrajectory {
         }
     }
 
+    // MARK: - Completed-cycle scoring (the feedback loop)
+
+    /// A model's verdict over one completed cycle: overall accuracy and how
+    /// early it converged.
+    public struct CycleScore: Sendable, Equatable {
+        public let modelId: String
+        public let meanAbsError: Double
+        public let convergenceFraction: Double
+    }
+
+    /// Within this many percentage points of the realized final counts as
+    /// "locked in" for the convergence metric.
+    public static let convergenceTolerance: Double = 5
+
+    /// Score each model over a *completed* cycle: replay it at a grid of cut
+    /// points, projecting the final each time, and measure (a) mean absolute
+    /// error vs the realized final and (b) the earliest cut fraction from
+    /// which it stayed within `tolerance`. This is what gets persisted as
+    /// `ForecastModelOutcome` and aggregated by `ForecastScoreboard`.
+    public static func scoreCompletedCycle(
+        _ cycle: Cycle,
+        models: [any Model] = defaultModels,
+        cutFractions: [Double] = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        tolerance: Double = convergenceTolerance
+    ) -> [CycleScore] {
+        let trueFinal = cycle.samples.map { $0.usedPercentage }.max() ?? 0
+        guard trueFinal > 0 else { return [] }
+        let duration = cycle.resetsAt.timeIntervalSince(cycle.cycleStart)
+        guard duration > 0 else { return [] }
+
+        return models.compactMap { model -> CycleScore? in
+            var graded: [(f: Double, err: Double)] = []
+            for f in cutFractions {
+                let now = cycle.cycleStart.addingTimeInterval(duration * f)
+                let seen = cycle.samples.filter { $0.at <= now }
+                guard seen.count >= 3 else { continue }
+                let partial = PartialCycle(samples: seen, now: now,
+                                           cycleStart: cycle.cycleStart, resetsAt: cycle.resetsAt)
+                guard let projection = model.fit(partial) else { continue }
+                graded.append((f, abs(projection(cycle.resetsAt) - trueFinal)))
+            }
+            guard !graded.isEmpty else { return nil }
+            let mean = graded.reduce(0) { $0 + $1.err } / Double(graded.count)
+            // Convergence: earliest f from which every later cut stayed within
+            // tolerance. Walk from the latest cut backward while still in band.
+            var convergence = 1.0
+            for g in graded.sorted(by: { $0.f > $1.f }) {
+                if g.err <= tolerance { convergence = g.f } else { break }
+            }
+            return CycleScore(modelId: model.id, meanAbsError: mean, convergenceFraction: convergence)
+        }
+    }
+
     /// Friendly display name for a model id.
     public static func displayName(_ modelId: String) -> String {
         switch modelId {

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/ForecastScoreboard.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/ForecastScoreboard.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Aggregates the per-completed-cycle `ForecastModelOutcome` records into
+/// per-model scores the shared `ForecastSelector` can rank — turning
+/// accumulated real-world verdicts into the model the dashboard picks.
+///
+/// The key twist over a plain accuracy average: a model that *converges early*
+/// is worth more than one that's only right at the very end. So the effective
+/// error folds in the convergence fraction:
+///
+///   effectiveError = median(meanAbsError) + convergenceWeight · median(convergenceFraction)
+///
+/// A model that nails the final by 30% into cycles beats one that only nails it
+/// at 90%, even at equal raw accuracy. As cycles accumulate this scoreboard
+/// gradually overrides the cold-start on-the-fly backtest — and because the ML
+/// candidate is recorded here too, it earns its slot from real outcomes.
+public enum ForecastScoreboard {
+
+    /// A decoupled view of a `ForecastModelOutcome` row (so this stays pure
+    /// and testable without SwiftData).
+    public struct Record: Sendable, Equatable {
+        public let window: String
+        public let modelId: String
+        public let meanAbsError: Double
+        public let convergenceFraction: Double
+        public init(window: String, modelId: String, meanAbsError: Double, convergenceFraction: Double) {
+            self.window = window
+            self.modelId = modelId
+            self.meanAbsError = meanAbsError
+            self.convergenceFraction = convergenceFraction
+        }
+    }
+
+    /// Percentage-point penalty per unit of convergence fraction. Converging
+    /// only at the very end (1.0) rather than immediately (0) adds this many
+    /// effective pp — the lever that makes selection prefer models that get it
+    /// right *early*.
+    public static let convergenceWeight: Double = 15
+
+    /// Aggregate the records for one window into `Backtester.Score`s. The
+    /// `medianAbsPctError` field carries the *effective* error (accuracy +
+    /// earliness penalty); `meanAbsPctError` carries the raw accuracy for
+    /// display. `scoredCount` is how many completed cycles backed each model.
+    public static func scores(
+        for window: String,
+        records: [Record],
+        models: [any BurnTrajectory.Model] = BurnTrajectory.defaultModels
+    ) -> [Backtester.Score] {
+        let complexity = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0.complexity) })
+        let byModel = Dictionary(grouping: records.filter { $0.window == window }, by: { $0.modelId })
+        return byModel.map { id, recs in
+            let rawError = median(recs.map { $0.meanAbsError })
+            let convergence = median(recs.map { $0.convergenceFraction })
+            return Backtester.Score(
+                id: id,
+                complexity: complexity[id] ?? 3,
+                medianAbsPctError: rawError + convergenceWeight * convergence,
+                meanAbsPctError: rawError,
+                coverage: 1,
+                scoredCount: recs.count
+            )
+        }
+    }
+
+    private static func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return .infinity }
+        let s = xs.sorted(); let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/PacerCore/Sources/PacerCore/Models/ForecastModelOutcome.swift
+++ b/PacerCore/Sources/PacerCore/Models/ForecastModelOutcome.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftData
+
+/// How one forecast model actually did over one *completed* rate-limit cycle —
+/// the persisted memory that turns the tournament into a self-improving loop.
+///
+/// The tournament re-backtests raw history each time it selects, but it never
+/// remembered the verdict. This records, per `(window, cycle, model)`, two
+/// things once a cycle finishes:
+///   - **accuracy** (`meanAbsError`): how close the model's projected final
+///     was to the realized final, averaged across cut points through the cycle;
+///   - **convergence** (`convergenceFraction`): *how early* it locked onto the
+///     right answer — the earliest fraction of the cycle from which its
+///     projection stayed within tolerance. A model that's right by 30% in is
+///     worth more than one that's only right at the very end.
+///
+/// `ForecastScoreboard` aggregates these into per-model weights that drive
+/// selection, and the on-device ML candidate is scored here too — so it earns
+/// (or loses) its place from real outcomes, not just an offline backtest.
+@Model
+public final class ForecastModelOutcome {
+    #Index<ForecastModelOutcome>([\.window], [\.window, \.modelId])
+
+    /// `"\(window)|\(resetsAtISO)|\(modelId)"` — unique so a completed cycle is
+    /// scored exactly once per model.
+    @Attribute(.unique) public var key: String
+    public var window: String          // "five_hour" | "seven_day"
+    public var modelId: String
+    /// The cycle's reset boundary — its identity.
+    public var resetsAt: Date
+    /// Realized final utilization of the cycle (the truth the models aimed at).
+    public var trueFinalPct: Double
+    /// Mean absolute error (percentage points) of the model's projected final
+    /// across the cut grid — overall accuracy through the cycle.
+    public var meanAbsError: Double
+    /// Earliest fraction of the cycle (0…1) from which the projection stayed
+    /// within tolerance of the realized final. 1.0 = it never locked in.
+    public var convergenceFraction: Double
+    public var recordedAt: Date
+
+    public init(
+        window: String,
+        modelId: String,
+        resetsAt: Date,
+        trueFinalPct: Double,
+        meanAbsError: Double,
+        convergenceFraction: Double,
+        recordedAt: Date = Date()
+    ) {
+        self.key = Self.makeKey(window: window, resetsAt: resetsAt, modelId: modelId)
+        self.window = window
+        self.modelId = modelId
+        self.resetsAt = resetsAt
+        self.trueFinalPct = trueFinalPct
+        self.meanAbsError = meanAbsError
+        self.convergenceFraction = convergenceFraction
+        self.recordedAt = recordedAt
+    }
+
+    public static func makeKey(window: String, resetsAt: Date, modelId: String) -> String {
+        "\(window)|\(ISO8601DateFormatter().string(from: resetsAt))|\(modelId)"
+    }
+}

--- a/PacerCore/Sources/PacerCore/PacerStore.swift
+++ b/PacerCore/Sources/PacerCore/PacerStore.swift
@@ -113,6 +113,7 @@ public enum PacerStore {
         ProjectPathProbe.self,
         ProjectBudget.self,
         AlertRule.self,
+        ForecastModelOutcome.self,
     ]
 
     public static func makeModelContainer() throws -> ModelContainer {

--- a/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
@@ -66,6 +66,42 @@ struct BurnTrajectoryTests {
         #expect(traj.crossesFullAt == nil)
     }
 
+    @Test func scoreCompletedCycleMeasuresAccuracyAndConvergence() {
+        // A clean linear cycle to ~90%. linear/recency models should track it
+        // well (low error) and lock in early (low convergence fraction).
+        let c = cycle(durationHours: 5) { min(95, 18 * $0) }
+        let scores = BurnTrajectory.scoreCompletedCycle(c)
+        let linear = scores.first { $0.modelId == "linear-recent" }
+        #expect(linear != nil)
+        #expect(linear!.meanAbsError < 15)
+        #expect(linear!.convergenceFraction <= 0.6)
+        // Every score reports a convergence fraction in [0, 1].
+        #expect(scores.allSatisfy { $0.convergenceFraction >= 0 && $0.convergenceFraction <= 1 })
+    }
+
+    @Test func scoreboardPrefersEarlyConvergersAtEqualAccuracy() {
+        // "early" is slightly less accurate but converges much sooner;
+        // "late" is marginally more accurate but only locks in at the end.
+        let records = [
+            ForecastScoreboard.Record(window: "five_hour", modelId: "early", meanAbsError: 5, convergenceFraction: 0.3),
+            ForecastScoreboard.Record(window: "five_hour", modelId: "late", meanAbsError: 4, convergenceFraction: 0.9),
+        ]
+        let scores = ForecastScoreboard.scores(for: "five_hour", records: records)
+        // effective: early = 5 + 15·0.3 = 9.5 ; late = 4 + 15·0.9 = 17.5.
+        let pick = ForecastSelector.select(scores: scores, policy: .init(minScoredCases: 1, minCoverage: 0.5))
+        #expect(pick.id == "early")
+    }
+
+    @Test func scoreboardFiltersByWindow() {
+        let records = [
+            ForecastScoreboard.Record(window: "five_hour", modelId: "a", meanAbsError: 5, convergenceFraction: 0.2),
+            ForecastScoreboard.Record(window: "seven_day", modelId: "b", meanAbsError: 9, convergenceFraction: 0.2),
+        ]
+        let five = ForecastScoreboard.scores(for: "five_hour", records: records)
+        #expect(five.count == 1)
+        #expect(five.first?.id == "a")
+    }
+
     @Test func segmentSplitsCurrentCycleFromHistory() throws {
         // Three back-to-back 5h cycles resetting at 5h, 10h, 15h.
         var rows: [(at: Date, usedPercentage: Double, resetsAt: Date)] = []


### PR DESCRIPTION
The persisted memory + math that makes the tournament **self-improving**. Today the selector re-backtests raw history but never remembers how each model actually did; this records the verdict per completed cycle and will weight future selection by it — rewarding models that get it right **early**, not just at the end.

- **`ForecastModelOutcome`** (`@Model`, schema-registered): per (window, cycle, model) — realized final, mean abs error across the cut grid, and **convergence fraction** (earliest cut from which it stayed within tolerance). Additive → safe lightweight migration.
- **`BurnTrajectory.scoreCompletedCycle`**: pure — replay a finished cycle at a cut grid, project the final each time, compute accuracy + convergence.
- **`ForecastScoreboard`**: aggregate outcomes per window into `Backtester.Score`s the shared `ForecastSelector` ranks. effectiveError = median(meanAbsError) + convergenceWeight·median(convergenceFraction) → early-converging models win.

**Foundation only** — recording on scan + wiring into selection is the next PR. The ML candidate is scored here too, so it earns its slot from real outcomes. +3 tests; full suite green (383); installed (new table created via lightweight migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)