### PR TITLE
feat(intelligence): self-eval persistence — the engine learns from its own track record

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// The engine's self-evaluation: score the prediction methods against the
+/// user's own realized outcomes, persist the verdicts, and read them back to
+/// pick the per-user winner. The cost-surface analogue of the rate-limit
+/// `ForecastOutcomeRecorder` + `ForecastScoreboard`, and the layer that makes
+/// the engine "learn constantly" — its selection is driven by an accumulating
+/// per-user track record, not a value recomputed cold each launch.
+///
+/// All logic here is pure (operates on plain `Record`s, not `@Model`s), so it
+/// tests without a container; the actor does the fetch/insert/save around it.
+///
+/// **End-of-day selection lives here too.** On real data the learned hour-of-day
+/// shape only robustly beats the clock-linear baseline once most of the day is
+/// observed (evening). `crossover` learns, per user, the fraction-of-day from
+/// which to switch — and the bar it applies (a majority sign-test + coverage)
+/// is a *generic statistical default applied to each user's own record*, so no
+/// individual's data is baked into what ships. The bootstrap-CI width was
+/// rejected for this: it flaps run-to-run because case ordering (dictionary/set
+/// iteration) isn't stable, while the sign-test is deterministic at small n.
+public enum EngineSelfEval {
+
+    public static let surfaceEOD = "eod"
+    /// Candidate ids compared on the end-of-day surface.
+    static let clockId = "average-rate"
+    static let shapeId = "regime-gated-eod"
+    /// Cut fractions (early morning → late evening) the experts are scored at.
+    public static let cutFractions = [0.25, 0.375, 0.5, 0.625, 0.75, 0.875]
+    /// Selection bar — applied to each user's *own* accumulated record.
+    static let minShared = 10
+    static let minCoverage = 0.6
+    static let minWinFraction = 0.6
+
+    // MARK: - Decoupled value types (SwiftData-free)
+
+    /// A persisted outcome, decoupled from `EngineEvalOutcome`.
+    public struct Record: Sendable, Equatable {
+        public let method: String
+        public let bucket: String
+        public let periodKey: String
+        public let predicted: Double
+        public let truth: Double
+        public init(method: String, bucket: String, periodKey: String, predicted: Double, truth: Double) {
+            self.method = method; self.bucket = bucket; self.periodKey = periodKey
+            self.predicted = predicted; self.truth = truth
+        }
+        var absPctError: Double { truth > 0 ? abs(predicted - truth) / truth * 100 : .infinity }
+    }
+
+    /// A not-yet-persisted outcome — pure output of `newOutcomesEOD`.
+    public struct NewOutcome: Sendable, Equatable {
+        public let surface: String
+        public let method: String
+        public let bucket: String
+        public let periodKey: String
+        public let predicted: Double
+        public let truth: Double
+    }
+
+    // MARK: - Scoring completed periods
+
+    /// Replay each candidate over the prior complete days at each cut and emit
+    /// the outcomes not already persisted (idempotent via `existingKeys`). Uses
+    /// the shared walk-forward case builder so each prediction sees only earlier
+    /// days — leak-free. Only records a candidate when it actually produced a
+    /// projection, so coverage is honest (the shape declines early).
+    public static func newOutcomesEOD(
+        periods: [ForecastInput.PriorPeriod],
+        calendar: Calendar,
+        existingKeys: Set<String>,
+        candidates: [any Forecaster] = [AverageRateForecaster(), RegimeGatedEOD()]
+    ) -> [NewOutcome] {
+        let cases = WalkForward.cases(
+            periods: periods, periodEnd: { $0.start.addingTimeInterval(86400) },
+            cutFractions: cutFractions, calendar: calendar)
+        var out: [NewOutcome] = []
+        for c in cases {
+            guard c.truth > 0 else { continue }
+            let periodKey = TokenSample.formatDate(c.input.periodStart, timeZone: calendar.timeZone)
+            for cand in candidates {
+                let key = EngineEvalOutcome.makeKey(
+                    surface: surfaceEOD, method: cand.id, bucket: c.bucket, periodKey: periodKey)
+                guard !existingKeys.contains(key) else { continue }
+                guard let pred = cand.projectTotal(c.input), pred.isFinite, pred > 0 else { continue }
+                out.append(NewOutcome(surface: surfaceEOD, method: cand.id, bucket: c.bucket,
+                                      periodKey: periodKey, predicted: pred, truth: c.truth))
+            }
+        }
+        return out
+    }
+
+    // MARK: - Selection (from the persisted scoreboard)
+
+    private struct BucketStat { let cf: Double; let coverage: Double; let winFraction: Double; let medianDelta: Double; let n: Int }
+
+    /// The learned fraction-of-day from which the shape beats clock, computed
+    /// from the accumulated per-user record. `.infinity` when the shape never
+    /// robustly wins (so clock all day) — also the safe answer on thin data.
+    public static func crossover(from records: [Record]) -> Double {
+        crossoverFromTail(cutFractions.map { stat(at: $0, records: records) })
+    }
+
+    /// Per-bucket paired stats from the persisted records: pair clock vs shape
+    /// on the days where *both* predicted, and measure how often (and by how
+    /// much) the shape was closer.
+    private static func stat(at cf: Double, records: [Record]) -> BucketStat {
+        let bucket = "cut=\(String(format: "%.2f", cf))|all"
+        let inBucket = records.filter { $0.bucket == bucket }
+        let byPeriod = Dictionary(grouping: inBucket, by: { $0.periodKey })
+        var clockDays = 0, shared = 0, wins = 0
+        var deltas: [Double] = []
+        for (_, rows) in byPeriod {
+            guard let clock = rows.first(where: { $0.method == clockId }) else { continue }
+            clockDays += 1
+            guard let shape = rows.first(where: { $0.method == shapeId }) else { continue }
+            shared += 1
+            deltas.append(shape.absPctError - clock.absPctError)
+            if shape.absPctError < clock.absPctError { wins += 1 }
+        }
+        let coverage = clockDays > 0 ? Double(shared) / Double(clockDays) : 0
+        let winFraction = shared > 0 ? Double(wins) / Double(shared) : 0
+        return BucketStat(cf: cf, coverage: coverage, winFraction: winFraction,
+                          medianDelta: median(deltas), n: shared)
+    }
+
+    /// Take only the contiguous *evening* tail of robust shape wins — the
+    /// shape's advantage is monotone in fraction-observed, so an isolated midday
+    /// bucket clearing the bar is an artifact, not a real crossover.
+    private static func crossoverFromTail(_ stats: [BucketStat]) -> Double {
+        func robust(_ s: BucketStat) -> Bool {
+            s.n >= minShared && s.coverage >= minCoverage
+                && s.winFraction >= minWinFraction && s.medianDelta < 0
+        }
+        var crossover = Double.infinity
+        for s in stats.sorted(by: { $0.cf > $1.cf }) {
+            if robust(s) { crossover = s.cf } else { break }
+        }
+        return crossover
+    }
+
+    // MARK: - Accuracy report (transparency)
+
+    /// How each method is doing on this user's data — median absolute % error
+    /// and how many completed periods back it. Sorted best-first.
+    public struct Accuracy: Sendable, Equatable {
+        public struct MethodStat: Sendable, Equatable {
+            public let method: String
+            public let medianAbsPctError: Double
+            public let periods: Int
+        }
+        public let surface: String
+        public let methods: [MethodStat]
+    }
+
+    public static func accuracy(surface: String = surfaceEOD, from records: [Record]) -> Accuracy {
+        let byMethod = Dictionary(grouping: records, by: { $0.method })
+        let methods = byMethod.map { method, rows -> Accuracy.MethodStat in
+            let periods = Set(rows.map { $0.periodKey }).count
+            return .init(method: method, medianAbsPctError: median(rows.map { $0.absPctError }), periods: periods)
+        }.sorted { $0.medianAbsPctError < $1.medianAbsPctError }
+        return Accuracy(surface: surface, methods: methods)
+    }
+
+    // MARK: - Stats
+
+    static func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return .infinity }
+        let s = xs.sorted(); let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -67,6 +67,8 @@ public actor UsageIntelligenceEngine {
     private var features: EngineFeatures?
     /// The per-user fit derived from `features`.
     private var fit = Fit()
+    /// The per-user end-of-day method track record, refreshed each recompute.
+    private var eodAccuracy: EngineSelfEval.Accuracy?
 
     /// Per-user fitted state cached between scans. Holds the shapes that are
     /// expensive to derive (calibrators, the diurnal rate table); the cheap,
@@ -111,12 +113,25 @@ public actor UsageIntelligenceEngine {
             rate: fetchRate(now: now),
             lastArrivalAt: fetchLastArrival())
         self.features = f
-        self.fit = Self.makeFit(f)
+
+        // Self-eval feedback loop: score any newly-completed days into the
+        // persisted scoreboard (idempotent), then drive end-of-day selection
+        // from the accumulated per-user track record — not a value recomputed
+        // cold each launch. Empty store ⇒ no records ⇒ clock-only (safe).
+        recordNewEODOutcomes(periods: f.dailyPeriods, calendar: calendar, now: now)
+        let records = fetchEODRecords()
+        self.eodAccuracy = EngineSelfEval.accuracy(from: records)
+        self.fit = Self.makeFit(f, eodCrossover: EngineSelfEval.crossover(from: records))
     }
 
     /// Number of historical days the fit was trained on — for a future
     /// "the engine knows X days about you" affordance and for tests.
     public func trainingDayCount() -> Int { features?.dailyPeriods.count ?? 0 }
+
+    /// How each end-of-day prediction method is doing on this user's own data —
+    /// median absolute % error and how many completed days back it, best-first.
+    /// `nil` before the first recompute; empty methods until some days complete.
+    public func selfEvalAccuracy() -> EngineSelfEval.Accuracy? { eodAccuracy }
 
     // MARK: - Ask (the typed question → Estimate contract)
 
@@ -266,18 +281,16 @@ public actor UsageIntelligenceEngine {
 
     // MARK: - Fitting (pure; testable without a store)
 
-    /// Cut fractions the EOD router scores the experts at (early morning →
-    /// late evening). The crossover where the learned shape starts beating the
-    /// clock baseline is learned per-user, not assumed.
-    static let eodCutFractions = [0.25, 0.375, 0.5, 0.625, 0.75, 0.875]
-
-    static func makeFit(_ f: EngineFeatures) -> Fit {
+    /// Build the per-user fit. `eodCrossover` is the learned clock→shape switch
+    /// fraction, resolved by `recompute` from the persisted self-eval scoreboard
+    /// (`.infinity` = clock all day, the safe default before any track record).
+    static func makeFit(_ f: EngineFeatures, eodCrossover: Double = .infinity) -> Fit {
         var fit = Fit()
         let shape = RegimeGatedEOD()
         let clock = AverageRateForecaster()
         fit.eodShapeCalibrator = eodCalibrator(model: shape, periods: f.dailyPeriods, calendar: f.calendar)
         fit.eodClockCalibrator = eodCalibrator(model: clock, periods: f.dailyPeriods, calendar: f.calendar)
-        fit.eodShapeCrossover = eodShapeCrossover(periods: f.dailyPeriods, calendar: f.calendar)
+        fit.eodShapeCrossover = eodCrossover
 
         // Norm bands + baselines from zero-filled prior complete days.
         let prior = priorDays(f)
@@ -439,7 +452,7 @@ public actor UsageIntelligenceEngine {
         model: any Forecaster,
         periods: [ForecastInput.PriorPeriod],
         calendar: Calendar,
-        cutFractions: [Double] = eodCutFractions
+        cutFractions: [Double] = EngineSelfEval.cutFractions
     ) -> ConformalCalibrator {
         let sorted = periods.sorted { $0.start < $1.start }
         var preds: [Double] = []
@@ -458,59 +471,6 @@ public actor UsageIntelligenceEngine {
             }
         }
         return ConformalCalibrator.fromPairs(mode: .multiplicative, predictions: preds, truths: truths)
-    }
-
-    /// Minimum fraction of a bucket's days the shape must actually produce a
-    /// projection for before it's trusted to beat clock there. Early in the day
-    /// the shape declines on most days (a tiny fraction-done explodes the
-    /// scale-up), so it would otherwise be "selected" on a favourable handful.
-    static let eodShapeMinCoverage = 0.6
-    static let eodShapeMinShared = 10
-    /// Fraction of shared days the shape must be strictly closer than clock on
-    /// before it's trusted (a sign test). Deterministic at small n — unlike the
-    /// bootstrap-CI width, which flaps run-to-run on a borderline bucket because
-    /// the case ordering (dictionary/set iteration) isn't stable.
-    static let eodShapeMinWinFraction = 0.6
-
-    /// Learn the fraction-of-day from which the hour-of-day shape *robustly*
-    /// beats clock-linear on the user's own history. Four guards make this
-    /// honest (the throwaway real-store harness caught each): compare on the
-    /// **shared** cases each could project (a paired delta, not two independent
-    /// medians on different subsets); require the shape to **cover** most of the
-    /// bucket's days (else it wins by only ever projecting the easy ones);
-    /// require the shape to be strictly closer than clock on a **majority of
-    /// shared days** (a sign test, `winFraction`) with a negative median delta,
-    /// so a within-noise in-sample edge (round-2's early-cut weekday signal,
-    /// Wilcoxon p≈0.19) never trades the simple line for a noisier model; and
-    /// take only the **contiguous evening tail** of winning buckets, because the
-    /// shape's advantage is monotone in fraction-observed — an isolated midday
-    /// bucket clearing the bar is an artifact, not a real crossover.
-    ///
-    /// On real data this lands the crossover in the evening (clock through the
-    /// morning/afternoon, the learned shape only once most of the day is seen),
-    /// which is exactly where the shape's win is significant and durable. This
-    /// is the EOD analogue of the burn tournament's selector.
-    static func eodShapeCrossover(periods: [ForecastInput.PriorPeriod], calendar: Calendar) -> Double {
-        let shape = RegimeGatedEOD(), clock = AverageRateForecaster()
-        let cases = WalkForward.cases(
-            periods: periods, periodEnd: { $0.start.addingTimeInterval(86400) },
-            cutFractions: eodCutFractions, calendar: calendar)
-        let coverage = WalkForward.score(models: [shape], cases: cases)
-        let paired = WalkForward.paired(model: shape, baseline: clock, cases: cases)
-        func robustWin(at cf: Double) -> Bool {
-            let bucket = "cut=\(String(format: "%.2f", cf))|all"
-            let cov = coverage.first { $0.bucket == bucket }?.coverage ?? 0
-            guard let p = paired.first(where: { $0.bucket == bucket }) else { return false }
-            return cov >= eodShapeMinCoverage && p.n >= eodShapeMinShared
-                && p.winFraction >= eodShapeMinWinFraction && p.medianDelta < 0
-        }
-        // Walk fractions high → low; the crossover is the lowest fraction whose
-        // bucket and every later bucket are robust shape wins.
-        var crossover = Double.infinity
-        for cf in eodCutFractions.sorted(by: >) {
-            if robustWin(at: cf) { crossover = cf } else { break }
-        }
-        return crossover
     }
 
     static func clampPct(_ r: ClosedRange<Double>) -> ClosedRange<Double> {
@@ -546,5 +506,32 @@ public actor UsageIntelligenceEngine {
         var descriptor = FetchDescriptor<TokenSample>(sortBy: [SortDescriptor(\.sampledAt, order: .reverse)])
         descriptor.fetchLimit = 1
         return (try? modelContext.fetch(descriptor))?.first?.sampledAt
+    }
+
+    // MARK: - Self-eval persistence
+
+    private func fetchEODRecords() -> [EngineSelfEval.Record] {
+        let surface = EngineSelfEval.surfaceEOD
+        let descriptor = FetchDescriptor<EngineEvalOutcome>(predicate: #Predicate { $0.surface == surface })
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.map { .init(method: $0.method, bucket: $0.bucket, periodKey: $0.periodKey,
+                                predicted: $0.predicted, truth: $0.truth) }
+    }
+
+    /// Score the prior complete days' candidates into persisted outcomes, once
+    /// each (idempotent by key) — the standing re-score that grows the per-user
+    /// track record on every scan.
+    private func recordNewEODOutcomes(periods: [ForecastInput.PriorPeriod], calendar: Calendar, now: Date) {
+        let surface = EngineSelfEval.surfaceEOD
+        let descriptor = FetchDescriptor<EngineEvalOutcome>(predicate: #Predicate { $0.surface == surface })
+        let existingKeys = Set((try? modelContext.fetch(descriptor))?.map { $0.key } ?? [])
+        let news = EngineSelfEval.newOutcomesEOD(periods: periods, calendar: calendar, existingKeys: existingKeys)
+        guard !news.isEmpty else { return }
+        for n in news {
+            modelContext.insert(EngineEvalOutcome(
+                surface: n.surface, method: n.method, bucket: n.bucket, periodKey: n.periodKey,
+                predicted: n.predicted, truth: n.truth, recordedAt: now))
+        }
+        try? modelContext.save()
     }
 }

--- a/PacerCore/Sources/PacerCore/Models/EngineEvalOutcome.swift
+++ b/PacerCore/Sources/PacerCore/Models/EngineEvalOutcome.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+/// How one engine prediction method actually did on one *completed* period —
+/// the persisted memory that turns the engine's selection into a self-improving,
+/// per-user loop. The cost-surface analogue of `ForecastModelOutcome` (which
+/// does this for rate-limit cycles); generalising the feedback loop to "all
+/// surfaces" is the whole point of this layer.
+///
+/// One row = one (surface, method, bucket, period): what a candidate predicted
+/// for that period at that cut bucket, and the realized truth. `EngineSelfEval`
+/// scores newly-completed periods into these rows on each scan (idempotent), and
+/// reads the accumulated rows back to pick the per-user winner and to report
+/// "method X is right to Y% on your data". Because it persists, the track record
+/// survives restarts and keeps growing — the engine learns continuously from the
+/// user's own outcomes rather than re-deriving from scratch each launch, and it
+/// outlives the raw aggregates (which get pruned).
+@Model
+public final class EngineEvalOutcome {
+    #Index<EngineEvalOutcome>([\.surface], [\.surface, \.bucket])
+
+    /// `"\(surface)|\(method)|\(bucket)|\(periodKey)"` — unique so a completed
+    /// period is scored exactly once per method/bucket.
+    @Attribute(.unique) public var key: String
+    /// Which engine surface this scores, e.g. `"eod"` (extensible: monthly, …).
+    public var surface: String
+    /// The candidate's stable id (a `Forecaster.id`, e.g. `"average-rate"` or
+    /// `"regime-gated-eod"`).
+    public var method: String
+    /// The walk-forward bucket the prediction was made in, e.g. `"cut=0.75|all"`.
+    public var bucket: String
+    /// The completed period's identity — `yyyy-MM-dd` for the end-of-day surface.
+    public var periodKey: String
+    /// What the candidate projected for the period total at this cut.
+    public var predicted: Double
+    /// The realized period total (the truth the candidates aimed at).
+    public var truth: Double
+    /// Absolute percentage error, stored so the scoreboard aggregates without
+    /// recomputing.
+    public var absPctError: Double
+    public var recordedAt: Date
+
+    public init(
+        surface: String,
+        method: String,
+        bucket: String,
+        periodKey: String,
+        predicted: Double,
+        truth: Double,
+        recordedAt: Date = Date()
+    ) {
+        self.key = Self.makeKey(surface: surface, method: method, bucket: bucket, periodKey: periodKey)
+        self.surface = surface
+        self.method = method
+        self.bucket = bucket
+        self.periodKey = periodKey
+        self.predicted = predicted
+        self.truth = truth
+        self.absPctError = truth > 0 ? abs(predicted - truth) / truth * 100 : .infinity
+        self.recordedAt = recordedAt
+    }
+
+    public static func makeKey(surface: String, method: String, bucket: String, periodKey: String) -> String {
+        "\(surface)|\(method)|\(bucket)|\(periodKey)"
+    }
+}

--- a/PacerCore/Sources/PacerCore/PacerStore.swift
+++ b/PacerCore/Sources/PacerCore/PacerStore.swift
@@ -114,6 +114,7 @@ public enum PacerStore {
         ProjectBudget.self,
         AlertRule.self,
         ForecastModelOutcome.self,
+        EngineEvalOutcome.self,
     ]
 
     public static func makeModelContainer() throws -> ModelContainer {

--- a/PacerCore/Tests/PacerCoreTests/EngineSelfEvalTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/EngineSelfEvalTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+import SwiftData
+@testable import PacerCore
+
+/// Tests for the self-eval feedback loop: scoring completed days into the
+/// persisted scoreboard, learning the per-user clock→shape crossover from the
+/// accumulated record, the accuracy report, and the end-to-end actor path.
+@Suite("Engine self-eval")
+struct EngineSelfEvalTests {
+
+    static var utc: Calendar {
+        var c = Calendar(identifier: .gregorian); c.timeZone = TimeZone(identifier: "UTC")!; return c
+    }
+    static let now = utc.date(from: DateComponents(year: 2026, month: 6, day: 10, hour: 20, minute: 30))!
+
+    private func bucket(_ cf: Double) -> String { "cut=\(String(format: "%.2f", cf))|all" }
+    private func rec(_ method: String, _ cf: Double, _ period: String, _ predicted: Double, _ truth: Double) -> EngineSelfEval.Record {
+        .init(method: method, bucket: bucket(cf), periodKey: period, predicted: predicted, truth: truth)
+    }
+
+    // MARK: - Crossover from the persisted record
+
+    @Test func crossoverPicksEveningTailWhereShapeRobustlyWins() {
+        // Shape is much closer than clock only at the late buckets (>=0.75);
+        // clock wins earlier. Crossover should land at the start of that tail.
+        var records: [EngineSelfEval.Record] = []
+        for i in 0..<12 {
+            let p = "p\(i)", truth = 100.0
+            for cf in EngineSelfEval.cutFractions {
+                let lateWin = cf >= 0.75
+                records.append(rec("regime-gated-eod", cf, p, lateWin ? 100 : 150, truth))  // APE 0 late, 50 early
+                records.append(rec("average-rate", cf, p, lateWin ? 130 : 110, truth))       // APE 30 late, 10 early
+            }
+        }
+        #expect(EngineSelfEval.crossover(from: records) == 0.75)
+    }
+
+    @Test func crossoverIsInfinityWhenShapeNeverRobustlyWins() {
+        // Shape always worse → never selected → clock all day.
+        var records: [EngineSelfEval.Record] = []
+        for i in 0..<12 {
+            let p = "p\(i)", truth = 100.0
+            for cf in EngineSelfEval.cutFractions {
+                records.append(rec("regime-gated-eod", cf, p, 200, truth))   // APE 100
+                records.append(rec("average-rate", cf, p, 110, truth))       // APE 10
+            }
+        }
+        #expect(EngineSelfEval.crossover(from: records) == .infinity)
+    }
+
+    @Test func crossoverIsInfinityOnThinData() {
+        // Even a clean shape win doesn't get trusted below the shared-day bar.
+        var records: [EngineSelfEval.Record] = []
+        for i in 0..<5 {                      // < minShared
+            let p = "p\(i)", truth = 100.0
+            records.append(rec("regime-gated-eod", 0.875, p, 100, truth))
+            records.append(rec("average-rate", 0.875, p, 140, truth))
+        }
+        #expect(EngineSelfEval.crossover(from: records) == .infinity)
+    }
+
+    // MARK: - Accuracy report
+
+    @Test func accuracyReportsMedianErrorPerMethod() {
+        let records = [
+            rec("average-rate", 0.5, "p0", 110, 100),   // APE 10
+            rec("average-rate", 0.5, "p1", 120, 100),   // APE 20
+            rec("average-rate", 0.5, "p2", 130, 100),   // APE 30
+        ]
+        let acc = EngineSelfEval.accuracy(from: records)
+        let clock = acc.methods.first { $0.method == "average-rate" }
+        #expect(clock?.periods == 3)
+        #expect(abs((clock?.medianAbsPctError ?? 0) - 20) < 1e-9)
+    }
+
+    // MARK: - Scoring completed days (pure)
+
+    @Test func newOutcomesAreIdempotentAndCoverBothMethods() {
+        // Build prior days as cumulative-by-hour periods via the feature builder.
+        var hourly: [EngineFeatures.HourlyRow] = []
+        var daily: [EngineFeatures.DailyRow] = []
+        let cal = Self.utc
+        for i in 1...30 {
+            let day = cal.date(byAdding: .day, value: -i, to: cal.startOfDay(for: Self.now))!
+            let k = TokenSample.formatDate(day, timeZone: cal.timeZone)
+            for h in [9, 13, 17] { hourly.append(.init(date: k, hour: h, cost: 12, sampleCount: 1)) }
+            daily.append(.init(date: k, cost: 36))
+        }
+        let f = EngineFeatures.build(now: Self.now, calendar: cal, daily: daily, hourly: hourly, rate: [], lastArrivalAt: nil)
+
+        let first = EngineSelfEval.newOutcomesEOD(periods: f.dailyPeriods, calendar: cal, existingKeys: [])
+        #expect(!first.isEmpty)
+        #expect(first.contains { $0.method == "average-rate" })
+        #expect(first.contains { $0.method == "regime-gated-eod" })
+
+        // Re-running with everything already recorded yields nothing new.
+        let keys = Set(first.map { EngineEvalOutcome.makeKey(surface: $0.surface, method: $0.method, bucket: $0.bucket, periodKey: $0.periodKey) })
+        let second = EngineSelfEval.newOutcomesEOD(periods: f.dailyPeriods, calendar: cal, existingKeys: keys)
+        #expect(second.isEmpty)
+    }
+
+    // MARK: - End-to-end actor persistence
+
+    @Test func recomputePersistsScoreboardAndIsIdempotent() async throws {
+        let container = try PacerStore.makeInMemoryContainer()
+        let cal = Self.utc
+
+        // Seed ~30 prior complete days of pre-aggregated cost.
+        let seed = ModelContext(container)
+        for i in 1...30 {
+            let day = cal.date(byAdding: .day, value: -i, to: cal.startOfDay(for: Self.now))!
+            let k = TokenSample.formatDate(day, timeZone: cal.timeZone)
+            seed.insert(DailyAggregate(date: k, model: "m", totalCostUSD: 36))
+            for h in [9, 13, 17] {
+                seed.insert(HourlyAggregate(date: k, hour: h, model: "m", totalCostUSD: 12, sampleCount: 1))
+            }
+        }
+        try seed.save()
+
+        let engine = UsageIntelligenceEngine(modelContainer: container)
+        await engine.recompute(now: Self.now, calendar: cal)
+
+        func outcomeCount() throws -> Int {
+            try ModelContext(container).fetch(FetchDescriptor<EngineEvalOutcome>()).count
+        }
+        let afterFirst = try outcomeCount()
+        #expect(afterFirst > 0)                       // the scoreboard persisted
+
+        // A second recompute scores nothing new — the loop is idempotent.
+        await engine.recompute(now: Self.now, calendar: cal)
+        #expect(try outcomeCount() == afterFirst)
+
+        // The track record is exposed and includes the clock baseline.
+        let acc = await engine.selfEvalAccuracy()
+        #expect(acc != nil)
+        #expect(acc?.methods.contains { $0.method == "average-rate" } == true)
+    }
+}


### PR DESCRIPTION
PR9 of the on-device intelligence engine (#65 = PR8). Generalizes the rate-limit feedback loop to the cost/end-of-day surface and drives selection from an **accumulating per-user track record**, so the engine improves as it's used rather than re-deriving its choices cold each launch — the "learn constantly" piece.

## What's here
- **`EngineEvalOutcome`** (`@Model`, additive — lightweight migration, no SwiftData reset): one row per `(surface, method, bucket, completed-period)` = what a candidate predicted for that period at that cut, and the realized truth. The cost-surface analogue of `ForecastModelOutcome`.
- **`EngineSelfEval`** (pure, SwiftData-free): scores newly-completed days into the scoreboard (idempotent — each period scored once per method), and learns the per-user **clock→shape crossover from the accumulated record** instead of a cold recompute. The end-of-day selection authority now lives here.
- The engine records on every `recompute` (the scan tick already drives it) and resolves the crossover from the persisted scoreboard. The record survives restarts, keeps growing, and outlives the raw aggregates (which get pruned). New `selfEvalAccuracy()` exposes "method X is right to Y% on your data" for a future transparency affordance.

## Addresses the feedback from the last round
- *"It should learn from my own data, not yours-shipped"*: the models already refit per-user on-device; this adds the **persistent per-user track record** that drives selection. The only shared element is the **significance bar** (coverage + a deterministic majority sign-test) — a generic statistical default applied to *each user's own* outcomes, like a p-value threshold. PR8's hardcoded crossover constants are gone (folded into that per-user-applied bar).
- The bootstrap-CI significance test was rejected because it flaps run-to-run (Swift `Dictionary`/`Set` iteration order isn't stable, so the seeded bootstrap resamples differ); the sign-test is deterministic at small n.

## Validation
On the real store the persisted path **reproduces PR8's crossover exactly (0.75)** and reports `regime-gated-eod` 18.5% vs `average-rate` (clock) 30% pooled — i.e. the learned selection is unchanged, now accumulating per-user. 6 new tests; `make test` 436 green; app builds, migrates, and runs clean.

## Next
PR7 — spend-by-model NNLS attribution (least critical, transparency). And the natural follow-on this enables: a CreateML on-device candidate that joins the tournament and only gets selected if it beats a given user's own baselines on this very scoreboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)