### PR TITLE
feat(intelligence): extend the self-eval loop to the rate-limit outlook

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
@@ -161,6 +161,88 @@ public enum EngineSelfEval {
         return Accuracy(surface: surface, methods: methods)
     }
 
+    // MARK: - Rate-limit outlook self-eval
+
+    /// Surface id for a rate-limit window's outlook track record.
+    public static func rlSurface(_ window: String) -> String { "rl-\(window)" }
+    /// Cut grid for scoring completed cycles (mirrors `scoreCompletedCycle`).
+    static let rlCutFractions = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+
+    /// Score the rate-limit roster over *completed* cycles and emit the
+    /// outcomes not already persisted — the rate-limit analogue of
+    /// `newOutcomesEOD`, and how the diurnal model finally earns a persistent
+    /// per-user track record instead of being re-picked cold each scan.
+    ///
+    /// Leak-free by walk-forward: the diurnal model scored against cycle *i* is
+    /// fit only on cycles *before* it (plus the activity-grid prior, which is a
+    /// cost-activity shape, not the rate-limit data being scored).
+    public static func newOutcomesRL(
+        window: String,
+        cycles: [BurnTrajectory.Cycle],
+        activityGrid: [[Double]],
+        calendar: Calendar,
+        existingKeys: Set<String>,
+        includeDiurnal: Bool
+    ) -> [NewOutcome] {
+        let surface = rlSurface(window)
+        let sorted = cycles.sorted { $0.cycleStart < $1.cycleStart }
+        var out: [NewOutcome] = []
+        for (i, cycle) in sorted.enumerated() {
+            let trueFinal = cycle.samples.map { $0.usedPercentage }.max() ?? 0
+            guard trueFinal > 0 else { continue }
+            let periodKey = periodKeyRL(cycle.resetsAt)
+            var roster = BurnTrajectory.defaultModels
+            if includeDiurnal {
+                let table = DiurnalBurnModel.rateTable(cycles: Array(sorted[0..<i]), calendar: calendar, prior: activityGrid)
+                roster.append(DiurnalBurnModel(rate: table, calendar: calendar))
+            }
+            let duration = cycle.resetsAt.timeIntervalSince(cycle.cycleStart)
+            guard duration > 0 else { continue }
+            for cf in rlCutFractions {
+                let now = cycle.cycleStart.addingTimeInterval(duration * cf)
+                let seen = cycle.samples.filter { $0.at <= now }
+                guard seen.count >= 3 else { continue }
+                let partial = BurnTrajectory.PartialCycle(
+                    samples: seen, now: now, cycleStart: cycle.cycleStart, resetsAt: cycle.resetsAt)
+                let bucket = "cut=\(String(format: "%.2f", cf))"
+                for m in roster {
+                    let key = EngineEvalOutcome.makeKey(surface: surface, method: m.id, bucket: bucket, periodKey: periodKey)
+                    guard !existingKeys.contains(key) else { continue }
+                    guard let proj = m.fit(partial) else { continue }
+                    out.append(NewOutcome(surface: surface, method: m.id, bucket: bucket,
+                                          periodKey: periodKey, predicted: proj(cycle.resetsAt), truth: trueFinal))
+                }
+            }
+        }
+        return out
+    }
+
+    /// Pick the best method from an accumulated record: lowest median absolute
+    /// error, breaking near-ties (within 2pp) toward the simpler model. `nil`
+    /// until at least `minPeriods` completed periods back a method — the engine
+    /// then falls back to its cold on-the-fly backtest.
+    public static func bestMethod(
+        from records: [Record],
+        minPeriods: Int = 2,
+        complexity: [String: Int] = [:]
+    ) -> String? {
+        let byMethod = Dictionary(grouping: records, by: { $0.method })
+        let scored = byMethod.compactMap { id, rows -> (id: String, err: Double, cx: Int)? in
+            guard Set(rows.map { $0.periodKey }).count >= minPeriods else { return nil }
+            return (id, median(rows.map { $0.absPctError }), complexity[id] ?? 3)
+        }
+        guard let best = scored.min(by: { $0.err < $1.err }) else { return nil }
+        return scored.filter { $0.err <= best.err + 2 }
+            .min { ($0.cx, $0.err) < ($1.cx, $1.err) }?.id
+    }
+
+    /// Cycle identity, rounded to the minute so reset jitter doesn't split a
+    /// cycle across scans (matches `BurnTrajectory.segment`).
+    static func periodKeyRL(_ reset: Date) -> String {
+        let rounded = Date(timeIntervalSince1970: (reset.timeIntervalSince1970 / 60).rounded() * 60)
+        return ISO8601DateFormatter().string(from: rounded)
+    }
+
     // MARK: - Stats
 
     static func median(_ xs: [Double]) -> Double {

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -67,8 +67,9 @@ public actor UsageIntelligenceEngine {
     private var features: EngineFeatures?
     /// The per-user fit derived from `features`.
     private var fit = Fit()
-    /// The per-user end-of-day method track record, refreshed each recompute.
-    private var eodAccuracy: EngineSelfEval.Accuracy?
+    /// Per-surface method track records (end-of-day, rate-limit windows),
+    /// refreshed each recompute.
+    private var accuracyBySurface: [String: EngineSelfEval.Accuracy] = [:]
 
     /// Per-user fitted state cached between scans. Holds the shapes that are
     /// expensive to derive (calibrators, the diurnal rate table); the cheap,
@@ -114,24 +115,50 @@ public actor UsageIntelligenceEngine {
             lastArrivalAt: fetchLastArrival())
         self.features = f
 
-        // Self-eval feedback loop: score any newly-completed days into the
-        // persisted scoreboard (idempotent), then drive end-of-day selection
-        // from the accumulated per-user track record — not a value recomputed
-        // cold each launch. Empty store ⇒ no records ⇒ clock-only (safe).
+        // Self-eval feedback loop: score newly-completed periods into the
+        // persisted scoreboard (idempotent), then drive selection from the
+        // accumulated per-user track record — not a value recomputed cold each
+        // launch. Empty store ⇒ no records ⇒ safe defaults.
         recordNewEODOutcomes(periods: f.dailyPeriods, calendar: calendar, now: now)
-        let records = fetchEODRecords()
-        self.eodAccuracy = EngineSelfEval.accuracy(from: records)
-        self.fit = Self.makeFit(f, eodCrossover: EngineSelfEval.crossover(from: records))
+        recordNewRLOutcomes(features: f, calendar: calendar, now: now)
+
+        let eodRecords = fetchRecords(surface: EngineSelfEval.surfaceEOD)
+        accuracyBySurface[EngineSelfEval.surfaceEOD] = EngineSelfEval.accuracy(from: eodRecords)
+
+        // Pick each rate-limit window's outlook model from its accumulated
+        // record (the diurnal model now competes here on realized accuracy).
+        var rlSelection: [String: String] = [:]
+        for window in RateLimitWindowKind.allCases {
+            let surface = EngineSelfEval.rlSurface(window.rawValue)
+            let recs = fetchRecords(surface: surface)
+            accuracyBySurface[surface] = EngineSelfEval.accuracy(surface: surface, from: recs)
+            if let pick = EngineSelfEval.bestMethod(from: recs, complexity: Self.rlComplexities(window)) {
+                rlSelection[window.rawValue] = pick
+            }
+        }
+
+        self.fit = Self.makeFit(f, eodCrossover: EngineSelfEval.crossover(from: eodRecords), rlSelection: rlSelection)
     }
 
     /// Number of historical days the fit was trained on — for a future
     /// "the engine knows X days about you" affordance and for tests.
     public func trainingDayCount() -> Int { features?.dailyPeriods.count ?? 0 }
 
-    /// How each end-of-day prediction method is doing on this user's own data —
-    /// median absolute % error and how many completed days back it, best-first.
-    /// `nil` before the first recompute; empty methods until some days complete.
-    public func selfEvalAccuracy() -> EngineSelfEval.Accuracy? { eodAccuracy }
+    /// How each prediction method is doing on this user's own data for a surface
+    /// (`EngineSelfEval.surfaceEOD`, or `EngineSelfEval.rlSurface(window)`):
+    /// median absolute % error and how many completed periods back it,
+    /// best-first. `nil` before the first recompute or for an unscored surface.
+    public func selfEvalAccuracy(surface: String = EngineSelfEval.surfaceEOD) -> EngineSelfEval.Accuracy? {
+        accuracyBySurface[surface]
+    }
+
+    /// Roster complexities for a rate-limit window — so the persisted-scoreboard
+    /// pick can break near-ties toward the simpler model.
+    static func rlComplexities(_ window: RateLimitWindowKind) -> [String: Int] {
+        var c = Dictionary(uniqueKeysWithValues: BurnTrajectory.defaultModels.map { ($0.id, $0.complexity) })
+        if window == .sevenDay { c["diurnal-rate"] = 3 }
+        return c
+    }
 
     // MARK: - Ask (the typed question → Estimate contract)
 
@@ -284,7 +311,7 @@ public actor UsageIntelligenceEngine {
     /// Build the per-user fit. `eodCrossover` is the learned clock→shape switch
     /// fraction, resolved by `recompute` from the persisted self-eval scoreboard
     /// (`.infinity` = clock all day, the safe default before any track record).
-    static func makeFit(_ f: EngineFeatures, eodCrossover: Double = .infinity) -> Fit {
+    static func makeFit(_ f: EngineFeatures, eodCrossover: Double = .infinity, rlSelection: [String: String] = [:]) -> Fit {
         var fit = Fit()
         let shape = RegimeGatedEOD()
         let clock = AverageRateForecaster()
@@ -313,13 +340,15 @@ public actor UsageIntelligenceEngine {
                 roster.append(DiurnalBurnModel(rate: table, calendar: f.calendar))
             }
 
+            // Prefer the accumulated per-user track record (`rlSelection`);
+            // fall back to a cold on-the-fly backtest, then a hardcoded default
+            // (diurnal for 7d — it works off the activity prior even with no
+            // completed cycles — recency-weighted for 5h).
             let scores = BurnTrajectory.score(models: roster, cycles: history)
-            let picked = ForecastSelector.select(
+            let onTheFly = ForecastSelector.select(
                 scores: scores, policy: .init(minScoredCases: 6, minCoverage: 0.5)).id
-            // Cold-start default: the diurnal model for 7d (it works off the
-            // activity prior even with no completed cycles), recency-weighted
-            // for 5h (tracks that window best on real data).
-            let selectedId = picked ?? (window == .sevenDay ? "diurnal-rate" : "recency-weighted")
+            let selectedId = rlSelection[window.rawValue] ?? onTheFly
+                ?? (window == .sevenDay ? "diurnal-rate" : "recency-weighted")
             let model = roster.first { $0.id == selectedId } ?? roster.first
             let calibrator = model.map { rateLimitCalibrator(model: $0, history: history, duration: duration) }
 
@@ -510,22 +539,19 @@ public actor UsageIntelligenceEngine {
 
     // MARK: - Self-eval persistence
 
-    private func fetchEODRecords() -> [EngineSelfEval.Record] {
-        let surface = EngineSelfEval.surfaceEOD
+    private func fetchRecords(surface: String) -> [EngineSelfEval.Record] {
         let descriptor = FetchDescriptor<EngineEvalOutcome>(predicate: #Predicate { $0.surface == surface })
         let rows = (try? modelContext.fetch(descriptor)) ?? []
         return rows.map { .init(method: $0.method, bucket: $0.bucket, periodKey: $0.periodKey,
                                 predicted: $0.predicted, truth: $0.truth) }
     }
 
-    /// Score the prior complete days' candidates into persisted outcomes, once
-    /// each (idempotent by key) — the standing re-score that grows the per-user
-    /// track record on every scan.
-    private func recordNewEODOutcomes(periods: [ForecastInput.PriorPeriod], calendar: Calendar, now: Date) {
-        let surface = EngineSelfEval.surfaceEOD
+    private func existingKeys(surface: String) -> Set<String> {
         let descriptor = FetchDescriptor<EngineEvalOutcome>(predicate: #Predicate { $0.surface == surface })
-        let existingKeys = Set((try? modelContext.fetch(descriptor))?.map { $0.key } ?? [])
-        let news = EngineSelfEval.newOutcomesEOD(periods: periods, calendar: calendar, existingKeys: existingKeys)
+        return Set((try? modelContext.fetch(descriptor))?.map { $0.key } ?? [])
+    }
+
+    private func persist(_ news: [EngineSelfEval.NewOutcome], now: Date) {
         guard !news.isEmpty else { return }
         for n in news {
             modelContext.insert(EngineEvalOutcome(
@@ -533,5 +559,31 @@ public actor UsageIntelligenceEngine {
                 predicted: n.predicted, truth: n.truth, recordedAt: now))
         }
         try? modelContext.save()
+    }
+
+    /// Score the prior complete days' candidates into persisted outcomes, once
+    /// each (idempotent by key) — the standing re-score that grows the per-user
+    /// track record on every scan.
+    private func recordNewEODOutcomes(periods: [ForecastInput.PriorPeriod], calendar: Calendar, now: Date) {
+        let news = EngineSelfEval.newOutcomesEOD(
+            periods: periods, calendar: calendar, existingKeys: existingKeys(surface: EngineSelfEval.surfaceEOD))
+        persist(news, now: now)
+    }
+
+    /// Score each rate-limit window's roster over its newly-completed cycles —
+    /// the diurnal model (7d) finally earns a persistent per-user track record.
+    private func recordNewRLOutcomes(features f: EngineFeatures, calendar: Calendar, now: Date) {
+        for window in RateLimitWindowKind.allCases {
+            guard let samples = f.rateLimit[window.rawValue], !samples.isEmpty,
+                  let duration = PaceMath.windowDuration(for: window.rawValue) else { continue }
+            let (_, history) = BurnTrajectory.segment(samples: samples, duration: duration, now: now)
+            let completed = history.filter { $0.resetsAt <= now }
+            guard !completed.isEmpty else { continue }
+            let news = EngineSelfEval.newOutcomesRL(
+                window: window.rawValue, cycles: completed, activityGrid: f.activityGrid, calendar: calendar,
+                existingKeys: existingKeys(surface: EngineSelfEval.rlSurface(window.rawValue)),
+                includeDiurnal: window == .sevenDay)
+            persist(news, now: now)
+        }
     }
 }

--- a/PacerCore/Tests/PacerCoreTests/EngineSelfEvalTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/EngineSelfEvalTests.swift
@@ -100,6 +100,53 @@ struct EngineSelfEvalTests {
         #expect(second.isEmpty)
     }
 
+    // MARK: - Rate-limit outlook self-eval
+
+    /// Build `n` complete 7-day cycles, each ramping 0 → ~60%.
+    private func sevenDayCycles(_ n: Int) -> [BurnTrajectory.Cycle] {
+        let duration: TimeInterval = 7 * 24 * 3600
+        return (0..<n).map { c in
+            let start = Self.now.addingTimeInterval(-Double(n - c) * duration)
+            let reset = start.addingTimeInterval(duration)
+            var samples: [BurnTrajectory.Sample] = []
+            var pct = 0.0, t = start
+            while t <= reset {
+                samples.append(.init(at: t, usedPercentage: min(60, pct)))
+                t = t.addingTimeInterval(6 * 3600); pct += 2.2
+            }
+            return BurnTrajectory.Cycle(samples: samples, cycleStart: start, resetsAt: reset)
+        }
+    }
+
+    @Test func rlOutcomesIncludeDiurnalAndAreIdempotent() {
+        let cycles = sevenDayCycles(4)
+        let grid = [[Double]](repeating: [Double](repeating: 1, count: 24), count: 7)
+        let first = EngineSelfEval.newOutcomesRL(
+            window: "seven_day", cycles: cycles, activityGrid: grid, calendar: Self.utc,
+            existingKeys: [], includeDiurnal: true)
+        #expect(!first.isEmpty)
+        #expect(first.contains { $0.method == "diurnal-rate" })          // the diurnal model earns a record
+        #expect(first.contains { $0.method == "linear-recent" })
+
+        let keys = Set(first.map { EngineEvalOutcome.makeKey(surface: $0.surface, method: $0.method, bucket: $0.bucket, periodKey: $0.periodKey) })
+        let second = EngineSelfEval.newOutcomesRL(
+            window: "seven_day", cycles: cycles, activityGrid: grid, calendar: Self.utc,
+            existingKeys: keys, includeDiurnal: true)
+        #expect(second.isEmpty)
+    }
+
+    @Test func bestMethodPrefersLowerErrorAcrossPeriods() {
+        var records: [EngineSelfEval.Record] = []
+        for i in 0..<4 {
+            let p = "c\(i)", truth = 60.0
+            records.append(.init(method: "diurnal-rate", bucket: "cut=0.50", periodKey: p, predicted: 58, truth: truth))   // APE ~3
+            records.append(.init(method: "linear-recent", bucket: "cut=0.50", periodKey: p, predicted: 90, truth: truth))  // APE 50
+        }
+        #expect(EngineSelfEval.bestMethod(from: records) == "diurnal-rate")
+        // Below the min-periods bar, no pick (engine falls back to on-the-fly).
+        #expect(EngineSelfEval.bestMethod(from: Array(records.prefix(1)), minPeriods: 2) == nil)
+    }
+
     // MARK: - End-to-end actor persistence
 
     @Test func recomputePersistsScoreboardAndIsIdempotent() async throws {
@@ -135,5 +182,35 @@ struct EngineSelfEvalTests {
         let acc = await engine.selfEvalAccuracy()
         #expect(acc != nil)
         #expect(acc?.methods.contains { $0.method == "average-rate" } == true)
+    }
+
+    @Test func recomputePersistsRateLimitTrackRecordIncludingDiurnal() async throws {
+        let container = try PacerStore.makeInMemoryContainer()
+        let cal = Self.utc
+        let duration: TimeInterval = 7 * 24 * 3600
+
+        // Seed 3 complete 7-day cycles of OAuth utilisation samples.
+        let seed = ModelContext(container)
+        for c in 0..<3 {
+            let start = Self.now.addingTimeInterval(-Double(3 - c) * duration)
+            let reset = start.addingTimeInterval(duration)
+            var pct = 0.0, t = start
+            while t <= reset {
+                seed.insert(RateLimitSample(sampledAt: t, window: "seven_day", usedPercentage: min(60, pct), resetsAt: reset, source: "oauth"))
+                t = t.addingTimeInterval(6 * 3600); pct += 2.2
+            }
+        }
+        try seed.save()
+
+        let engine = UsageIntelligenceEngine(modelContainer: container)
+        await engine.recompute(now: Self.now, calendar: cal)
+
+        let rows = try ModelContext(container).fetch(FetchDescriptor<EngineEvalOutcome>())
+        let rl = rows.filter { $0.surface == EngineSelfEval.rlSurface("seven_day") }
+        #expect(!rl.isEmpty)
+        #expect(rl.contains { $0.method == "diurnal-rate" })   // diurnal now has a persisted track record
+
+        let acc = await engine.selfEvalAccuracy(surface: EngineSelfEval.rlSurface("seven_day"))
+        #expect(acc != nil)
     }
 }


### PR DESCRIPTION
Finishes PR9's "all surfaces" (#66 did end-of-day): the engine's **diurnal 7-day rate-limit model now earns a persistent per-user track record** instead of being re-selected cold each scan.

## What's here
- **`EngineSelfEval.newOutcomesRL`** — scores each window's roster (the four burn baselines + the diurnal model on 7d) over completed cycles, **leak-free by walk-forward**: the diurnal rate table for cycle *i* is fit only on cycles before it (plus the activity-grid prior, a cost-activity shape, not the rate-limit data being scored). Persisted into `EngineEvalOutcome` under an `rl-<window>` surface, idempotent per cycle.
- **`EngineSelfEval.bestMethod`** — picks the lowest-median-error method from the accumulated record, prefer-simpler on near-ties, `nil` below a min-cycles bar (engine then falls back to the cold on-the-fly backtest).
- The engine records rate-limit outcomes on every `recompute` and selects each window's outlook model from its accumulated record. `selfEvalAccuracy(surface:)` now reports any surface (end-of-day or a rate-limit window).

## Validation (real store, real activity grid)
The leak-free walk-forward over Eric's 5 completed 7-day cycles confirms diurnal genuinely wins:

| method | median APE |
|---|---:|
| **diurnal-rate** | **23.1%** |
| saturating | 25.7% |
| damped-acceleration | 77.4% |
| linear-recent | 83.0% |
| recency-weighted | 91.2% |

Same pick as PR8 — now *earned* from a persistent leak-free record rather than a cold fit on all cycles. A uniform-grid control flipped the winner to `saturating`, confirming the activity grid is load-bearing for the diurnal model (a useful robustness fact).

## Scope
No App changes — `recompute` (already on the scan tick) does the recording. 3 new tests; `make test` 439 green; app builds, migrates, runs clean.

This completes the engine's feedback loop across its forecasting surfaces. Remaining backlog item is PR7 (per-model rate-limit attribution, transparency) if/when wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)