### PR TITLE
fix(oauth): only accept a .credentials.json that holds claudeAiOauth

### DIFF
--- a/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
@@ -303,14 +303,21 @@ public struct KeychainOAuth: Sendable {
         return urls
     }
 
-    /// First readable, non-empty file from `urls`, as raw bytes. `nil`
-    /// when none exist or are readable — the caller maps that back to the
-    /// keychain error so a clean machine still reports `.notFound`.
-    /// Deliberately tolerant: a missing candidate is normal (not every box
-    /// has every layout), so we just try the next one.
+    /// First file from `urls` that actually holds a Claude Code OAuth
+    /// credential, as raw bytes. We require the `claudeAiOauth` marker so we
+    /// SKIP an unrelated `.credentials.json`: on macOS that filename is the
+    /// per-plugin MCP token store (top-level `mcpOAuth`), while the OAuth
+    /// credential lives only in the keychain — the `claudeAiOauth` file form
+    /// is the Linux/headless layout. `nil` when no candidate qualifies, which
+    /// the caller maps back to the keychain error (so a clean machine still
+    /// reports `.notFound` rather than a misleading malformed error).
+    /// Deliberately tolerant: a missing/foreign candidate is normal, so we
+    /// just try the next one.
     static func readCredentialsFileData(urls: [URL]) -> Data? {
+        let marker = Data("claudeAiOauth".utf8)
         for url in urls {
-            if let data = try? Data(contentsOf: url), !data.isEmpty {
+            guard let data = try? Data(contentsOf: url), !data.isEmpty else { continue }
+            if data.range(of: marker) != nil {
                 return data
             }
         }

--- a/PacerCore/Tests/PacerCoreTests/KeychainOAuthTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/KeychainOAuthTests.swift
@@ -179,17 +179,21 @@ import Testing
 
         let missing = dir.appendingPathComponent("missing.json")
         let empty = dir.appendingPathComponent("empty.json")
+        let mcp = dir.appendingPathComponent("mcp.json")
         let real = dir.appendingPathComponent("real.json")
         try Data().write(to: empty)
+        // A real macOS `~/.claude/.credentials.json`: MCP plugin tokens, NOT
+        // the OAuth credential. Must be skipped, not returned-then-rejected.
+        try Data(#"{"mcpOAuth":{"plugin:x|abc":{"accessToken":"nope"}}}"#.utf8).write(to: mcp)
         let blob = #"{"claudeAiOauth":{"accessToken":"tok"}}"#
         try Data(blob.utf8).write(to: real)
 
-        // First candidate missing, second empty (skipped), third is real.
-        let data = KeychainOAuth.readCredentialsFileData(urls: [missing, empty, real])
+        // Missing → skip, empty → skip, mcpOAuth → skip (no marker), real → hit.
+        let data = KeychainOAuth.readCredentialsFileData(urls: [missing, empty, mcp, real])
         #expect(data == Data(blob.utf8))
 
-        // None readable → nil.
-        #expect(KeychainOAuth.readCredentialsFileData(urls: [missing]) == nil)
+        // Only foreign/absent candidates → nil (so the caller reports .notFound).
+        #expect(KeychainOAuth.readCredentialsFileData(urls: [missing, mcp]) == nil)
     }
 
     @Test func fileFallbackBlobDecodesLikeKeychain() {


### PR DESCRIPTION
Follow-up to #82. While building a token-status inspector I checked the real `~/.claude/.credentials.json` on a Mac and found it holds **`mcpOAuth`** (per-plugin MCP tokens), not the `claudeAiOauth` OAuth credential — that's keychain-only on macOS; the `claudeAiOauth` file form is the Linux/headless layout.

The fallback added in #82 returned the first non-empty `.credentials.json` regardless of content, so over SSH on a Mac it would grab the mcpOAuth file and the decoder would report `.keychainMalformed` instead of a clean `.notFound`. (No impact when the keychain is readable — the fallback never triggers there.)

**Fix:** require the `claudeAiOauth` marker when selecting a credentials file; skip foreign files and keep scanning. `nil` when none qualify → caller surfaces the keychain error.

- 416 tests pass; the file-fallback test now asserts an mcpOAuth file is skipped in favor of a real `claudeAiOauth` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a7NXLY2ExtfrMpzDQUyDA