### PR TITLE
feat(intelligence): usage norms — typical-range bands, anomaly, pace-vs-norm

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageNorms.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageNorms.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// "What's normal for this user" — typical-range bands, anomaly flags, and a
+/// pace-vs-norm signal. Greenfield (the app ships no norms today); the round-2
+/// research made these the cleanest, best-calibrated wins.
+///
+/// Everything is computed in **log space**, because cost is heavy-right-tailed:
+/// in dollars even a huge day is barely an outlier while the many quiet days look
+/// extreme, so a naive z-score flags the wrong thing. In log space the tail
+/// compresses, and the honest finding holds — for this user the anomalies are
+/// *lulls, not spikes* (a dead Saturday stands out, a busy day doesn't).
+///
+/// Two anti-overfit defences carried from the research: bucket bands shrink their
+/// spread toward the pooled spread by sample count (a 2-sample bucket can't show
+/// a false-narrow band), and per-bucket *means* are empirical-Bayes-shrunk via
+/// `EmpiricalBayes`. Robust statistics (median / MAD) throughout so a single
+/// spike doesn't define "normal".
+public enum UsageNorms {
+
+    public enum Verdict: String, Sendable, Equatable { case lull, normal, spike }
+
+    /// A typical-range for one bucket (a weekday, an hour-of-day, a weekday×hour
+    /// cell): the central estimate plus the inner 50% and 80% ranges.
+    public struct Band: Sendable, Equatable {
+        public let typical: Double                 // robust central (median in log space)
+        public let range50: ClosedRange<Double>
+        public let range80: ClosedRange<Double>
+        public let count: Int
+    }
+
+    /// Floor so `$0` days have a finite log (and become "very low", not −∞).
+    static let logFloor = 0.01
+
+    // MARK: - Typical-range bands
+
+    /// EB-shrunk typical-range bands per bucket from labeled samples. Bucket means
+    /// are James–Stein-shrunk toward the pooled mean; bucket spreads are shrunk
+    /// toward the pooled spread by `(n−1)/((n−1)+varPseudocount)` so thin buckets
+    /// inherit a sane width instead of a falsely-tight one.
+    public static func bands(_ samples: [(key: String, value: Double)],
+                             varPseudocount: Double = 3) -> [String: Band] {
+        let groups = Dictionary(grouping: samples, by: { $0.key })
+        guard !groups.isEmpty else { return [:] }
+
+        var keys: [String] = []
+        var ebGroups: [EmpiricalBayes.Group] = []
+        var cellVar: [String: Double] = [:]
+        var cellN: [String: Int] = [:]
+        for (k, rows) in groups {
+            let logs = rows.map { logCost($0.value) }
+            keys.append(k)
+            ebGroups.append(.init(mean: mean(logs), count: logs.count, within: variance(logs)))
+            cellVar[k] = variance(logs)
+            cellN[k] = logs.count
+        }
+        let shr = EmpiricalBayes.shrink(ebGroups)
+        let pooledVar = shr.withinVar
+
+        var out: [String: Band] = [:]
+        for (i, k) in keys.enumerated() {
+            let mu = shr.shrunkMeans[i]
+            let n = cellN[k] ?? 0
+            let wv = Double(max(0, n - 1)) / (Double(max(0, n - 1)) + varPseudocount)
+            let sd = (wv * (cellVar[k] ?? 0) + (1 - wv) * pooledVar).squareRoot()
+            func band(_ z: Double) -> ClosedRange<Double> { exp(mu - z * sd)...exp(mu + z * sd) }
+            out[k] = Band(typical: exp(mu), range50: band(0.6745), range80: band(1.2816), count: n)
+        }
+        return out
+    }
+
+    // MARK: - Anomaly
+
+    /// Robust z-score of `value` against a baseline, in log space: how many
+    /// median-absolute-deviations from the baseline median. Negative = unusually
+    /// low (a lull), positive = unusually high (a spike). 0 when the baseline is
+    /// too small to judge (`< minBaseline`) — the engine's warm-up gate.
+    public static func anomalyZ(value: Double, baseline: [Double], minBaseline: Int = 14) -> Double {
+        guard baseline.count >= minBaseline else { return 0 }
+        let logs = baseline.map { logCost($0) }
+        let med = median(logs)
+        let mad = median(logs.map { abs($0 - med) })
+        let scale = mad > 0 ? 1.4826 * mad : standardDeviation(logs)
+        guard scale > 0 else { return 0 }
+        return (logCost(value) - med) / scale
+    }
+
+    public static func classify(z: Double, threshold: Double = 3) -> Verdict {
+        if z <= -threshold { return .lull }
+        if z >= threshold { return .spike }
+        return .normal
+    }
+
+    // MARK: - Pace vs norm
+
+    /// Where `value` sits in the baseline distribution, as a percentile rank in
+    /// [0,1]. 0.5 = right at the personal median, 0.9 = higher than 90% of
+    /// comparable periods ("running hot"). `nil` when the baseline is empty.
+    public static func paceRank(value: Double, baseline: [Double]) -> Double? {
+        guard !baseline.isEmpty else { return nil }
+        let below = baseline.reduce(0) { $0 + ($1 < value ? 1 : 0) }
+        return Double(below) / Double(baseline.count)
+    }
+
+    // MARK: - Stats
+
+    static func logCost(_ v: Double) -> Double { Foundation.log(max(v, logFloor)) }
+    static func mean(_ xs: [Double]) -> Double { xs.isEmpty ? 0 : xs.reduce(0, +) / Double(xs.count) }
+    static func variance(_ xs: [Double]) -> Double {
+        guard xs.count > 1 else { return 0 }
+        let m = mean(xs)
+        return xs.reduce(0) { $0 + ($1 - m) * ($1 - m) } / Double(xs.count - 1)
+    }
+    static func standardDeviation(_ xs: [Double]) -> Double { variance(xs).squareRoot() }
+    static func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return 0 }
+        let s = xs.sorted(); let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/UsageNormsTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/UsageNormsTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Usage norms")
+struct UsageNormsTests {
+
+    private func gauss(_ rng: inout SplitMix64) -> Double {
+        let u1 = max(1e-12, Double.random(in: 0..<1, using: &rng))
+        let u2 = Double.random(in: 0..<1, using: &rng)
+        return (-2 * log(u1)).squareRoot() * cos(2 * .pi * u2)
+    }
+
+    @Test func bandsAreCalibrated() {
+        // Per-key lognormal samples; the 80% band should contain ~80% of fresh draws.
+        var rng = SplitMix64(seed: 11)
+        let mus = ["a": 3.0, "b": 4.5, "c": 5.5]
+        var samples: [(key: String, value: Double)] = []
+        for (k, mu) in mus {
+            for _ in 0..<200 { samples.append((k, exp(mu + 0.4 * gauss(&rng)))) }
+        }
+        let bands = UsageNorms.bands(samples)
+        var hit = 0, total = 0
+        for (k, mu) in mus {
+            let b = bands[k]!
+            for _ in 0..<1500 {
+                let v = exp(mu + 0.4 * gauss(&rng))
+                if b.range80.contains(v) { hit += 1 }
+                total += 1
+            }
+        }
+        let coverage = Double(hit) / Double(total)
+        #expect(coverage > 0.74 && coverage < 0.86)
+    }
+
+    @Test func thinBucketGetsAShrunkenNotDegenerateBand() {
+        // One rich, varied bucket establishes a pooled spread; a 2-sample bucket
+        // whose values happen identical must NOT show a zero-width band.
+        var samples: [(key: String, value: Double)] = []
+        for i in 0..<50 { samples.append(("rich", 100 + Double(i) * 5)) }
+        samples.append(("thin", 100)); samples.append(("thin", 100))
+        let bands = UsageNorms.bands(samples)
+        let thin = bands["thin"]!
+        #expect(thin.count == 2)
+        #expect(thin.range80.lowerBound < thin.range80.upperBound)   // not degenerate
+        // EB pulls the thin bucket's central estimate toward the pooled mean (it
+        // can't trust 2 samples) — above its raw 100, but not all the way to the
+        // rich bucket's typical.
+        #expect(thin.typical > 100)
+        #expect(thin.typical < bands["rich"]!.typical)
+    }
+
+    @Test func anomalyFlagsLullsAndSpikesWithWarmup() {
+        let baseline = (0..<30).map { 100.0 + Double($0 % 7) * 20 }   // ~100–220, stable
+        let lullZ = UsageNorms.anomalyZ(value: 3, baseline: baseline)
+        let spikeZ = UsageNorms.anomalyZ(value: 5000, baseline: baseline)
+        #expect(lullZ < -3)
+        #expect(spikeZ > 3)
+        #expect(UsageNorms.classify(z: lullZ) == .lull)
+        #expect(UsageNorms.classify(z: spikeZ) == .spike)
+        #expect(UsageNorms.classify(z: 0.5) == .normal)
+        // Warm-up: too few baseline points → no judgement (z = 0).
+        #expect(UsageNorms.anomalyZ(value: 3, baseline: [100, 120, 90]) == 0)
+    }
+
+    @Test func anomaliesAreLullsNotSpikesOnSkewedData() {
+        // Heavy-right-tailed cost: in log space a quiet day is more anomalous than
+        // even the biggest day — the real finding for this user.
+        var base = (0..<28).map { 50.0 + Double($0 % 10) * 25 }   // $50–$275
+        base.append(1400)                                         // one huge day
+        let quietZ = UsageNorms.anomalyZ(value: 4, baseline: base)
+        let hugeZ = UsageNorms.anomalyZ(value: 1400, baseline: base)
+        #expect(abs(quietZ) > abs(hugeZ))                         // the lull stands out more
+        #expect(UsageNorms.classify(z: quietZ) == .lull)
+    }
+
+    @Test func paceRankIsMonotone() {
+        let base = (1...100).map { Double($0) }
+        let low = UsageNorms.paceRank(value: 10, baseline: base)!
+        let mid = UsageNorms.paceRank(value: 50, baseline: base)!
+        let high = UsageNorms.paceRank(value: 95, baseline: base)!
+        #expect(low < mid && mid < high)
+        #expect(abs(mid - 0.5) < 0.05)
+        #expect(UsageNorms.paceRank(value: 1, baseline: []) == nil)
+    }
+}


### PR DESCRIPTION
PR5 — the greenfield "what's normal for this user" surface, which round-2 found to be the cleanest, best-calibrated win (cov80 0.845 on real data).

## What `UsageNorms` provides
- **`bands(_:)`** — EB-shrunk typical-range bands per bucket (weekday, hour-of-day, weekday×hour). Bucket *means* are James–Stein-shrunk toward the pooled mean; bucket *spreads* are shrunk toward the pooled spread by `(n−1)/((n−1)+k)`, so a 2-sample bucket inherits a sane width instead of a falsely-tight one.
- **`anomalyZ` / `classify`** — robust z-score (median/MAD) with a warm-up gate, flagging `lull` / `normal` / `spike`.
- **`paceRank`** — where a partial period sits in the personal distribution (0.9 = "running hot").

Everything is computed in **log space**, because cost is heavy-right-tailed: in dollars even a huge day barely registers while quiet days look extreme, so a naive z flags the wrong thing. In log space the tail compresses and the real finding holds — for this user the anomalies are **lulls, not spikes**.

## Tests
5 synthetic, including an 80%-band **coverage** check (~0.80 on fresh draws), the thin-bucket shrinkage behavior, the warm-up gate, and the lulls-not-spikes property on skewed data. Suite green (416). Pure logic; no store/UI. `make install` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)