### PR TITLE
feat(intelligence): engine actor — owns the store, typed question→Estimate API

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -36,6 +36,21 @@ final class AppBackgroundService {
     /// the whole point is to tell the user limits reset early while they
     /// weren't looking.
     private var globalResetObserver: NSObjectProtocol?
+    /// The on-device usage-intelligence engine. Owns its own `ModelContext`,
+    /// rebuilds the per-user feature representation and refits its models on
+    /// each scan tick, and answers the typed `EngineQuestion` → `Estimate`
+    /// contract views call. Lives here so it's warmed headless (a view that
+    /// opens later gets an already-fitted engine), and so it shares the one
+    /// container the rest of the process uses.
+    private var engine: UsageIntelligenceEngine?
+    /// Observer for `.pacerScanCycleDidComplete` that drives `engine.recompute`.
+    private var engineRecomputeObserver: NSObjectProtocol?
+    /// Coalesce engine recomputes — the JSONL scan path posts `samplesChanged`
+    /// many times a minute, and refitting is cheap but not free, so we refit at
+    /// most this often. The next scan after the interval picks up everything
+    /// missed in between (the engine reads the whole store, not a delta).
+    private static let engineRecomputeMinInterval: TimeInterval = 20
+    private var lastEngineRecomputeAt: Date?
     /// Bridges `pacerScanCycleDidComplete` notifications to per-kind
     /// `WidgetCenter.reloadTimelines` calls so the WidgetKit extension
     /// — which can't observe SwiftData — refreshes when new data
@@ -95,6 +110,7 @@ final class AppBackgroundService {
 
         installImmediateScanObserver()
         installGlobalResetObserver()
+        startEngine()
         widgetRefreshCoordinator.start()
         startPricingRefreshTask()
         startHistoryPruneTask()
@@ -117,6 +133,12 @@ final class AppBackgroundService {
             NotificationCenter.default.removeObserver(observer)
             globalResetObserver = nil
         }
+        if let observer = engineRecomputeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            engineRecomputeObserver = nil
+        }
+        engine = nil
+        lastEngineRecomputeAt = nil
         widgetRefreshCoordinator.stop()
         pricingRefreshTask?.cancel()
         pricingRefreshTask = nil
@@ -298,6 +320,43 @@ final class AppBackgroundService {
                 // Score any rate-limit cycles that finished since last scan,
                 // feeding the self-improving model scoreboard. Idempotent.
                 ForecastOutcomeRecorder.record(in: ModelContext(self.container))
+            }
+        }
+    }
+
+    // MARK: - Intelligence engine
+
+    /// Create the engine on the shared container and warm it once, then keep it
+    /// fresh by recomputing (throttled) whenever a scan cycle reports new cost
+    /// or rate-limit data. The initial recompute matters because a quiet launch
+    /// (no new samples) posts no `samplesChanged`, so without it a freshly
+    /// opened view would see an unwarmed engine until the next real change.
+    private func startEngine() {
+        guard engine == nil else { return }
+        let engine = UsageIntelligenceEngine(modelContainer: container)
+        self.engine = engine
+        Task { await engine.recompute(now: Date()) }
+        installEngineRecomputeObserver()
+    }
+
+    private func installEngineRecomputeObserver() {
+        engineRecomputeObserver = NotificationCenter.default.addObserver(
+            forName: .pacerScanCycleDidComplete,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            // Recompute on either cost (`samplesChanged`) or rate-limit data,
+            // since the engine answers both cost and rate-limit questions.
+            let summary = note.object as? ScanCycleSummary
+            let relevant = (summary?.samplesChanged ?? false) || (summary?.rateLimitsChanged ?? false)
+            guard relevant else { return }
+            Task { @MainActor [weak self] in
+                guard let self, let engine = self.engine else { return }
+                let now = Date()
+                if let last = self.lastEngineRecomputeAt,
+                   now.timeIntervalSince(last) < Self.engineRecomputeMinInterval { return }
+                self.lastEngineRecomputeAt = now
+                await engine.recompute(now: now)
             }
         }
     }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineFeatures.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineFeatures.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// The engine's immutable per-user feature representation — everything the
+/// fitted models read, built once per scan tick from the whole store so the
+/// typed `answer(_:)` API never touches SwiftData on the read path.
+///
+/// It is deliberately split from the actor: `build` is a *pure* function over
+/// plain value rows (not `@Model` objects), so the whole feature pipeline —
+/// the cumulative-by-hour series, the diurnal activity grid, the rate-limit
+/// segmentation — unit-tests without a `ModelContainer`, and the same builder
+/// runs against the research CSVs to validate on the real store.
+///
+/// The one genuinely new signal here is the **activity grid**: a `[7][24]`
+/// `P(active)` diurnal shape (probability that a given weekday×hour has *any*
+/// token arrival), measured over complete prior days. It feeds two things the
+/// earlier PRs deferred for lack of a live feature stream: the empirical-Bayes
+/// *prior* that `DiurnalBurnModel` shrinks thin per-cell rates toward, and the
+/// end-of-day **idle/done gate** (don't scale a near-zero quiet day up by a
+/// back-loaded weekday shape when the rest of the day is typically idle).
+struct EngineFeatures: Sendable {
+
+    let now: Date
+    let calendar: Calendar
+    /// Local start-of-day for `now`.
+    let todayStart: Date
+
+    /// `yyyy-MM-dd` → realized cost, for every day that had spend (gaps are
+    /// absent — callers that need a zero-filled grid walk the calendar). The
+    /// authoritative repriced daily cost, summed across models.
+    let dailyCosts: [String: Double]
+
+    /// Prior *complete* days as cumulative-by-hour `Point` series (oldest →
+    /// newest), for the end-of-day shape and its conformal calibration. Capped
+    /// to a recent window so old behaviour doesn't anchor the shape.
+    let dailyPeriods: [ForecastInput.PriorPeriod]
+
+    /// Today's cumulative-cost series so far (last point at `now`).
+    let todayElapsed: [ForecastInput.Point]
+
+    /// Rate-limit utilisation samples per window key (`five_hour`/`seven_day`),
+    /// as the `(at, usedPercentage, resetsAt)` tuples `BurnTrajectory.segment`
+    /// consumes. Only rows with a known reset are kept.
+    let rateLimit: [String: [(at: Date, usedPercentage: Double, resetsAt: Date)]]
+
+    /// `[weekday 0=Sun…6=Sat][hour 0…23]` probability that the cell has any
+    /// token arrival, over complete prior days. Unit-meanable shape for the
+    /// diurnal prior; `remainingActivityShare` reads it for the idle gate.
+    let activityGrid: [[Double]]
+
+    /// Wall-clock of the most recent token arrival — the idle gate's "have we
+    /// gone quiet?" signal. `nil` when there's been no activity at all.
+    let lastArrivalAt: Date?
+
+    // MARK: - Plain input rows (so `build` is SwiftData-free and testable)
+
+    struct DailyRow: Sendable { let date: String; let cost: Double }
+    struct HourlyRow: Sendable { let date: String; let hour: Int; let cost: Double; let sampleCount: Int }
+    struct RateRow: Sendable { let window: String; let at: Date; let usedPercentage: Double; let resetsAt: Date? }
+
+    /// Build the feature snapshot from store rows. Pure — no I/O, no clock
+    /// reads beyond the passed `now`.
+    static func build(
+        now: Date,
+        calendar: Calendar,
+        daily: [DailyRow],
+        hourly: [HourlyRow],
+        rate: [RateRow],
+        lastArrivalAt: Date?,
+        eodPriorDays: Int = 60
+    ) -> EngineFeatures {
+        let todayStart = calendar.startOfDay(for: now)
+        let todayKey = TokenSample.formatDate(now, timeZone: calendar.timeZone)
+
+        // Daily costs summed across models.
+        var dailyCosts: [String: Double] = [:]
+        for r in daily { dailyCosts[r.date, default: 0] += r.cost }
+
+        // Hourly costs summed across models, indexed by (date, hour).
+        var hourCost: [String: [Double]] = [:]    // date → [24] cost
+        for r in hourly where r.hour >= 0 && r.hour < 24 && (r.cost > 0 || r.sampleCount > 0) {
+            hourCost[r.date, default: [Double](repeating: 0, count: 24)][r.hour] += r.cost
+        }
+
+        // Prior complete days as cumulative-by-hour Point series.
+        let priorKeys = hourCost.keys.filter { $0 < todayKey }.sorted()
+        let kept = priorKeys.suffix(max(0, eodPriorDays))
+        var dailyPeriods: [ForecastInput.PriorPeriod] = []
+        for key in kept {
+            guard let start = parseDay(key, calendar: calendar),
+                  let pts = cumulativePoints(hourCost[key]!, dayStart: start, cap: nil) else { continue }
+            dailyPeriods.append(.init(start: start, points: pts))
+        }
+
+        // Today so far — last point pinned to `now`.
+        let nowHour = calendar.component(.hour, from: now)
+        var todayElapsed: [ForecastInput.Point] = []
+        if let todayHours = hourCost[todayKey] {
+            todayElapsed = cumulativePoints(todayHours, dayStart: todayStart, cap: nowHour, lastAt: now) ?? []
+        }
+
+        // Diurnal P(active) grid over complete prior days (idle days counted in
+        // the denominator — a quiet Saturday lowers weekend activity).
+        let activityGrid = buildActivityGrid(hourCost: hourCost, dailyCosts: dailyCosts,
+                                             todayKey: todayKey, calendar: calendar)
+
+        // Rate-limit tuples per window.
+        var rateLimit: [String: [(at: Date, usedPercentage: Double, resetsAt: Date)]] = [:]
+        for r in rate {
+            guard let resets = r.resetsAt else { continue }
+            rateLimit[r.window, default: []].append((r.at, r.usedPercentage, resets))
+        }
+        for k in rateLimit.keys { rateLimit[k]?.sort { $0.at < $1.at } }
+
+        return EngineFeatures(
+            now: now, calendar: calendar, todayStart: todayStart,
+            dailyCosts: dailyCosts, dailyPeriods: dailyPeriods, todayElapsed: todayElapsed,
+            rateLimit: rateLimit, activityGrid: activityGrid, lastArrivalAt: lastArrivalAt)
+    }
+
+    // MARK: - Idle gate
+
+    /// Share of a weekday's typical daily activity that lands *after* `hour`,
+    /// from the activity grid. ~0 means the rest of the day is normally idle;
+    /// 1 (the safe default) when the grid can't judge, so the gate never fires
+    /// on no information.
+    static func remainingActivityShare(_ grid: [[Double]], weekday: Int, afterHour hour: Int) -> Double {
+        guard grid.indices.contains(weekday) else { return 1 }
+        let row = grid[weekday]
+        let total = row.reduce(0, +)
+        guard total > 0 else { return 1 }
+        let from = hour + 1
+        let remaining = from < 24 ? row[from...].reduce(0, +) : 0
+        return remaining / total
+    }
+
+    // MARK: - Helpers
+
+    /// Cumulative-cost `Point` series from a day's per-hour costs: one point at
+    /// the middle of each active hour carrying the running total, so
+    /// `HourOfDayShapeForecaster.hourlyCosts` reconstructs the per-hour costs
+    /// exactly. `cap` limits to hours ≤ cap (today); `lastAt` pins the final
+    /// point's timestamp (so "now" isn't in the future). `nil` if no activity.
+    static func cumulativePoints(_ hourCosts: [Double], dayStart: Date, cap: Int?, lastAt: Date? = nil) -> [ForecastInput.Point]? {
+        let maxHour = min(23, cap ?? 23)
+        var cumulative = 0.0
+        var pts: [ForecastInput.Point] = []
+        for h in 0...maxHour where h < hourCosts.count {
+            cumulative += hourCosts[h]
+            guard hourCosts[h] > 0 else { continue }
+            let at = dayStart.addingTimeInterval(Double(h) * 3600 + 1800)
+            pts.append(.init(at: at, cumulative: cumulative))
+        }
+        guard !pts.isEmpty else { return nil }
+        if let lastAt {
+            let last = pts.removeLast()
+            pts.append(.init(at: min(last.at, lastAt), cumulative: last.cumulative))
+        }
+        return pts
+    }
+
+    private static func buildActivityGrid(
+        hourCost: [String: [Double]],
+        dailyCosts: [String: Double],
+        todayKey: String,
+        calendar: Calendar
+    ) -> [[Double]] {
+        // Span the full calendar from the earliest observed day to the last
+        // complete day, so idle (gap) days land in the per-weekday denominator.
+        let allKeys = Set(hourCost.keys).union(dailyCosts.keys).filter { $0 < todayKey }
+        guard let minKey = allKeys.min(),
+              let start = parseDay(minKey, calendar: calendar),
+              let todayStart = parseDay(todayKey, calendar: calendar),
+              let lastComplete = calendar.date(byAdding: .day, value: -1, to: todayStart) else {
+            return [[Double]](repeating: [Double](repeating: 0, count: 24), count: 7)
+        }
+        var dayCount = [Double](repeating: 0, count: 7)
+        var activeCount = [[Double]](repeating: [Double](repeating: 0, count: 24), count: 7)
+        var day = start
+        while day <= lastComplete {
+            let key = TokenSample.formatDate(day, timeZone: calendar.timeZone)
+            let wd = calendar.component(.weekday, from: day) - 1
+            if wd >= 0 && wd < 7 {
+                dayCount[wd] += 1
+                if let hours = hourCost[key] {
+                    for h in 0..<24 where hours[h] > 0 { activeCount[wd][h] += 1 }
+                }
+            }
+            guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+            day = next
+        }
+        var grid = [[Double]](repeating: [Double](repeating: 0, count: 24), count: 7)
+        for wd in 0..<7 where dayCount[wd] > 0 {
+            for h in 0..<24 { grid[wd][h] = activeCount[wd][h] / dayCount[wd] }
+        }
+        return grid
+    }
+
+    static func parseDay(_ ymd: String, calendar: Calendar) -> Date? {
+        let p = ymd.split(separator: "-").compactMap { Int($0) }
+        guard p.count == 3 else { return nil }
+        var dc = DateComponents(); dc.year = p[0]; dc.month = p[1]; dc.day = p[2]
+        return calendar.date(from: dc)
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -1,0 +1,550 @@
+import Foundation
+import SwiftData
+
+/// A rate-limit window, typed for the engine's question API. (`RateLimitWindow`
+/// is already a per-window *snapshot* struct elsewhere; this is just the window
+/// identity.)
+public enum RateLimitWindowKind: String, Sendable, CaseIterable {
+    case fiveHour = "five_hour"
+    case sevenDay = "seven_day"
+}
+
+/// Horizon for a cost projection.
+public enum CostHorizon: Sendable, Equatable {
+    /// End of the current local day.
+    case today
+    /// End of the current calendar month.
+    case thisMonth
+}
+
+/// The fixed set of questions the engine answers. Every one resolves to an
+/// `Estimate` (value + honest band + confidence + support), so a view renders
+/// one consistent shape and can lean on the interval when the point is too
+/// early to trust. The engine owns the meaning of `value` per question:
+/// dollars for `projectedCost`, utilisation percentage points for
+/// `rateLimitOutlook`, a percentile in [0,1] for `pace`, a robust z-score for
+/// `isAnomalous` (with the categorical verdict in `note`).
+public enum EngineQuestion: Sendable, Equatable {
+    /// Projected total cost for a horizon (dollars).
+    case projectedCost(CostHorizon)
+    /// Projected final utilisation at the window's reset (percentage points).
+    case rateLimitOutlook(RateLimitWindowKind)
+    /// Today's projected spend as a percentile of the user's own daily norm.
+    case pace
+    /// Typical daily cost for today's weekday (the personal "normal" band).
+    case typicalUsage
+    /// Whether the most recent complete day was anomalous (z-score; `note`
+    /// carries `lull`/`normal`/`spike`).
+    case isAnomalous
+    /// A next-day cost estimate — wide by nature; ship the band, not the point.
+    case shortHorizon
+}
+
+/// The standalone, on-device usage-intelligence engine.
+///
+/// A background actor with **its own `ModelContext`** that owns the whole
+/// dataset: on each scan tick it reads the store, rebuilds the per-user
+/// `EngineFeatures`, and refits the per-user models (the regime-gated
+/// end-of-day shape and its conformal calibrator, the diurnal rate-limit
+/// model shrunk toward the activity-grid prior plus its calibrator, the usage-
+/// norm bands, the daily baseline). Views never hand it data — they `ask`
+/// typed questions and get back calibrated `Estimate`s computed from the
+/// cached fit. This is the question→`Estimate` contract the rest of the
+/// app (and future plugins) call.
+///
+/// Everything the models need is the validated pure-Swift work from the
+/// earlier engine PRs (`RegimeGatedEOD`, `DiurnalBurnModel`, `UsageNorms`,
+/// `MonthlyProjector`, `ConformalCalibrator`) — no CreateML/Accelerate at this
+/// data scale. The actor is the integration layer: store → features → fit →
+/// answer. The answer logic is split into pure statics so it tests without a
+/// container. Self-eval persistence and per-regime winner selection across all
+/// surfaces is the next PR; here selection is the on-the-fly walk-forward
+/// backtest the burn tournament already does.
+@ModelActor
+public actor UsageIntelligenceEngine {
+
+    /// The most recent feature snapshot, or nil before the first recompute.
+    private var features: EngineFeatures?
+    /// The per-user fit derived from `features`.
+    private var fit = Fit()
+
+    /// Per-user fitted state cached between scans. Holds the shapes that are
+    /// expensive to derive (calibrators, the diurnal rate table); the cheap,
+    /// time-dependent projection runs on read.
+    struct Fit {
+        /// Multiplicative conformal calibrators for the two end-of-day experts,
+        /// each fit to that expert's own walk-forward residuals.
+        var eodShapeCalibrator: ConformalCalibrator?
+        var eodClockCalibrator: ConformalCalibrator?
+        /// Fraction-of-day from which the learned hour-of-day shape robustly
+        /// beats clock-linear on the user's own history. Below it the engine
+        /// uses the simple line; at/above it, the learned shape. `.infinity`
+        /// when the shape never robustly wins (so clock all day).
+        var eodShapeCrossover: Double = .infinity
+        var rl: [String: RateLimitFit] = [:]
+        var normBands: [Int: UsageNorms.Band] = [:]
+        /// Prior complete days' costs, zero-filled over gaps (for pace/anomaly).
+        var dailyBaseline: [Double] = []
+        /// Precomputed anomaly verdict for the most recent complete day.
+        var anomaly: Estimate = .insufficient(method: "anomaly-z", note: "no history yet")
+    }
+
+    struct RateLimitFit {
+        var roster: [any BurnTrajectory.Model]
+        var selectedId: String?
+        var calibrator: ConformalCalibrator?
+        var duration: TimeInterval
+        var historyCount: Int
+    }
+
+    // MARK: - Recompute (called on the scan tick)
+
+    /// Rebuild the feature snapshot and refit every model from the live store.
+    /// Cheap enough to run per scan: it reads pre-aggregated rows, not raw
+    /// samples (save for a single most-recent token timestamp), and the fits
+    /// are closed-form. Failures degrade to an empty fit rather than throwing.
+    public func recompute(now: Date = Date(), calendar: Calendar = .current) {
+        let f = EngineFeatures.build(
+            now: now, calendar: calendar,
+            daily: fetchDaily(),
+            hourly: fetchHourly(),
+            rate: fetchRate(now: now),
+            lastArrivalAt: fetchLastArrival())
+        self.features = f
+        self.fit = Self.makeFit(f)
+    }
+
+    /// Number of historical days the fit was trained on — for a future
+    /// "the engine knows X days about you" affordance and for tests.
+    public func trainingDayCount() -> Int { features?.dailyPeriods.count ?? 0 }
+
+    // MARK: - Ask (the typed question → Estimate contract)
+
+    /// Answer one question from the cached fit. Pure read — no store access.
+    /// Returns an `insufficient` estimate (never throws, never a confident
+    /// wrong number) when there isn't enough history yet.
+    public func ask(_ question: EngineQuestion) -> Estimate {
+        guard let f = features else {
+            return .insufficient(method: "engine", note: "engine not warmed up yet")
+        }
+        return Self.answer(question, features: f, fit: fit)
+    }
+
+    /// The pure answer function — `(question, features, fit) → Estimate`. The
+    /// actor's `ask` is a thin wrapper so this whole surface tests directly.
+    static func answer(_ question: EngineQuestion, features f: EngineFeatures, fit: Fit) -> Estimate {
+        switch question {
+        case .projectedCost(.today):     return projectedCostToday(f, fit)
+        case .projectedCost(.thisMonth): return MonthlyProjector.project(dailyCosts: f.dailyCosts, now: f.now, calendar: f.calendar)
+        case .rateLimitOutlook(let w):   return rateLimitOutlook(f, fit, window: w)
+        case .pace:                      return pace(f, fit)
+        case .typicalUsage:              return typicalUsage(fit, weekday: f.calendar.component(.weekday, from: f.now))
+        case .isAnomalous:               return fit.anomaly
+        case .shortHorizon:              return shortHorizon(f, fit)
+        }
+    }
+
+    // MARK: - End-of-day (+ idle/done gate)
+
+    static func projectedCostToday(_ f: EngineFeatures, _ fit: Fit) -> Estimate {
+        let input = ForecastInput(
+            now: f.now, periodStart: f.todayStart,
+            periodEnd: f.todayStart.addingTimeInterval(86400),
+            calendar: f.calendar, elapsed: f.todayElapsed, priorPeriods: f.dailyPeriods)
+
+        // Route to the expert that wins the user's own history at this cut.
+        // On real data the learned shape only beats clock-linear once most of
+        // the day is observed (evening); early on, the simple line is better,
+        // so the engine uses it rather than over-projecting a noisy shape.
+        let clock = clockEstimate(input, calibrator: fit.eodClockCalibrator, support: f.dailyPeriods.count)
+        var routed = clock
+        if input.elapsedFraction >= fit.eodShapeCrossover {
+            let shape = RegimeGatedEOD().estimate(input, calibrator: fit.eodShapeCalibrator)
+            // Past the crossover the shape can still decline on an unusually
+            // quiet day — fall back to clock so we always answer.
+            if !shape.isInsufficient { routed = shape }
+        }
+        return idleGate(routed, input: input, features: f)
+    }
+
+    /// The clock-linear (`soFar ÷ elapsed-fraction`) end-of-day estimate with a
+    /// conformal band — the strong simple baseline, wrapped as an `Estimate`.
+    static func clockEstimate(_ input: ForecastInput, calibrator: ConformalCalibrator?, support: Int) -> Estimate {
+        guard let point = AverageRateForecaster().projectTotal(input), point > 0 else {
+            return .insufficient(method: "eod-clock", note: "too early to project end-of-day", support: support)
+        }
+        let frac = input.elapsedFraction
+        let confidence: Estimate.Confidence = frac < 0.3 ? .low : (frac < 0.6 ? .medium : .high)
+        return Estimate(value: point,
+                        interval80: calibrator?.interval(around: point, level: 0.8),
+                        interval50: calibrator?.interval(around: point, level: 0.5),
+                        method: "eod-clock", confidence: confidence, support: support,
+                        note: frac < 0.3 ? "early in the day — lean on the range" : nil)
+    }
+
+    // MARK: - Rate-limit outlook
+
+    static func rateLimitOutlook(_ f: EngineFeatures, _ fit: Fit, window: RateLimitWindowKind) -> Estimate {
+        let key = window.rawValue
+        guard let samples = f.rateLimit[key], let rf = fit.rl[key] else {
+            return .insufficient(method: "rate-limit", note: "no rate-limit history yet")
+        }
+        let (currentOpt, _) = BurnTrajectory.segment(samples: samples, duration: rf.duration, now: f.now)
+        guard let current = currentOpt else {
+            return .insufficient(method: "rate-limit", note: "no live cycle")
+        }
+        let model = rf.roster.first { $0.id == rf.selectedId } ?? rf.roster.first
+        guard let model, let projection = model.fit(current) else {
+            return .insufficient(method: "rate-limit", note: "too early in the cycle to project", support: rf.historyCount)
+        }
+        let raw = projection(current.resetsAt)
+        let point = min(100, max(current.usedNow, raw))
+        let band80 = rf.calibrator?.interval(around: raw, level: 0.8).map { clampPct($0) }
+        let band50 = rf.calibrator?.interval(around: raw, level: 0.5).map { clampPct($0) }
+
+        let confidence: Estimate.Confidence
+        if rf.historyCount < 3 { confidence = .low }
+        else if current.durationHours > 0 && current.nowHours / current.durationHours < 0.3 { confidence = .low }
+        else { confidence = .medium }
+
+        // P(hitting 100%) is unlearnable for this user (one cap-hit in ~80 5h
+        // cycles): never assert a hit, just flag it as rare when the projection
+        // and history both sit low.
+        let note = (point < 60 && raw < 90) ? "hitting the cap is rare for you" : nil
+        return Estimate(value: point, interval80: band80, interval50: band50,
+                        method: "rl-\(model.id)", confidence: confidence,
+                        support: rf.historyCount, note: note)
+    }
+
+    // MARK: - Pace vs norm
+
+    static func pace(_ f: EngineFeatures, _ fit: Fit) -> Estimate {
+        let projected = projectedCostToday(f, fit).value
+        guard projected.isFinite, !fit.dailyBaseline.isEmpty,
+              let rank = UsageNorms.paceRank(value: projected, baseline: fit.dailyBaseline) else {
+            return .insufficient(method: "pace-rank", note: "not enough history to judge pace",
+                                 support: fit.dailyBaseline.count)
+        }
+        let note: String
+        switch rank {
+        case ..<0.25:  note = "quieter than usual"
+        case ..<0.75:  note = "about normal"
+        default:       note = "running hot"
+        }
+        let confidence: Estimate.Confidence = fit.dailyBaseline.count >= 14 ? .medium : .low
+        return Estimate(value: rank, method: "pace-rank", confidence: confidence,
+                        support: fit.dailyBaseline.count, note: note)
+    }
+
+    // MARK: - Typical usage / short horizon (norm bands)
+
+    static func typicalUsage(_ fit: Fit, weekday: Int) -> Estimate {
+        guard let band = fit.normBands[weekday] else {
+            return .insufficient(method: "usage-norm", note: "not enough history for a typical range")
+        }
+        let confidence: Estimate.Confidence = band.count >= 8 ? .medium : .low
+        return Estimate(value: band.typical, interval80: band.range80, interval50: band.range50,
+                        method: "usage-norm", confidence: confidence, support: band.count,
+                        note: "typical for this weekday")
+    }
+
+    static func shortHorizon(_ f: EngineFeatures, _ fit: Fit) -> Estimate {
+        // Next-day estimate = the personal norm band for tomorrow's weekday.
+        // The research is blunt that next-day point error is a property of the
+        // data (~60%), not fixable — so present the band and a low confidence.
+        guard let tomorrow = f.calendar.date(byAdding: .day, value: 1, to: f.now) else {
+            return .insufficient(method: "short-horizon", note: "could not resolve tomorrow")
+        }
+        let wd = f.calendar.component(.weekday, from: tomorrow)
+        guard let band = fit.normBands[wd] else {
+            return .insufficient(method: "short-horizon", note: "not enough history for a next-day estimate")
+        }
+        return Estimate(value: band.typical, interval80: band.range80, interval50: band.range50,
+                        method: "short-horizon", confidence: .low, support: band.count,
+                        note: "next-day estimate — wide by nature")
+    }
+
+    // MARK: - Fitting (pure; testable without a store)
+
+    /// Cut fractions the EOD router scores the experts at (early morning →
+    /// late evening). The crossover where the learned shape starts beating the
+    /// clock baseline is learned per-user, not assumed.
+    static let eodCutFractions = [0.25, 0.375, 0.5, 0.625, 0.75, 0.875]
+
+    static func makeFit(_ f: EngineFeatures) -> Fit {
+        var fit = Fit()
+        let shape = RegimeGatedEOD()
+        let clock = AverageRateForecaster()
+        fit.eodShapeCalibrator = eodCalibrator(model: shape, periods: f.dailyPeriods, calendar: f.calendar)
+        fit.eodClockCalibrator = eodCalibrator(model: clock, periods: f.dailyPeriods, calendar: f.calendar)
+        fit.eodShapeCrossover = eodShapeCrossover(periods: f.dailyPeriods, calendar: f.calendar)
+
+        // Norm bands + baselines from zero-filled prior complete days.
+        let prior = priorDays(f)
+        fit.dailyBaseline = prior.map { $0.cost }
+        fit.normBands = normBands(prior)
+        fit.anomaly = anomalyEstimate(prior)
+
+        // Rate-limit fits per window.
+        for window in RateLimitWindowKind.allCases {
+            guard let samples = f.rateLimit[window.rawValue], !samples.isEmpty,
+                  let duration = PaceMath.windowDuration(for: window.rawValue) else { continue }
+            let (_, history) = BurnTrajectory.segment(samples: samples, duration: duration, now: f.now)
+
+            // The 7-day window is where the diurnal idle structure lives; a 5h
+            // window rarely straddles a day/night boundary (a measured null),
+            // so it competes only the simple baselines there.
+            var roster = BurnTrajectory.defaultModels
+            if window == .sevenDay {
+                let table = DiurnalBurnModel.rateTable(cycles: history, calendar: f.calendar, prior: f.activityGrid)
+                roster.append(DiurnalBurnModel(rate: table, calendar: f.calendar))
+            }
+
+            let scores = BurnTrajectory.score(models: roster, cycles: history)
+            let picked = ForecastSelector.select(
+                scores: scores, policy: .init(minScoredCases: 6, minCoverage: 0.5)).id
+            // Cold-start default: the diurnal model for 7d (it works off the
+            // activity prior even with no completed cycles), recency-weighted
+            // for 5h (tracks that window best on real data).
+            let selectedId = picked ?? (window == .sevenDay ? "diurnal-rate" : "recency-weighted")
+            let model = roster.first { $0.id == selectedId } ?? roster.first
+            let calibrator = model.map { rateLimitCalibrator(model: $0, history: history, duration: duration) }
+
+            fit.rl[window.rawValue] = RateLimitFit(
+                roster: roster, selectedId: selectedId, calibrator: calibrator,
+                duration: duration, historyCount: history.count)
+        }
+        return fit
+    }
+
+    /// Don't scale a near-done quiet day up by a back-loaded weekday shape.
+    /// When the rest of today is typically idle *and* there's been no recent
+    /// arrival, the day is effectively done — project end-of-day at what's
+    /// already been spent (it can only edge up), rather than dividing a small
+    /// spend by a small fraction and exploding. This is the EOD idle/done gate
+    /// the activity-grid feature unlocks (deferred from PR3 for lack of the
+    /// arrival stream).
+    static let doneRemainingShareThreshold = 0.05
+    static let doneIdleMinutes: Double = 120
+
+    static func idleGate(_ scaled: Estimate, input: ForecastInput, features f: EngineFeatures) -> Estimate {
+        let soFar = input.soFar
+        guard soFar > 0 else { return scaled }
+        let weekday = f.calendar.component(.weekday, from: f.now) - 1
+        let hour = f.calendar.component(.hour, from: f.now)
+        let remaining = EngineFeatures.remainingActivityShare(f.activityGrid, weekday: weekday, afterHour: hour)
+        let idleMinutes = f.lastArrivalAt.map { f.now.timeIntervalSince($0) / 60 } ?? .infinity
+        guard remaining < doneRemainingShareThreshold, idleMinutes > doneIdleMinutes else { return scaled }
+
+        // Held estimate: the day can only edge up by the tiny remaining share.
+        let hi = max(soFar * (1 + max(remaining, 0)), soFar)
+        return Estimate(
+            value: soFar,
+            interval80: soFar...hi,
+            interval50: soFar...(soFar * (1 + remaining / 2)),
+            method: "eod-done-gate",
+            confidence: scaled.isInsufficient ? .low : scaled.confidence,
+            support: f.dailyPeriods.count,
+            note: "today looks done — held at spend so far")
+    }
+
+    // MARK: - Norm / baseline helpers
+
+    struct DayPoint { let weekday: Int; let cost: Double }
+
+    /// Prior complete days (strictly before today), zero-filled over gap days,
+    /// oldest → newest. Missing day = $0 is load-bearing (the anomalies on this
+    /// user are lulls, not spikes), so gaps are real zeros, not skipped.
+    static func priorDays(_ f: EngineFeatures) -> [DayPoint] {
+        let todayKey = TokenSample.formatDate(f.now, timeZone: f.calendar.timeZone)
+        guard let minKey = f.dailyCosts.keys.filter({ $0 < todayKey }).min(),
+              let start = EngineFeatures.parseDay(minKey, calendar: f.calendar) else { return [] }
+        var out: [DayPoint] = []
+        var day = start
+        while true {
+            let key = TokenSample.formatDate(day, timeZone: f.calendar.timeZone)
+            guard key < todayKey else { break }
+            out.append(DayPoint(weekday: f.calendar.component(.weekday, from: day),
+                                cost: f.dailyCosts[key] ?? 0))
+            guard let next = f.calendar.date(byAdding: .day, value: 1, to: day) else { break }
+            day = next
+        }
+        return out
+    }
+
+    static func normBands(_ prior: [DayPoint]) -> [Int: UsageNorms.Band] {
+        guard !prior.isEmpty else { return [:] }
+        let samples = prior.map { (key: String($0.weekday), value: $0.cost) }
+        let byKey = UsageNorms.bands(samples)
+        var out: [Int: UsageNorms.Band] = [:]
+        for (k, band) in byKey { if let wd = Int(k) { out[wd] = band } }
+        return out
+    }
+
+    static func anomalyEstimate(_ prior: [DayPoint]) -> Estimate {
+        guard let test = prior.last else {
+            return .insufficient(method: "anomaly-z", note: "no complete day to judge yet")
+        }
+        let baseline = prior.dropLast().map { $0.cost }
+        guard baseline.count >= 14 else {
+            return .insufficient(method: "anomaly-z",
+                                 note: "not enough history to judge what's normal yet",
+                                 support: baseline.count)
+        }
+        let z = UsageNorms.anomalyZ(value: test.cost, baseline: baseline)
+        let verdict = UsageNorms.classify(z: z)
+        let note: String
+        switch verdict {
+        case .lull:   note = "lull — unusually quiet"
+        case .spike:  note = "spike — unusually busy"
+        case .normal: note = "normal"
+        }
+        return Estimate(value: z, method: "anomaly-z", confidence: .medium,
+                        support: baseline.count, note: note)
+    }
+
+    /// Additive conformal calibrator for a rate-limit model: walk-forward over
+    /// completed cycles, projecting the final at each cut, residual = truth −
+    /// projection (percentage points).
+    static func rateLimitCalibrator(
+        model: any BurnTrajectory.Model,
+        history: [BurnTrajectory.Cycle],
+        duration: TimeInterval,
+        cutFractions: [Double] = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    ) -> ConformalCalibrator {
+        var preds: [Double] = []
+        var truths: [Double] = []
+        for cycle in history {
+            let trueFinal = cycle.samples.map { $0.usedPercentage }.max() ?? 0
+            guard trueFinal > 0 else { continue }
+            for cf in cutFractions {
+                let cutNow = cycle.cycleStart.addingTimeInterval(duration * cf)
+                let seen = cycle.samples.filter { $0.at <= cutNow }
+                guard seen.count >= 3 else { continue }
+                let partial = BurnTrajectory.PartialCycle(
+                    samples: seen, now: cutNow, cycleStart: cycle.cycleStart, resetsAt: cycle.resetsAt)
+                if let projection = model.fit(partial) {
+                    preds.append(projection(cycle.resetsAt)); truths.append(trueFinal)
+                }
+            }
+        }
+        return ConformalCalibrator.fromPairs(mode: .additive, predictions: preds, truths: truths)
+    }
+
+    /// Multiplicative conformal calibrator for any end-of-day `Forecaster`,
+    /// from its walk-forward residuals over the prior complete days: at each
+    /// cut of each past day, project the day total using only earlier days and
+    /// collect truth/prediction ratios. Leak-free.
+    static func eodCalibrator(
+        model: any Forecaster,
+        periods: [ForecastInput.PriorPeriod],
+        calendar: Calendar,
+        cutFractions: [Double] = eodCutFractions
+    ) -> ConformalCalibrator {
+        let sorted = periods.sorted { $0.start < $1.start }
+        var preds: [Double] = []
+        var truths: [Double] = []
+        for (i, p) in sorted.enumerated() {
+            let priors = Array(sorted[0..<i])
+            guard !priors.isEmpty, p.total > 0 else { continue }
+            let end = p.start.addingTimeInterval(86400)
+            for cf in cutFractions {
+                let now = p.start.addingTimeInterval(86400 * cf)
+                let elapsed = p.points.filter { $0.at <= now }
+                guard !elapsed.isEmpty else { continue }
+                let input = ForecastInput(now: now, periodStart: p.start, periodEnd: end,
+                                          calendar: calendar, elapsed: elapsed, priorPeriods: priors)
+                if let pt = model.projectTotal(input), pt > 0 { preds.append(pt); truths.append(p.total) }
+            }
+        }
+        return ConformalCalibrator.fromPairs(mode: .multiplicative, predictions: preds, truths: truths)
+    }
+
+    /// Minimum fraction of a bucket's days the shape must actually produce a
+    /// projection for before it's trusted to beat clock there. Early in the day
+    /// the shape declines on most days (a tiny fraction-done explodes the
+    /// scale-up), so it would otherwise be "selected" on a favourable handful.
+    static let eodShapeMinCoverage = 0.6
+    static let eodShapeMinShared = 10
+    /// Fraction of shared days the shape must be strictly closer than clock on
+    /// before it's trusted (a sign test). Deterministic at small n — unlike the
+    /// bootstrap-CI width, which flaps run-to-run on a borderline bucket because
+    /// the case ordering (dictionary/set iteration) isn't stable.
+    static let eodShapeMinWinFraction = 0.6
+
+    /// Learn the fraction-of-day from which the hour-of-day shape *robustly*
+    /// beats clock-linear on the user's own history. Four guards make this
+    /// honest (the throwaway real-store harness caught each): compare on the
+    /// **shared** cases each could project (a paired delta, not two independent
+    /// medians on different subsets); require the shape to **cover** most of the
+    /// bucket's days (else it wins by only ever projecting the easy ones);
+    /// require the shape to be strictly closer than clock on a **majority of
+    /// shared days** (a sign test, `winFraction`) with a negative median delta,
+    /// so a within-noise in-sample edge (round-2's early-cut weekday signal,
+    /// Wilcoxon p≈0.19) never trades the simple line for a noisier model; and
+    /// take only the **contiguous evening tail** of winning buckets, because the
+    /// shape's advantage is monotone in fraction-observed — an isolated midday
+    /// bucket clearing the bar is an artifact, not a real crossover.
+    ///
+    /// On real data this lands the crossover in the evening (clock through the
+    /// morning/afternoon, the learned shape only once most of the day is seen),
+    /// which is exactly where the shape's win is significant and durable. This
+    /// is the EOD analogue of the burn tournament's selector.
+    static func eodShapeCrossover(periods: [ForecastInput.PriorPeriod], calendar: Calendar) -> Double {
+        let shape = RegimeGatedEOD(), clock = AverageRateForecaster()
+        let cases = WalkForward.cases(
+            periods: periods, periodEnd: { $0.start.addingTimeInterval(86400) },
+            cutFractions: eodCutFractions, calendar: calendar)
+        let coverage = WalkForward.score(models: [shape], cases: cases)
+        let paired = WalkForward.paired(model: shape, baseline: clock, cases: cases)
+        func robustWin(at cf: Double) -> Bool {
+            let bucket = "cut=\(String(format: "%.2f", cf))|all"
+            let cov = coverage.first { $0.bucket == bucket }?.coverage ?? 0
+            guard let p = paired.first(where: { $0.bucket == bucket }) else { return false }
+            return cov >= eodShapeMinCoverage && p.n >= eodShapeMinShared
+                && p.winFraction >= eodShapeMinWinFraction && p.medianDelta < 0
+        }
+        // Walk fractions high → low; the crossover is the lowest fraction whose
+        // bucket and every later bucket are robust shape wins.
+        var crossover = Double.infinity
+        for cf in eodCutFractions.sorted(by: >) {
+            if robustWin(at: cf) { crossover = cf } else { break }
+        }
+        return crossover
+    }
+
+    static func clampPct(_ r: ClosedRange<Double>) -> ClosedRange<Double> {
+        let lo = min(100, max(0, r.lowerBound))
+        let hi = min(100, max(0, r.upperBound))
+        return lo...max(lo, hi)
+    }
+
+    // MARK: - Store reads
+
+    private func fetchDaily() -> [EngineFeatures.DailyRow] {
+        let rows = (try? modelContext.fetch(FetchDescriptor<DailyAggregate>())) ?? []
+        return rows.map { .init(date: $0.date, cost: $0.totalCostUSD) }
+    }
+
+    private func fetchHourly() -> [EngineFeatures.HourlyRow] {
+        let rows = (try? modelContext.fetch(FetchDescriptor<HourlyAggregate>())) ?? []
+        return rows.map { .init(date: $0.date, hour: $0.hour, cost: $0.totalCostUSD, sampleCount: $0.sampleCount) }
+    }
+
+    /// ~32 days of rate-limit samples — enough to hold several complete 7-day
+    /// cycles for the backtest while staying a small read.
+    private func fetchRate(now: Date) -> [EngineFeatures.RateRow] {
+        let cutoff = now.addingTimeInterval(-32 * 24 * 3600)
+        let descriptor = FetchDescriptor<RateLimitSample>(
+            predicate: #Predicate { $0.sampledAt >= cutoff },
+            sortBy: [SortDescriptor(\.sampledAt, order: .forward)])
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.map { .init(window: $0.window, at: $0.sampledAt, usedPercentage: $0.usedPercentage, resetsAt: $0.resetsAt) }
+    }
+
+    private func fetchLastArrival() -> Date? {
+        var descriptor = FetchDescriptor<TokenSample>(sortBy: [SortDescriptor(\.sampledAt, order: .reverse)])
+        descriptor.fetchLimit = 1
+        return (try? modelContext.fetch(descriptor))?.first?.sampledAt
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/JSONLWatcherTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/JSONLWatcherTests.swift
@@ -18,8 +18,11 @@ import Testing
         await watcher.manualTrigger()
     }
 
-    // Race the trigger against a 1s safety timeout so a miss fails
-    // loudly rather than hanging the suite.
+    // Race the trigger against a safety timeout so a miss fails loudly
+    // rather than hanging the suite. 5s, not 1s: the trigger fires after
+    // ~50ms, but on a loaded/slow CI runner (where the whole suite's tests
+    // run in parallel) scheduling that task within 1s isn't guaranteed — a
+    // too-tight timeout turns a scheduling delay into a spurious failure.
     let received = await withTaskGroup(of: Date?.self) { group in
         group.addTask {
             for await date in stream {
@@ -28,7 +31,7 @@ import Testing
             return nil
         }
         group.addTask {
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
             return nil
         }
         let first = await group.next() ?? nil

--- a/PacerCore/Tests/PacerCoreTests/UsageIntelligenceEngineTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/UsageIntelligenceEngineTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import Testing
+import SwiftData
+@testable import PacerCore
+
+/// Tests for the engine integration layer: the feature builder (cumulative
+/// series, diurnal activity grid, idle gate) and the typed question→Estimate
+/// answers. Everything but the actor smoke test runs on the pure statics, so
+/// no `ModelContainer` is needed.
+@Suite("Usage intelligence engine")
+struct UsageIntelligenceEngineTests {
+
+    // A fixed clock + UTC Gregorian calendar so date keys are deterministic.
+    static var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+    static let now = utc.date(from: DateComponents(year: 2026, month: 6, day: 10, hour: 20, minute: 30))!
+
+    func key(_ date: Date) -> String { TokenSample.formatDate(date, timeZone: Self.utc.timeZone) }
+    func dayBack(_ i: Int) -> Date {
+        Self.utc.date(byAdding: .day, value: -i, to: Self.utc.startOfDay(for: Self.now))!
+    }
+
+    // MARK: - Feature builder
+
+    @Test func cumulativePointsRoundTripThroughHourlyCosts() {
+        var hours = [Double](repeating: 0, count: 24)
+        hours[9] = 4; hours[13] = 6; hours[17] = 2     // $12 total, three active hours
+        let start = Self.utc.startOfDay(for: Self.now)
+        let pts = EngineFeatures.cumulativePoints(hours, dayStart: start, cap: nil)
+        #expect(pts != nil)
+        // The shape forecaster must reconstruct the per-hour costs exactly.
+        let recovered = HourOfDayShapeForecaster.hourlyCosts(points: pts!, start: start, calendar: Self.utc)
+        #expect(recovered != nil)
+        #expect(abs(recovered![9] - 4) < 1e-9)
+        #expect(abs(recovered![13] - 6) < 1e-9)
+        #expect(abs(recovered![17] - 2) < 1e-9)
+        #expect(abs((recovered!.reduce(0, +)) - 12) < 1e-9)
+    }
+
+    @Test func activityGridIsPActiveAndCountsIdleDays() {
+        // 14 consecutive complete days, each active only at hour 9.
+        var hourly: [EngineFeatures.HourlyRow] = []
+        var daily: [EngineFeatures.DailyRow] = []
+        for i in 1...14 {
+            let k = key(dayBack(i))
+            hourly.append(.init(date: k, hour: 9, cost: 10, sampleCount: 1))
+            daily.append(.init(date: k, cost: 10))
+        }
+        let f = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: daily,
+                                     hourly: hourly, rate: [], lastArrivalAt: nil)
+        // Every weekday that appears was active at hour 9 on all its days → P = 1.
+        var sawFull = false
+        for wd in 0..<7 {
+            let total = f.activityGrid[wd].reduce(0, +)
+            if total > 0 {
+                #expect(abs(f.activityGrid[wd][9] - 1.0) < 1e-9)
+                #expect(f.activityGrid[wd][10] == 0)
+                sawFull = true
+            }
+            // P(active) is a probability — never exceeds 1.
+            #expect(f.activityGrid[wd].allSatisfy { $0 <= 1.0 + 1e-9 })
+        }
+        #expect(sawFull)
+
+        // Remaining-activity share: everything is at hour 9, so nothing is left
+        // after hour 9, but it's all still ahead after hour 8.
+        let presentWd = (0..<7).first { f.activityGrid[$0].reduce(0, +) > 0 }!
+        #expect(EngineFeatures.remainingActivityShare(f.activityGrid, weekday: presentWd, afterHour: 9) == 0)
+        #expect(abs(EngineFeatures.remainingActivityShare(f.activityGrid, weekday: presentWd, afterHour: 8) - 1.0) < 1e-9)
+        // Unknown weekday (no data) → safe default 1 (never gate on nothing).
+        let emptyGrid = [[Double]](repeating: [Double](repeating: 0, count: 24), count: 7)
+        #expect(EngineFeatures.remainingActivityShare(emptyGrid, weekday: 0, afterHour: 12) == 1)
+    }
+
+    // MARK: - Idle / done gate
+
+    /// Build features where activity is concentrated at hour 9 (so the rest of
+    /// the day is typically idle) with a small spend today.
+    private func quietDayFeatures(lastArrival: Date?) -> EngineFeatures {
+        var hourly: [EngineFeatures.HourlyRow] = []
+        var daily: [EngineFeatures.DailyRow] = []
+        for i in 1...21 {
+            let k = key(dayBack(i))
+            hourly.append(.init(date: k, hour: 9, cost: 10, sampleCount: 1))
+            daily.append(.init(date: k, cost: 10))
+        }
+        // Today: a small early spend, now is hour 20.
+        let todayKey = key(Self.now)
+        hourly.append(.init(date: todayKey, hour: 9, cost: 5, sampleCount: 1))
+        daily.append(.init(date: todayKey, cost: 5))
+        return EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: daily,
+                                    hourly: hourly, rate: [], lastArrivalAt: lastArrival)
+    }
+
+    @Test func idleGateHoldsAQuietDoneDay() {
+        // Last arrival was this morning — long idle, rest of day typically dead.
+        let morning = Self.utc.date(bySettingHour: 9, minute: 0, second: 0, of: Self.now)!
+        let f = quietDayFeatures(lastArrival: morning)
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        let e = UsageIntelligenceEngine.projectedCostToday(f, fit)
+        #expect(e.method == "eod-done-gate")
+        #expect(abs(e.value - 5) < 1e-9)               // held at spend so far
+        #expect(e.interval80?.lowerBound == 5)         // can't un-spend
+        #expect((e.interval80?.upperBound ?? 0) >= 5)
+    }
+
+    @Test func idleGateYieldsToRecentActivity() {
+        // A token arrived 10 minutes ago — the day is still live, don't hold.
+        let f = quietDayFeatures(lastArrival: Self.now.addingTimeInterval(-600))
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        let e = UsageIntelligenceEngine.projectedCostToday(f, fit)
+        #expect(e.method != "eod-done-gate")
+    }
+
+    // MARK: - Synthetic rich history for the cost/norm questions
+
+    /// ~55 prior active days spanning >2 calendar months, weekdays heavier than
+    /// weekends, each day's cost spread across active hours.
+    private func richHistory() -> EngineFeatures {
+        var hourly: [EngineFeatures.HourlyRow] = []
+        var daily: [EngineFeatures.DailyRow] = []
+        for i in 1...55 {
+            let day = dayBack(i)
+            let k = key(day)
+            let wd = Self.utc.component(.weekday, from: day)
+            let weekend = (wd == 1 || wd == 7)
+            let total = weekend ? Double(6 + i % 3) : Double(40 + (i % 5) * 4)
+            let hoursActive = weekend ? [11, 12] : [9, 11, 13, 15, 17]
+            let per = total / Double(hoursActive.count)
+            for h in hoursActive {
+                hourly.append(.init(date: k, hour: h, cost: per, sampleCount: 1))
+            }
+            daily.append(.init(date: k, cost: total))
+        }
+        // A little spend today too.
+        let todayKey = key(Self.now)
+        hourly.append(.init(date: todayKey, hour: 9, cost: 12, sampleCount: 1))
+        hourly.append(.init(date: todayKey, hour: 13, cost: 18, sampleCount: 1))
+        daily.append(.init(date: todayKey, cost: 30))
+        return EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: daily,
+                                    hourly: hourly, rate: [], lastArrivalAt: Self.now.addingTimeInterval(-300))
+    }
+
+    @Test func monthlyProjectionIsEligibleOnRichHistory() {
+        let f = richHistory()
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        let e = UsageIntelligenceEngine.answer(.projectedCost(.thisMonth), features: f, fit: fit)
+        #expect(!e.isInsufficient)
+        #expect(e.value > 0)
+        #expect(e.method == "monthly-daily-sum")       // seasonal model, not the flat fallback
+    }
+
+    @Test func typicalUsageAndPaceAndShortHorizon() {
+        let f = richHistory()
+        let fit = UsageIntelligenceEngine.makeFit(f)
+
+        let typical = UsageIntelligenceEngine.answer(.typicalUsage, features: f, fit: fit)
+        #expect(!typical.isInsufficient)
+        #expect(typical.value > 0)
+        #expect(typical.interval80 != nil)
+
+        let pace = UsageIntelligenceEngine.answer(.pace, features: f, fit: fit)
+        #expect(!pace.isInsufficient)
+        #expect(pace.value >= 0 && pace.value <= 1)
+
+        let next = UsageIntelligenceEngine.answer(.shortHorizon, features: f, fit: fit)
+        #expect(!next.isInsufficient)
+        #expect(next.confidence == .low)               // honest: next-day is wide
+    }
+
+    @Test func anomalyNeedsAtLeastTwoWeeksOfBaseline() {
+        // Only 10 prior days → can't judge what's normal yet.
+        var hourly: [EngineFeatures.HourlyRow] = []
+        var daily: [EngineFeatures.DailyRow] = []
+        for i in 1...10 {
+            let k = key(dayBack(i))
+            hourly.append(.init(date: k, hour: 10, cost: 20, sampleCount: 1))
+            daily.append(.init(date: k, cost: 20))
+        }
+        let thin = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: daily,
+                                        hourly: hourly, rate: [], lastArrivalAt: nil)
+        #expect(UsageIntelligenceEngine.makeFit(thin).anomaly.isInsufficient)
+
+        // With a long baseline and a dead final day, the verdict is a lull.
+        var hourly2: [EngineFeatures.HourlyRow] = []
+        var daily2: [EngineFeatures.DailyRow] = []
+        for i in 2...30 {                               // days 2..30 are busy
+            let k = key(dayBack(i))
+            hourly2.append(.init(date: k, hour: 10, cost: 50, sampleCount: 1))
+            daily2.append(.init(date: k, cost: 50))
+        }
+        // day 1 (most recent complete day) has no spend → $0 lull.
+        let rich = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: daily2,
+                                        hourly: hourly2, rate: [], lastArrivalAt: nil)
+        let anomaly = UsageIntelligenceEngine.makeFit(rich).anomaly
+        #expect(!anomaly.isInsufficient)
+        #expect(anomaly.note == "lull — unusually quiet")
+        #expect(anomaly.value < 0)                      // negative z = below normal
+    }
+
+    // MARK: - Rate-limit outlook
+
+    @Test func rateLimitOutlookProjectsWithinBounds() {
+        let duration: TimeInterval = 7 * 24 * 3600
+        var rate: [EngineFeatures.RateRow] = []
+        // Three complete cycles + one live one, each ramping 0 → ~60%.
+        for c in 0..<4 {
+            // cycle c starts (3 - c) cycles ago; the last one is live (reset future).
+            let cycleStart = Self.now.addingTimeInterval(-Double(3 - c) * duration - 2 * 86400)
+            let resetsAt = cycleStart.addingTimeInterval(duration)
+            var t = cycleStart
+            var pct = 0.0
+            while t <= min(resetsAt, Self.now) {
+                rate.append(.init(window: "seven_day", at: t, usedPercentage: min(60, pct), resetsAt: resetsAt))
+                t = t.addingTimeInterval(6 * 3600)
+                pct += 2.2
+            }
+        }
+        let f = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: [],
+                                     hourly: [], rate: rate, lastArrivalAt: nil)
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        let e = UsageIntelligenceEngine.answer(.rateLimitOutlook(.sevenDay), features: f, fit: fit)
+        #expect(!e.isInsufficient)
+        #expect(e.value >= 0 && e.value <= 100)
+        #expect(e.method.hasPrefix("rl-"))
+    }
+
+    // MARK: - Insufficient / cold-start guards
+
+    @Test func emptyFeaturesAnswerInsufficientNotZero() {
+        let f = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: [],
+                                     hourly: [], rate: [], lastArrivalAt: nil)
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        for q: EngineQuestion in [.projectedCost(.today), .projectedCost(.thisMonth),
+                                  .rateLimitOutlook(.fiveHour), .rateLimitOutlook(.sevenDay),
+                                  .pace, .typicalUsage, .isAnomalous, .shortHorizon] {
+            #expect(UsageIntelligenceEngine.answer(q, features: f, fit: fit).isInsufficient)
+        }
+    }
+
+    // MARK: - Actor smoke test (exercises the @ModelActor + store fetches)
+
+    @Test func actorRecomputeOnEmptyStoreIsSafe() async throws {
+        let container = try PacerStore.makeInMemoryContainer()
+        let engine = UsageIntelligenceEngine(modelContainer: container)
+        await engine.recompute(now: Self.now, calendar: Self.utc)
+        #expect(await engine.trainingDayCount() == 0)
+        let e = await engine.ask(.projectedCost(.today))
+        #expect(e.isInsufficient)
+    }
+}


### PR DESCRIPTION
PR8 of the on-device intelligence engine (#59–#64 = PR1–6). A standalone background actor that owns the whole dataset and answers a fixed typed question set; views never pass data in.

## What's here
- **`EngineFeatures`** — pure, store-free feature builder (unit-tested without a container): daily-cost series, prior days as cumulative-by-hour `Point` series, today-so-far, rate-limit tuples per window, and the new **`[7][24]` P(active) diurnal activity grid** (idle days counted in the denominator). The grid feeds both the `DiurnalBurnModel` prior and the EOD idle/done gate deferred in PR3.
- **`UsageIntelligenceEngine`** (`@ModelActor`, own `ModelContext`) — `recompute(now:)` on the scan tick reads pre-aggregated rows and refits the per-user models (EOD calibrators, the diurnal 7d model shrunk toward the activity prior + its conformal calibrator, usage-norm bands, daily baseline). `ask(_:)` answers `projectedCost(.today/.thisMonth)`, `rateLimitOutlook`, `pace`, `typicalUsage`, `isAnomalous`, `shortHorizon` — every one an `Estimate` with honest band/confidence/support, never a confident wrong number.
- **EOD clock/shape crossover router** — the accuracy win the real-store validation drove out (see below).
- **EOD idle/done gate** — hold end-of-day at spend-so-far when the rest of the day is typically idle and there's been no recent arrival, instead of scaling a near-zero quiet day up by a back-loaded shape.
- **Scan-tick hook** in `AppBackgroundService` (throttled, ≥20s), creates + warms the engine on the shared container, recomputes on cost/rate-limit changes.

## Real-store validation (throwaway harness, deleted before commit)
Validating `RegimeGatedEOD`'s *point* on Eric's real store showed it's **worse than clock-linear at the early/most-actionable cuts** and only robustly beats it in the evening. So the engine learns, per user, the fraction-of-day from which the shape robustly beats the line — paired walk-forward on shared cases + coverage guard + a deterministic sign-test (`winFraction ≥ 0.6`, since the bootstrap CI flaps on borderline buckets) + a contiguous-evening-tail rule — and routes accordingly.

Median APE on Eric's store:

| cut | clock-linear | shape-only | **engine (routed + gated)** |
|----:|----:|----:|----:|
| 09:00 | 43% | 65% | **43%** (clock) |
| 12:00 | 40% | 55% | **40%** (clock) |
| 15:00 | 36% | 37% | **36%** (clock) |
| 18:00 | 28% | 17% | **18%** (shape win captured) |

Never worse than the strong baseline; strictly better in the evening. Directly answers the "I could beat this with a best-fit line" critique — the engine *uses* the line where the line wins. The rate-limit outlook is sane too (5h: linear-recent ~33%, "cap-hit is rare" note; 7d: diurnal selected). The idle gate fires rarely and never hurts.

## Scope / next
UI wiring is intentionally out of scope (views get wired later). PR9 = self-eval persistence + standing per-regime re-score (this PR's selection is the cold on-the-fly walk-forward). 11 new unit tests; `make test` (430) green; app builds, installs, and runs clean on the real store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)