### PR TITLE
feat(intelligence): forecast-engine primitives — Estimate, conformal intervals, EB shrinkage

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Engine/ConformalCalibrator.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/ConformalCalibrator.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Split-conformal predictive intervals from a model's own past out-of-sample
+/// residuals. The engine's source of honest uncertainty.
+///
+/// The idea (and why it's the round-2 "real win"): instead of trusting a model's
+/// parametric error bars, collect how wrong it actually was on past walk-forward
+/// cases, and read the band straight off that empirical residual distribution.
+/// Two flavours, matching the surfaces:
+/// - `.multiplicative` — residuals are ratios `truth / prediction` (for cost,
+///   where error scales with magnitude). Band = `point × [q_lo, q_hi]`.
+/// - `.additive` — residuals are differences `truth − prediction` (for rate-limit
+///   utilisation in percentage points). Band = `point + [q_lo, q_hi]`.
+///
+/// Distribution-free and finite-sample honest: with `n` calibration residuals the
+/// two-sided level-`L` interval uses the conformal `(n+1)` rank adjustment, so
+/// coverage is ≥ `L` in expectation. When `n` is too small the band saturates to
+/// the widest observed residual rather than pretending to precision it lacks —
+/// exactly the "don't show a confident wrong number" posture.
+public struct ConformalCalibrator: Sendable, Equatable {
+
+    public enum Mode: Sendable, Equatable {
+        /// Residuals are `truth / prediction` ratios (cost-like, scale-relative).
+        case multiplicative
+        /// Residuals are `truth − prediction` differences (percentage-point-like).
+        case additive
+    }
+
+    public let mode: Mode
+    /// Calibration residuals, sorted ascending.
+    public let residuals: [Double]
+
+    public init(mode: Mode, residuals: [Double]) {
+        self.mode = mode
+        self.residuals = residuals.filter { $0.isFinite }.sorted()
+    }
+
+    public var count: Int { residuals.count }
+
+    /// Build a calibrator from paired out-of-sample (prediction, truth) cases.
+    /// Multiplicative skips non-positive predictions (ratio undefined).
+    public static func fromPairs(
+        mode: Mode,
+        predictions: [Double],
+        truths: [Double]
+    ) -> ConformalCalibrator {
+        var rs: [Double] = []
+        for (p, t) in zip(predictions, truths) where p.isFinite && t.isFinite {
+            switch mode {
+            case .multiplicative where p > 0: rs.append(t / p)
+            case .additive: rs.append(t - p)
+            default: break
+            }
+        }
+        return ConformalCalibrator(mode: mode, residuals: rs)
+    }
+
+    /// Two-sided predictive interval at `level` coverage (e.g. 0.8) around a new
+    /// point estimate. `nil` when there aren't at least `minResiduals` to form an
+    /// honest band.
+    public func interval(
+        around point: Double,
+        level: Double,
+        minResiduals: Int = 8
+    ) -> ClosedRange<Double>? {
+        guard residuals.count >= minResiduals, level > 0, level < 1, point.isFinite else { return nil }
+        let alpha = 1 - level
+        let lo = quantile(alpha / 2)
+        let hi = quantile(1 - alpha / 2)
+        let lower: Double
+        let upper: Double
+        switch mode {
+        case .multiplicative:
+            lower = point * lo
+            upper = point * hi
+        case .additive:
+            lower = point + lo
+            upper = point + hi
+        }
+        guard lower.isFinite, upper.isFinite, upper >= lower else { return nil }
+        return lower...upper
+    }
+
+    /// Empirical quantile of the residuals with the conformal `(n+1)` rank
+    /// adjustment. `p` in [0,1]; saturates to the extreme residual past the range
+    /// (the honest "can't be more precise than what we've seen").
+    public func quantile(_ p: Double) -> Double {
+        let n = residuals.count
+        guard n > 0 else { return .nan }
+        let rank = Int((Double(n + 1) * p).rounded(.up))
+        let idx = min(max(rank, 1), n) - 1
+        return residuals[idx]
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EmpiricalBayes.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EmpiricalBayes.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Empirical-Bayes / James–Stein shrinkage of per-group means toward the pooled
+/// mean. The engine's defence against the overfitting problem the user named:
+/// *a complex model overfits the bulk so a simple one wins on deviations.*
+///
+/// The fix isn't "pick simple" — it's to estimate each regime cell (a weekday, an
+/// hour-of-day, a weekday×hour bucket) but only *trust it as far as the data
+/// supports*. A cell with many consistent samples keeps its own mean; a thin or
+/// noisy cell is pulled toward the global mean. The shrinkage weight
+/// `w = τ² / (τ² + σ²/n)` is derived, not hand-tuned: when the between-group
+/// signal `τ²` is ~0 (this user's weekday cost carries almost none), every cell
+/// collapses to flat automatically — so seasonal structure can ship from day one
+/// without an eligibility cliff, and can't overfit when the signal isn't there.
+///
+/// `signalShare = τ² / (τ² + σ²)` is the one-number summary: 0 ⇒ no group signal
+/// (use flat), 1 ⇒ groups are genuinely distinct.
+public enum EmpiricalBayes {
+
+    /// One group's sufficient statistics. `within` is the variance of the
+    /// individual observations in the group (its noise), `count` their number.
+    public struct Group: Sendable, Equatable {
+        public let mean: Double
+        public let count: Int
+        public let within: Double
+        public init(mean: Double, count: Int, within: Double) {
+            self.mean = mean
+            self.count = count
+            self.within = within
+        }
+    }
+
+    public struct Result: Sendable, Equatable {
+        /// Shrunk group means, aligned to the input order.
+        public let shrunkMeans: [Double]
+        /// Per-group shrink weight toward the group's *own* mean (0 = full pool,
+        /// 1 = no shrink).
+        public let weights: [Double]
+        /// Count-weighted pooled mean (the shrink target).
+        public let grandMean: Double
+        /// Estimated between-group variance τ² (the "signal").
+        public let betweenVar: Double
+        /// Estimated pooled within-group (per-observation) variance σ² (the "noise").
+        public let withinVar: Double
+        /// τ² / (τ² + σ²) ∈ [0,1]. 0 ⇒ shrink everything to flat.
+        public let signalShare: Double
+    }
+
+    /// Shrink the given groups. Groups with `count < minCount` (default 1) are
+    /// dropped from the τ²/σ² estimation but still returned, shrunk fully to the
+    /// grand mean (we have no basis to trust them).
+    public static func shrink(_ groups: [Group], minCount: Int = 1) -> Result {
+        guard !groups.isEmpty else {
+            return Result(shrunkMeans: [], weights: [], grandMean: 0,
+                          betweenVar: 0, withinVar: 0, signalShare: 0)
+        }
+
+        let usable = groups.filter { $0.count >= max(1, minCount) }
+        let totalCount = usable.reduce(0) { $0 + $1.count }
+        // Count-weighted grand mean (the pooled center we shrink toward).
+        let grand: Double = totalCount > 0
+            ? usable.reduce(0.0) { $0 + Double($1.count) * $1.mean } / Double(totalCount)
+            : groups.reduce(0.0) { $0 + $1.mean } / Double(groups.count)
+
+        // Pooled within-group (per-observation) variance σ², weighted by (n−1).
+        let dof = usable.reduce(0) { $0 + max(0, $1.count - 1) }
+        let withinVar: Double = dof > 0
+            ? usable.reduce(0.0) { $0 + Double(max(0, $1.count - 1)) * $1.within } / Double(dof)
+            : (usable.map(\.within).reduce(0, +) / Double(max(1, usable.count)))
+
+        // Method-of-moments τ²: the observed spread of group means around the
+        // grand mean, minus the sampling variance that spread would have under
+        // pure noise. Clamp at 0 (no negative signal).
+        let k = usable.count
+        var betweenObserved = 0.0
+        var meanSamplingVar = 0.0
+        if k > 0 {
+            for g in usable {
+                betweenObserved += (g.mean - grand) * (g.mean - grand)
+                meanSamplingVar += withinVar / Double(max(1, g.count))
+            }
+            betweenObserved /= Double(k)        // variance of group means
+            meanSamplingVar /= Double(k)        // avg sampling variance of a group mean
+        }
+        let betweenVar = max(0, betweenObserved - meanSamplingVar)
+
+        // Per-group shrink weight and shrunk mean.
+        var shrunk: [Double] = []
+        var weights: [Double] = []
+        shrunk.reserveCapacity(groups.count)
+        weights.reserveCapacity(groups.count)
+        for g in groups {
+            let samplingVar = withinVar / Double(max(1, g.count))
+            let denom = betweenVar + samplingVar
+            // Untrusted (below minCount) or degenerate denom ⇒ full pool.
+            let w = (g.count >= max(1, minCount) && denom > 0) ? betweenVar / denom : 0
+            shrunk.append(grand + w * (g.mean - grand))
+            weights.append(w)
+        }
+
+        let signalShare = (betweenVar + withinVar) > 0 ? betweenVar / (betweenVar + withinVar) : 0
+        return Result(shrunkMeans: shrunk, weights: weights, grandMean: grand,
+                      betweenVar: betweenVar, withinVar: withinVar, signalShare: signalShare)
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/Estimate.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/Estimate.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The universal answer the prediction engine returns for any quantitative
+/// question — a point estimate carried together with its *honest uncertainty*.
+///
+/// The round-2 research verdict was blunt: on this kind of bursty, per-user
+/// data the point-accuracy lifts over a naive baseline are marginal, but a
+/// well-*calibrated* interval (the 80% band actually contains the truth ~80% of
+/// the time) is a real, defensible, net-new win. So every surface speaks in
+/// `Estimate`: a number, a band, which method produced it, how confident we are,
+/// and how much of the user's own history backs it. A view renders the band and
+/// can lean on it when the point is too early to trust — rather than showing a
+/// confident wrong number.
+///
+/// Value-agnostic: `value`/bounds are dollars for cost questions, percentage
+/// points for rate-limit utilisation, etc. The engine owns the meaning.
+public struct Estimate: Sendable, Equatable {
+
+    /// How much trust the point estimate has earned, driven by data sufficiency
+    /// and backtest support — not by the interval width.
+    public enum Confidence: String, Sendable, Equatable, Comparable, CaseIterable {
+        /// Not enough history to answer; callers should show the band (or a
+        /// "too early / not enough data yet" state) and suppress the point.
+        case insufficient
+        case low
+        case medium
+        case high
+
+        private var rank: Int { Self.allCases.firstIndex(of: self)! }
+        public static func < (a: Confidence, b: Confidence) -> Bool { a.rank < b.rank }
+    }
+
+    /// Point estimate (best single guess).
+    public let value: Double
+    /// ~80% predictive interval, when the method produces calibrated bands.
+    public let interval80: ClosedRange<Double>?
+    /// ~50% predictive interval (the "likely" range).
+    public let interval50: ClosedRange<Double>?
+    /// Stable id of the model/method that produced this (for logging + a
+    /// "projection method: …" affordance, and for the self-eval scoreboard).
+    public let method: String
+    public let confidence: Confidence
+    /// Number of historical cases (days/cycles/samples) backing the estimate —
+    /// the honest "how much do we actually know" counter.
+    public let support: Int
+    /// Optional human-readable caveat ("too early to project before noon",
+    /// "only 4 completed 7-day cycles so far").
+    public let note: String?
+
+    public init(
+        value: Double,
+        interval80: ClosedRange<Double>? = nil,
+        interval50: ClosedRange<Double>? = nil,
+        method: String,
+        confidence: Confidence,
+        support: Int,
+        note: String? = nil
+    ) {
+        self.value = value
+        self.interval80 = interval80
+        self.interval50 = interval50
+        self.method = method
+        self.confidence = confidence
+        self.support = support
+        self.note = note
+    }
+
+    /// The "we can't answer this yet" estimate — distinct from a confident zero.
+    /// Carries the reason so the UI can explain the empty state.
+    public static func insufficient(method: String, note: String, support: Int = 0) -> Estimate {
+        Estimate(value: .nan, interval80: nil, interval50: nil,
+                 method: method, confidence: .insufficient, support: support, note: note)
+    }
+
+    /// True when there isn't enough signal to show a point estimate.
+    public var isInsufficient: Bool { confidence == .insufficient || value.isNaN }
+}

--- a/PacerCore/Tests/PacerCoreTests/ForecastEnginePrimitivesTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ForecastEnginePrimitivesTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+/// Deterministic seeded RNG so the calibration-coverage tests are reproducible.
+private struct SplitMix64: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+private func gauss(_ rng: inout SplitMix64) -> Double {
+    // Box–Muller.
+    let u1 = max(1e-12, Double.random(in: 0..<1, using: &rng))
+    let u2 = Double.random(in: 0..<1, using: &rng)
+    return (-2 * log(u1)).squareRoot() * cos(2 * .pi * u2)
+}
+
+@Suite("Forecast engine primitives")
+struct ForecastEnginePrimitivesTests {
+
+    // MARK: - Estimate
+
+    @Test func insufficientEstimateIsDistinctFromZero() {
+        let e = Estimate.insufficient(method: "x", note: "too early")
+        #expect(e.isInsufficient)
+        #expect(e.confidence == .insufficient)
+        #expect(e.value.isNaN)
+        #expect(e.note == "too early")
+
+        let real = Estimate(value: 0, method: "y", confidence: .high, support: 30)
+        #expect(!real.isInsufficient)   // a confident zero is NOT "insufficient"
+    }
+
+    @Test func confidenceIsOrdered() {
+        #expect(Estimate.Confidence.insufficient < .low)
+        #expect(Estimate.Confidence.low < .medium)
+        #expect(Estimate.Confidence.medium < .high)
+        #expect(Estimate.Confidence.high > .insufficient)
+    }
+
+    // MARK: - ConformalCalibrator
+
+    @Test func quantileIsMonotonicAndRankAdjusted() {
+        let c = ConformalCalibrator(mode: .additive, residuals: Array(stride(from: 0.0, through: 100, by: 1)))
+        #expect(c.quantile(0.0) <= c.quantile(0.5))
+        #expect(c.quantile(0.5) <= c.quantile(1.0))
+        #expect(c.count == 101)
+        // Extremes saturate to the observed min/max, never beyond.
+        #expect(c.quantile(0.0) == 0)
+        #expect(c.quantile(1.0) == 100)
+    }
+
+    @Test func fromPairsMultiplicativeSkipsNonPositivePredictions() {
+        let c = ConformalCalibrator.fromPairs(
+            mode: .multiplicative,
+            predictions: [10, 0, -5, 20],
+            truths: [12, 5, 5, 22])
+        #expect(c.count == 2)   // the 0 and -5 predictions are dropped (ratio undefined)
+    }
+
+    @Test func tooFewResidualsYieldsNoBand() {
+        let c = ConformalCalibrator(mode: .additive, residuals: [1, 2, 3])
+        #expect(c.interval(around: 10, level: 0.8) == nil)
+    }
+
+    @Test func multiplicativeIntervalsAreCalibrated() {
+        // Calibration: truth/pred ratios ~ lognormal(0, 0.3). A fresh test set
+        // drawn from the same law should fall inside the 80% band ~80% of the time.
+        var rng = SplitMix64(seed: 42)
+        let cal = (0..<800).map { _ in exp(0.3 * gauss(&rng)) }
+        let c = ConformalCalibrator(mode: .multiplicative, residuals: cal)
+        let band = try! #require(c.interval(around: 100, level: 0.8))
+
+        var hit = 0, total = 0
+        for _ in 0..<4000 {
+            let truth = 100 * exp(0.3 * gauss(&rng))
+            if band.contains(truth) { hit += 1 }
+            total += 1
+        }
+        let coverage = Double(hit) / Double(total)
+        #expect(coverage > 0.75 && coverage < 0.87)   // ~0.80, conformal is mildly conservative
+    }
+
+    @Test func additiveIntervalsAreCalibrated() {
+        var rng = SplitMix64(seed: 7)
+        let cal = (0..<800).map { _ in 5.0 * gauss(&rng) }     // residuals ~ N(0, 5)
+        let c = ConformalCalibrator(mode: .additive, residuals: cal)
+        let band = try! #require(c.interval(around: 50, level: 0.8))
+
+        var hit = 0
+        for _ in 0..<4000 {
+            let truth = 50 + 5.0 * gauss(&rng)
+            if band.contains(truth) { hit += 1 }
+        }
+        #expect(Double(hit) / 4000 > 0.75 && Double(hit) / 4000 < 0.87)
+    }
+
+    // MARK: - EmpiricalBayes
+
+    @Test func noBetweenGroupSignalShrinksToFlat() {
+        // Group means differ by LESS than their sampling noise would produce →
+        // the estimator credits no real signal and pulls every cell to the grand
+        // mean. This is the "weekday carries no signal → ship flat" case.
+        let groups = [9.0, 11, 10, 8, 12].map {
+            EmpiricalBayes.Group(mean: $0, count: 4, within: 16)   // samplingVar 4 > spread 2
+        }
+        let r = EmpiricalBayes.shrink(groups)
+        #expect(r.betweenVar == 0)
+        #expect(r.signalShare < 0.01)
+        for m in r.shrunkMeans { #expect(abs(m - r.grandMean) < 1e-9) }
+        #expect(abs(r.grandMean - 10) < 1e-9)
+    }
+
+    @Test func strongSignalWithLargeNKeepsOwnMeans() {
+        let raw = [5.0, 50, 100]
+        let groups = raw.map { EmpiricalBayes.Group(mean: $0, count: 1000, within: 1) }
+        let r = EmpiricalBayes.shrink(groups)
+        #expect(r.signalShare > 0.9)
+        for (s, m) in zip(r.shrunkMeans, raw) { #expect(abs(s - m) < 1.0) }   // barely shrunk
+        for w in r.weights { #expect(w > 0.95) }
+    }
+
+    @Test func shrunkMeanLiesBetweenRawAndGrand() {
+        let groups = [EmpiricalBayes.Group(mean: 0, count: 4, within: 16),
+                      EmpiricalBayes.Group(mean: 20, count: 4, within: 16)]
+        let r = EmpiricalBayes.shrink(groups)
+        #expect(abs(r.grandMean - 10) < 1e-9)
+        // shrunk[0] in (0, 10), shrunk[1] in (10, 20), symmetric.
+        #expect(r.shrunkMeans[0] > 0 && r.shrunkMeans[0] < 10)
+        #expect(r.shrunkMeans[1] > 10 && r.shrunkMeans[1] < 20)
+        #expect(abs((r.shrunkMeans[0] - 10) + (r.shrunkMeans[1] - 10)) < 1e-9)
+        for w in r.weights { #expect(w >= 0 && w <= 1) }
+    }
+
+    @Test func untrustedThinCellsArePooledFully() {
+        // A high-count, distinct group establishes signal; a count-1 outlier cell
+        // below minCount is returned fully shrunk to the grand mean.
+        let groups = [EmpiricalBayes.Group(mean: 10, count: 200, within: 1),
+                      EmpiricalBayes.Group(mean: 12, count: 200, within: 1),
+                      EmpiricalBayes.Group(mean: 999, count: 1, within: 1)]
+        let r = EmpiricalBayes.shrink(groups, minCount: 2)
+        #expect(r.weights[2] == 0)                       // the n=1 cell gets no trust
+        #expect(abs(r.shrunkMeans[2] - r.grandMean) < 1e-9)
+    }
+}


### PR DESCRIPTION
First PR of the prediction-engine build (the pivot from per-card forecasting to a standalone on-device intelligence layer). Pure PacerCore foundations every later surface builds on.

## What
- **`Estimate`** — the universal typed answer: point + calibrated 80/50 intervals + method + confidence + support + note, with a distinct `.insufficient` state (vs a confident zero). This is the contract every future question returns.
- **`ConformalCalibrator`** — distribution-free predictive intervals from a model's own past out-of-sample residuals (multiplicative for cost, additive for rate-limit percentage-points), finite-sample `(n+1)` corrected. The round-2 research verdict was that a *calibrated band* is the real, defensible win on this bursty per-user data — not a marginal point-error lift.
- **`EmpiricalBayes`** — James–Stein shrinkage of per-regime cells toward the pooled mean (`w = τ²/(τ² + σ²/n)`, derived not tuned). The anti-overfit core: thin/noisy regime cells (a sparse weekday, an hour bucket) collapse to flat automatically when there's no between-group signal, so seasonal structure can ship from day one without an eligibility cliff and can't overfit when the signal isn't there.

## Tests
11 new deterministic tests including real **coverage** checks (the 80% conformal band contains ~80% of fresh draws) and the EB no-signal→flat / strong-signal→own-mean behaviors. Full suite green (395).

## Scope
Pure logic only — no store, no UI, no behavior change. `make install` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)