### PR TITLE
feat(intelligence): unified walk-forward harness — per-regime scoring + bootstrap CIs

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Engine/WalkForwardHarness.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/WalkForwardHarness.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// Honest, per-regime, walk-forward evaluation — the engine's self-evaluation
+/// core, and the fix for the single methodological flaw the round-2 audit
+/// caught: *pooled-across-cut medians are flattered by trivially-late cuts*
+/// (predicting the day total at 9pm when 100% of it is already observed is
+/// arithmetic, not forecasting), and different model harnesses quietly scored
+/// different case sets so their baselines disagreed.
+///
+/// `WalkForward` fixes both:
+/// - every candidate is scored on ONE identical case set per *bucket* (a
+///   cut-fraction × regime label like `cut=0.40|weekday`), so a baseline yields
+///   the same number everywhere and comparisons are apples-to-apples;
+/// - results are reported per bucket with a **bootstrap CI** on the median error
+///   and a **paired** model-vs-baseline delta — never a single pooled headline.
+///
+/// It's deliberately pure and value-typed: the same harness backtests at build
+/// time (synthetic), validates on the real store, and — once persisted outcomes
+/// accumulate — is what the live engine uses to pick the per-user winner. Seeded
+/// so every CI is reproducible.
+public enum WalkForward {
+
+    /// A walk-forward case: an input as it looked at a past cut-point, the
+    /// realized truth, and the bucket (cut × regime) it belongs to.
+    public struct Case: Sendable {
+        public let input: ForecastInput
+        public let truth: Double
+        public let bucket: String
+        public init(input: ForecastInput, truth: Double, bucket: String) {
+            self.input = input
+            self.truth = truth
+            self.bucket = bucket
+        }
+    }
+
+    /// One model's score within one bucket.
+    public struct Score: Sendable, Equatable {
+        public let modelId: String
+        public let bucket: String
+        public let medianAbsPctError: Double
+        public let meanAbsPctError: Double
+        /// Fraction of the bucket's cases the model produced a projection for.
+        public let coverage: Double
+        public let n: Int
+        /// Bootstrap 95% CI on the median absolute percentage error.
+        public let ciLow: Double
+        public let ciHigh: Double
+    }
+
+    /// A paired model-vs-baseline comparison within a bucket: both scored on the
+    /// identical cases each could project, so the delta is honest.
+    public struct Paired: Sendable, Equatable {
+        public let modelId: String
+        public let baselineId: String
+        public let bucket: String
+        /// median(modelAPE − baselineAPE) over shared cases. Negative ⇒ the model
+        /// beats the baseline.
+        public let medianDelta: Double
+        public let ciLow: Double
+        public let ciHigh: Double
+        /// Fraction of shared cases where the model was strictly closer to truth.
+        public let winFraction: Double
+        public let n: Int
+    }
+
+    // MARK: - Case construction
+
+    /// Build walk-forward cases from complete prior periods: for each period, at
+    /// each cut fraction, an input that has seen ONLY that period up to the cut
+    /// (with the periods before it as priors, so seasonal methods have history),
+    /// truth = the period's realized total. `regime` tags each case so the
+    /// harness can break results out by weekday/weekend, active/quiet, etc.
+    public static func cases(
+        periods: [ForecastInput.PriorPeriod],
+        periodEnd: (ForecastInput.PriorPeriod) -> Date,
+        cutFractions: [Double],
+        calendar: Calendar = .current,
+        regime: (ForecastInput) -> String = { _ in "all" }
+    ) -> [Case] {
+        var out: [Case] = []
+        for (i, period) in periods.enumerated() {
+            let truth = period.total
+            guard truth > 0 else { continue }
+            let priors = Array(periods[0..<i])
+            let end = periodEnd(period)
+            let span = end.timeIntervalSince(period.start)
+            guard span > 0 else { continue }
+            for cf in cutFractions {
+                let now = period.start.addingTimeInterval(span * cf)
+                let elapsed = period.points.filter { $0.at <= now }
+                guard !elapsed.isEmpty else { continue }
+                let input = ForecastInput(
+                    now: now, periodStart: period.start, periodEnd: end,
+                    calendar: calendar, elapsed: elapsed, priorPeriods: priors)
+                out.append(Case(input: input, truth: truth,
+                                bucket: "cut=\(String(format: "%.2f", cf))|\(regime(input))"))
+            }
+        }
+        return out
+    }
+
+    // MARK: - Scoring
+
+    /// Score every model on every bucket, on the bucket's identical case set,
+    /// with a bootstrap CI on each median error. Sorted by (bucket, error).
+    public static func score(
+        models: [any Forecaster],
+        cases: [Case],
+        bootstrap: Int = 1000,
+        seed: UInt64 = 0x5EED
+    ) -> [Score] {
+        let byBucket = Dictionary(grouping: cases, by: { $0.bucket })
+        var rng = SplitMix64(seed: seed)
+        var scores: [Score] = []
+        for (bucket, bucketCases) in byBucket {
+            for model in models {
+                var apes: [Double] = []
+                for c in bucketCases {
+                    guard c.truth > 0, let p = model.projectTotal(c.input) else { continue }
+                    apes.append(abs(p - c.truth) / c.truth * 100)
+                }
+                let coverage = bucketCases.isEmpty ? 0 : Double(apes.count) / Double(bucketCases.count)
+                let (lo, hi) = bootstrapMedianCI(apes, iterations: bootstrap, rng: &rng)
+                scores.append(Score(
+                    modelId: model.id, bucket: bucket,
+                    medianAbsPctError: median(apes),
+                    meanAbsPctError: apes.isEmpty ? .infinity : apes.reduce(0, +) / Double(apes.count),
+                    coverage: coverage, n: apes.count, ciLow: lo, ciHigh: hi))
+            }
+        }
+        return scores.sorted { ($0.bucket, $0.medianAbsPctError) < ($1.bucket, $1.medianAbsPctError) }
+    }
+
+    /// Paired model-vs-baseline comparison per bucket on shared cases.
+    public static func paired(
+        model: any Forecaster,
+        baseline: any Forecaster,
+        cases: [Case],
+        bootstrap: Int = 1000,
+        seed: UInt64 = 0x5EED
+    ) -> [Paired] {
+        let byBucket = Dictionary(grouping: cases, by: { $0.bucket })
+        var rng = SplitMix64(seed: seed)
+        var out: [Paired] = []
+        for (bucket, bucketCases) in byBucket {
+            var deltas: [Double] = []
+            var wins = 0
+            for c in bucketCases {
+                guard c.truth > 0,
+                      let pm = model.projectTotal(c.input),
+                      let pb = baseline.projectTotal(c.input) else { continue }
+                let am = abs(pm - c.truth) / c.truth * 100
+                let ab = abs(pb - c.truth) / c.truth * 100
+                deltas.append(am - ab)
+                if am < ab { wins += 1 }
+            }
+            guard !deltas.isEmpty else { continue }
+            let (lo, hi) = bootstrapMedianCI(deltas, iterations: bootstrap, rng: &rng)
+            out.append(Paired(
+                modelId: model.id, baselineId: baseline.id, bucket: bucket,
+                medianDelta: median(deltas), ciLow: lo, ciHigh: hi,
+                winFraction: Double(wins) / Double(deltas.count), n: deltas.count))
+        }
+        return out.sorted { $0.bucket < $1.bucket }
+    }
+
+    // MARK: - Stats
+
+    static func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return .infinity }
+        let s = xs.sorted(); let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+
+    /// Percentile bootstrap 95% CI on the median. Returns (median, median) when
+    /// there's too little data to resample meaningfully.
+    static func bootstrapMedianCI(_ xs: [Double], iterations: Int, rng: inout SplitMix64) -> (Double, Double) {
+        guard xs.count >= 2, iterations > 0 else {
+            let m = median(xs); return (m, m)
+        }
+        var meds: [Double] = []
+        meds.reserveCapacity(iterations)
+        let n = xs.count
+        for _ in 0..<iterations {
+            var sample: [Double] = []
+            sample.reserveCapacity(n)
+            for _ in 0..<n {
+                sample.append(xs[Int(rng.next() % UInt64(n))])
+            }
+            meds.append(median(sample))
+        }
+        meds.sort()
+        let lo = meds[Int(0.025 * Double(iterations))]
+        let hi = meds[min(iterations - 1, Int(0.975 * Double(iterations)))]
+        return (lo, hi)
+    }
+}
+
+/// Deterministic SplitMix64 — reproducible bootstraps (no global RNG, no
+/// per-run drift). Internal to the engine.
+struct SplitMix64: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/WalkForwardHarnessTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/WalkForwardHarnessTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Walk-forward harness")
+struct WalkForwardHarnessTests {
+
+    private var utc: Calendar { var c = Calendar(identifier: .gregorian); c.timeZone = TimeZone(identifier: "UTC")!; return c }
+    private func day(_ ymd: String, _ h: Int = 0) -> Date {
+        let p = ymd.split(separator: "-").compactMap { Int($0) }
+        var dc = DateComponents(); dc.year = p[0]; dc.month = p[1]; dc.day = p[2]; dc.hour = h
+        return utc.date(from: dc)!
+    }
+    private func input(now: Date, soFar: Double) -> ForecastInput {
+        ForecastInput(now: now, periodStart: day("2026-05-10"), periodEnd: day("2026-05-11"),
+                      calendar: utc, elapsed: [.init(at: now, cumulative: soFar)], priorPeriods: [])
+    }
+
+    // Synthetic forecasters with deterministic output.
+    private struct Constant: Forecaster { let id: String; let v: Double; let complexity = 0
+        func projectTotal(_ i: ForecastInput) -> Double? { v } }
+    private struct NilModel: Forecaster { let id = "nil"; let complexity = 0
+        func projectTotal(_ i: ForecastInput) -> Double? { nil } }
+
+    // MARK: - per-bucket isolation
+
+    @Test func scoresEachBucketOnItsOwnCases() {
+        let inA = input(now: day("2026-05-10", 12), soFar: 50)
+        let inB = input(now: day("2026-05-10", 12), soFar: 50)
+        // Bucket A: truth 100 (Constant(100) is perfect). Bucket B: truth 200 (Constant 50% low).
+        let cases = (0..<10).map { _ in WalkForward.Case(input: inA, truth: 100, bucket: "A") }
+                  + (0..<10).map { _ in WalkForward.Case(input: inB, truth: 200, bucket: "B") }
+        let scores = WalkForward.score(models: [Constant(id: "c100", v: 100)], cases: cases)
+        let a = scores.first { $0.bucket == "A" }!
+        let b = scores.first { $0.bucket == "B" }!
+        #expect(a.medianAbsPctError == 0)        // 100 vs truth 100
+        #expect(abs(b.medianAbsPctError - 50) < 1e-9)   // 100 vs truth 200
+        #expect(a.n == 10 && b.n == 10)
+        #expect(a.coverage == 1.0)
+    }
+
+    @Test func identicalErrorsGiveDegenerateCI() {
+        let inp = input(now: day("2026-05-10", 12), soFar: 50)
+        let cases = (0..<12).map { _ in WalkForward.Case(input: inp, truth: 100, bucket: "A") }
+        let s = WalkForward.score(models: [Constant(id: "c", v: 120)], cases: cases).first!
+        #expect(abs(s.medianAbsPctError - 20) < 1e-9)
+        #expect(abs(s.ciLow - 20) < 1e-9 && abs(s.ciHigh - 20) < 1e-9)  // no spread → tight CI
+    }
+
+    @Test func ciBracketsMedianWithSpread() {
+        // Two distinct truths in one bucket → spread of APEs → CI brackets median.
+        let inp = input(now: day("2026-05-10", 12), soFar: 50)
+        let cases = (0..<15).map { WalkForward.Case(input: inp, truth: $0 % 2 == 0 ? 100 : 150, bucket: "A") }
+        let s = WalkForward.score(models: [Constant(id: "c", v: 100)], cases: cases, bootstrap: 2000).first!
+        #expect(s.ciLow <= s.medianAbsPctError + 1e-9)
+        #expect(s.ciHigh >= s.medianAbsPctError - 1e-9)
+        #expect(s.ciLow < s.ciHigh)   // genuine spread
+    }
+
+    @Test func coverageDropsWhenModelDeclines() {
+        let inp = input(now: day("2026-05-10", 12), soFar: 50)
+        let cases = (0..<10).map { _ in WalkForward.Case(input: inp, truth: 100, bucket: "A") }
+        let s = WalkForward.score(models: [NilModel()], cases: cases).first!
+        #expect(s.coverage == 0)
+        #expect(s.n == 0)
+    }
+
+    // MARK: - paired
+
+    @Test func pairedFavoursTheCloserModel() {
+        let inp = input(now: day("2026-05-10", 12), soFar: 50)
+        let cases = (0..<10).map { _ in WalkForward.Case(input: inp, truth: 100, bucket: "A") }
+        // model 105 (5% off) vs baseline 130 (30% off): model strictly closer everywhere.
+        let p = WalkForward.paired(model: Constant(id: "m", v: 105),
+                                   baseline: Constant(id: "b", v: 130), cases: cases).first!
+        #expect(p.winFraction == 1.0)
+        #expect(p.medianDelta < 0)          // model APE − baseline APE < 0 ⇒ model better
+        #expect(p.ciHigh < 0)               // CI entirely below zero ⇒ decisive
+        #expect(p.n == 10)
+    }
+
+    // MARK: - case builder
+
+    @Test func caseBuilderTagsCutAndRegimeAndRespectsHistory() {
+        // Two prior "days", each a flat cumulative ramp to a known total.
+        func ramp(_ ymd: String, total: Double) -> ForecastInput.PriorPeriod {
+            var cum = 0.0
+            let pts = (0..<24).map { h -> ForecastInput.Point in
+                cum += total / 24
+                return .init(at: day(ymd, h).addingTimeInterval(3599), cumulative: cum)
+            }
+            return .init(start: day(ymd), points: pts)
+        }
+        let periods = [ramp("2026-05-01", total: 90), ramp("2026-05-02", total: 120)]
+        let cases = WalkForward.cases(
+            periods: periods,
+            periodEnd: { $0.start.addingTimeInterval(86400) },
+            cutFractions: [0.5],
+            calendar: utc,
+            regime: { self.utc.component(.day, from: $0.periodStart) == 1 ? "first" : "second" })
+
+        #expect(cases.count == 2)   // one cut per period
+        #expect(cases.contains { $0.bucket == "cut=0.50|first" })
+        #expect(cases.contains { $0.bucket == "cut=0.50|second" })
+        // Truth = each period's realized total.
+        let first = cases.first { $0.bucket.hasSuffix("first") }!
+        #expect(abs(first.truth - 90) < 1e-6)
+        // The earliest period sees no priors; the second sees one.
+        #expect(first.input.priorPeriods.isEmpty)
+        let second = cases.first { $0.bucket.hasSuffix("second") }!
+        #expect(second.input.priorPeriods.count == 1)
+        // At cut 0.5 (noon), ~half the ramp is observed.
+        #expect(abs(first.input.soFar - 45) < 90.0 / 24)
+    }
+}


### PR DESCRIPTION
PR2 of the prediction-engine build. The engine's self-evaluation core — and the fix for the one methodological flaw the round-2 research audit flagged.

## Why
Round-2 headlines were flattered two ways: **pooled-across-cut medians** mixed in trivially-late cuts (predicting the day's total at 9pm, when ~100% is already observed, is arithmetic — not forecasting), and **different model harnesses scored different case sets**, so the same baseline read 65% in one and 50% in another and "lifts" weren't apples-to-apples.

## What
`WalkForward`:
- scores **every candidate on ONE identical case set per bucket** (`cut-fraction × regime`, e.g. `cut=0.40|weekday`), so a baseline yields the same number everywhere;
- reports per-bucket median error with a **seeded bootstrap 95% CI**, plus a **paired** model-vs-baseline delta + win-fraction on shared cases;
- never emits a single pooled headline;
- includes a generic **walk-forward case builder** (prior periods → cut-point inputs that see only the past, tagged by a caller-supplied regime classifier).

Pure and value-typed, so the same harness backtests synthetically at build time, validates on the real store, and — once persisted outcomes accumulate — is what the live engine uses to pick the per-user winner. Deterministic `SplitMix64` ⇒ reproducible CIs.

## Tests
6 new: per-bucket isolation, degenerate-vs-spread CI behavior, coverage on declines, paired comparison decisiveness, and the case builder's cut/regime tagging + history-respecting priors. Suite green (401). The first real model (PR3) drives this harness on the real store to reproduce the round-2 numbers in Swift.

## Scope
Pure logic; no store, no UI. `make install` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)