### PR TITLE
feat(oauth): read Claude Desktop credentials (opt-in) + freshest-token-wins

### DIFF
--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -136,6 +136,7 @@ public enum PacerSettings {
         public static let timeRange              = PacerPreferenceKeys.timeRange
         public static let projectsSort           = PacerPreferenceKeys.projectsSort
         public static let oauthTokenOverride     = PacerPreferenceKeys.oauthTokenOverride
+        public static let desktopCredentialsEnabled = PacerPreferenceKeys.desktopCredentialsEnabled
     }
 
     // MARK: - Defaults
@@ -170,6 +171,7 @@ public enum PacerSettings {
         Key.timeRange:             "90d",
         Key.projectsSort:          "cost",
         Key.oauthTokenOverride:    "",
+        Key.desktopCredentialsEnabled: false,
     ]
 
     /// Register the defaults dict on first launch — `@AppStorage`'s

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -38,6 +38,7 @@ struct SettingsView: View {
                     NotificationTestCard()
                 }
                 SettingsSection("Authentication") {
+                    DesktopCredentialsCard()
                     OAuthTokenOverrideCard()
                 }
                 SettingsSection("Data") {
@@ -964,6 +965,134 @@ private struct ProjectAliasesPointerCard: View {
 }
 
 // MARK: - Authentication
+
+/// Opt-in: also read Claude Desktop's credential. When on, Pacer decrypts
+/// Claude Desktop's `safeStorage` token cache (read-only) and the poller
+/// uses whichever of it or the Claude Code token is freshest — so Pacer
+/// keeps working for Desktop/chat-only users and across Claude Code's idle
+/// token gaps. Off by default; turning it on triggers the one-time
+/// "Claude Safe Storage" keychain approval, which the Test run surfaces.
+private struct DesktopCredentialsCard: View {
+    @AppStorage(PacerSettings.Key.desktopCredentialsEnabled, store: PacerSettings.store)
+    private var enabled: Bool = false
+
+    @State private var testResult: TestResult?
+    @State private var testInProgress = false
+
+    private enum TestResult: Equatable {
+        case success(fiveHourPct: Double?, sevenDayPct: Double?)
+        case failure(message: String)
+    }
+
+    var body: some View {
+        PacerCard("Claude Desktop credentials", content: {
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle("Use Claude Desktop credentials", isOn: $enabled)
+                    .onChange(of: enabled) { _, on in
+                        testResult = nil
+                        // Surface the one-time keychain approval right away,
+                        // and confirm the token actually works.
+                        if on { runTest() }
+                    }
+                HStack(spacing: 8) {
+                    statusLabel
+                    Spacer(minLength: 8)
+                    Button("Test") { runTest() }
+                        .controlSize(.small)
+                        .disabled(testInProgress || !enabled)
+                }
+            }
+        }, footer: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Lets Pacer keep working when you use Claude Desktop / general chat rather than the Claude Code CLI. Pacer decrypts Desktop's stored token (read-only — it never refreshes or writes it) and uses whichever of Desktop or Claude Code is freshest.")
+                Text("Turning this on triggers a one-time macOS keychain approval for “Claude Safe Storage” — click Always Allow so Pacer can read it silently afterward.")
+                    .padding(.top, 2)
+            }
+        })
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        if testInProgress {
+            ProgressView().controlSize(.small)
+            Text("Reading Claude Desktop…")
+                .font(.caption).foregroundStyle(.secondary)
+        } else if let result = testResult {
+            switch result {
+            case .success(let fh, let sd):
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green).font(.system(size: 12))
+                Text("Working · \(formatSuccess(fiveHour: fh, sevenDay: sd))")
+                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            case .failure(let msg):
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red).font(.system(size: 12))
+                Text(msg).font(.caption).foregroundStyle(.red).lineLimit(3)
+            }
+        } else if enabled {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green).font(.system(size: 12))
+            Text("On · Pacer uses Desktop when it's freshest")
+                .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+        } else {
+            Image(systemName: "desktopcomputer")
+                .foregroundStyle(.tertiary).font(.system(size: 12))
+            Text("Off · Pacer reads only Claude Code's token")
+                .font(.caption).foregroundStyle(.tertiary).lineLimit(1)
+        }
+    }
+
+    private func formatSuccess(fiveHour: Double?, sevenDay: Double?) -> String {
+        let f = fiveHour.map { "5h=\(Int($0.rounded()))%" } ?? "5h=—"
+        let s = sevenDay.map { "7d=\(Int($0.rounded()))%" } ?? "7d=—"
+        return "\(f), \(s)"
+    }
+
+    /// Read Desktop's credential and run one usage call with it — proves it
+    /// works and triggers the keychain approval. Forces a broken keychain +
+    /// no override so the result reflects the Desktop token alone.
+    private func runTest() {
+        testInProgress = true
+        testResult = nil
+        Task { @MainActor in
+            let brokenKeychain = KeychainOAuth(rawReader: { .failure(.notFound) })
+            let client = OAuthClient(
+                keychain: brokenKeychain,
+                tokenOverride: { nil },
+                desktopEnabled: { true }
+            )
+            let result = await client.fetchUsage()
+            testInProgress = false
+            testResult = Self.classify(result)
+        }
+    }
+
+    private static func classify(
+        _ result: Result<RateLimitSnapshot, OAuthClientError>
+    ) -> TestResult {
+        switch result {
+        case .success(let snapshot):
+            return .success(
+                fiveHourPct: snapshot.fiveHour?.usedPercentage,
+                sevenDayPct: snapshot.sevenDay?.usedPercentage
+            )
+        case .failure(.credentialsNotFound):
+            return .failure(message: "No Claude Desktop credential found. Is Claude Desktop installed and signed in?")
+        case .failure(.keychainAccessDenied):
+            return .failure(message: "Keychain access denied. Approve the “Claude Safe Storage” prompt and retry.")
+        case .failure(.tokenExpired):
+            return .failure(message: "Desktop's token is expired right now — open Claude Desktop briefly to refresh it.")
+        case .failure(.unauthorized):
+            return .failure(message: "Anthropic rejected Desktop's token (401).")
+        case .failure(.rateLimited):
+            return .failure(message: "Rate-limited (429). Try again in a moment.")
+        case .failure(.transport):
+            return .failure(message: "Network error. Check your connection and retry.")
+        default:
+            return .failure(message: "Couldn't read Claude Desktop's credential. Check ~/Library/Logs/Pacer/Pacer.err.log.")
+        }
+    }
+}
 
 /// Manual OAuth access-token override. When non-empty, the OAuth poller
 /// uses this token instead of the keychain / `.credentials.json` copy.

--- a/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
@@ -1,0 +1,237 @@
+import Foundation
+import CommonCrypto
+
+/// Errors from `DesktopOAuth.read()`. Distinct from `KeychainOAuthError`
+/// because the failure modes differ — Desktop stores its token encrypted,
+/// so there's a decrypt step and a "no usable token in the cache" case.
+public enum DesktopOAuthError: Error, Sendable, Equatable {
+    /// No `~/Library/Application Support/Claude/config.json` — Claude
+    /// Desktop isn't installed / has never signed in on this machine.
+    case configNotFound
+    /// Couldn't read the `Claude Safe Storage` AES key from the keychain
+    /// (item absent / spawn failure / unexpected status).
+    case keychainKeyUnavailable(OSStatus)
+    /// The keychain approval was declined, or we ran in a non-UI context.
+    /// Recoverable by approving the one-time prompt in the foreground app.
+    case keychainAccessDenied
+    /// The key read succeeded but decryption of every cache blob failed —
+    /// almost certainly an Electron `safeStorage` format change worth
+    /// investigating before suppressing.
+    case decryptFailed(String)
+    /// Decrypted fine, but no entry carried a `user:profile` token — which
+    /// is the scope `/api/oauth/usage` requires. (A Desktop install that
+    /// only ever did inference could in principle land here.)
+    case noProfileToken
+}
+
+/// Reads Claude Desktop's OAuth credential out of its Electron
+/// `safeStorage`-encrypted token cache, so Pacer keeps working for users
+/// who use Claude Desktop / general chat rather than the Claude Code CLI.
+///
+/// ## Where it lives (verified live on macOS)
+///
+///   - Keychain item `Claude Safe Storage` / account `Claude Key` holds an
+///     AES key (an ASCII base64 string, used as the PBKDF2 password as-is).
+///   - `~/Library/Application Support/Claude/config.json` holds the
+///     encrypted token cache under `oauth:tokenCache` (and `…CacheV2`),
+///     each value being `base64("v10" + AES-128-CBC ciphertext)`.
+///   - Decrypted, the cache is a dict keyed by
+///     `<client_id>:<account>:<host>:<space-separated scopes>`; each value
+///     is `{ token, refreshToken, expiresAt(ms), subscriptionType, … }`.
+///     Entries whose scopes include `user:profile` work against
+///     `/api/oauth/usage`; we pick the freshest such token.
+///
+/// ## safeStorage decryption (Chromium OSCrypt, macOS)
+///
+/// AES-128-CBC, key = PBKDF2-HMAC-SHA1(keychain-password, salt "saltysalt",
+/// 1003 rounds, 16 bytes), IV = 16 × 0x20, PKCS#7 padding, after stripping
+/// the 3-byte `v10` prefix. All constants are Chromium's.
+///
+/// ## Safety
+///
+/// Strictly read-only: Pacer never writes `config.json` and never refreshes
+/// Desktop's token, so it can't rotate the shared refresh token or disturb
+/// the Desktop session. Gated behind an explicit opt-in (the first read
+/// triggers the one-time `Claude Safe Storage` keychain approval).
+public struct DesktopOAuth: Sendable {
+
+    public static let keychainService = "Claude Safe Storage"
+    public static let keychainAccount = "Claude Key"
+
+    /// Returns the safeStorage key password bytes (the ASCII base64 string,
+    /// trailing newline stripped), or a typed error. Injected for tests.
+    public typealias KeyReader = @Sendable () -> Result<Data, DesktopOAuthError>
+    /// Returns the encrypted cache blobs from config.json, or nil when the
+    /// config file is absent (Desktop not installed). An empty array means
+    /// the file exists but carries no token cache. Injected for tests.
+    public typealias CacheReader = @Sendable () -> [String]?
+
+    private let keyReader: KeyReader
+    private let cacheReader: CacheReader
+
+    public init(
+        keyReader: @escaping KeyReader = DesktopOAuth.defaultKeyReader,
+        cacheReader: @escaping CacheReader = DesktopOAuth.defaultCacheReader
+    ) {
+        self.keyReader = keyReader
+        self.cacheReader = cacheReader
+    }
+
+    // MARK: - Read
+
+    /// Resolve the freshest `user:profile` credential from Claude Desktop.
+    public func read() -> Result<OAuthCredential, DesktopOAuthError> {
+        guard let blobs = cacheReader() else { return .failure(.configNotFound) }
+        if blobs.isEmpty { return .failure(.noProfileToken) }
+
+        let keyPassword: Data
+        switch keyReader() {
+        case .success(let k): keyPassword = k
+        case .failure(let e): return .failure(e)
+        }
+
+        var merged: [String: Any] = [:]
+        var decryptedAny = false
+        for blob in blobs {
+            guard let plain = Self.decrypt(blobBase64: blob, keyPassword: keyPassword),
+                  let obj = try? JSONSerialization.jsonObject(with: plain) as? [String: Any]
+            else { continue }
+            decryptedAny = true
+            merged.merge(obj) { _, new in new }
+        }
+        guard decryptedAny else {
+            return .failure(.decryptFailed("no cache blob decrypted to JSON"))
+        }
+        guard let credential = Self.freshestProfileCredential(cache: merged) else {
+            return .failure(.noProfileToken)
+        }
+        return .success(credential)
+    }
+
+    // MARK: - Selection (pure, unit-tested)
+
+    /// Pick the `user:profile`-scoped entry with the latest `expiresAt`.
+    /// Expiry isn't filtered here — `OAuthClient` is the single expiry
+    /// authority and compares Desktop against the keychain token. `nil`
+    /// when no entry carries `user:profile`.
+    static func freshestProfileCredential(cache: [String: Any]) -> OAuthCredential? {
+        var best: OAuthCredential?
+        var bestKey = Date.distantPast
+        for (key, value) in cache {
+            guard key.contains("user:profile"),
+                  let entry = value as? [String: Any],
+                  let token = entry["token"] as? String, !token.isEmpty
+            else { continue }
+            let expiresAt = (entry["expiresAt"] as? NSNumber)
+                .map { Date(timeIntervalSince1970: $0.doubleValue / 1000) }
+            let cred = OAuthCredential(
+                accessToken: token,
+                expiresAt: expiresAt,
+                refreshToken: entry["refreshToken"] as? String,
+                subscriptionType: entry["subscriptionType"] as? String
+            )
+            // A missing expiry sorts as "never expires" so it wins.
+            let rank = expiresAt ?? .distantFuture
+            if best == nil || rank > bestKey {
+                best = cred
+                bestKey = rank
+            }
+        }
+        return best
+    }
+
+    // MARK: - Decryption (pure, unit-tested via round-trip)
+
+    /// Decrypt one `base64("v10" + ciphertext)` blob. `nil` on any failure
+    /// (bad base64, missing prefix, KDF/cipher error) so callers skip it.
+    static func decrypt(blobBase64: String, keyPassword: Data) -> Data? {
+        guard let raw = Data(base64Encoded: blobBase64.trimmingCharacters(in: .whitespacesAndNewlines)),
+              raw.count > 3,
+              raw.prefix(3) == Data("v10".utf8)
+        else { return nil }
+        let ciphertext = raw.subdata(in: 3..<raw.count)
+        guard let key = pbkdf2SHA1(password: keyPassword, salt: Data("saltysalt".utf8),
+                                   rounds: 1003, keyLength: kCCKeySizeAES128)
+        else { return nil }
+        let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+        return aes128CBCDecrypt(ciphertext: ciphertext, key: key, iv: iv)
+    }
+
+    static func pbkdf2SHA1(password: Data, salt: Data, rounds: Int, keyLength: Int) -> Data? {
+        var derived = Data(count: keyLength)
+        let status = derived.withUnsafeMutableBytes { derivedPtr in
+            salt.withUnsafeBytes { saltPtr in
+                password.withUnsafeBytes { pwPtr in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        pwPtr.bindMemory(to: Int8.self).baseAddress, password.count,
+                        saltPtr.bindMemory(to: UInt8.self).baseAddress, salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                        UInt32(rounds),
+                        derivedPtr.bindMemory(to: UInt8.self).baseAddress, keyLength
+                    )
+                }
+            }
+        }
+        return status == kCCSuccess ? derived : nil
+    }
+
+    static func aes128CBCDecrypt(ciphertext: Data, key: Data, iv: Data) -> Data? {
+        guard !ciphertext.isEmpty else { return nil }
+        var out = Data(count: ciphertext.count + kCCBlockSizeAES128)
+        var moved = 0
+        let status = out.withUnsafeMutableBytes { outPtr in
+            ciphertext.withUnsafeBytes { ctPtr in
+                key.withUnsafeBytes { keyPtr in
+                    iv.withUnsafeBytes { ivPtr in
+                        CCCrypt(
+                            CCOperation(kCCDecrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyPtr.baseAddress, key.count,
+                            ivPtr.baseAddress,
+                            ctPtr.baseAddress, ciphertext.count,
+                            outPtr.baseAddress, outPtr.count,
+                            &moved
+                        )
+                    }
+                }
+            }
+        }
+        guard status == kCCSuccess else { return nil }
+        out.removeSubrange(moved..<out.count)
+        return out
+    }
+
+    // MARK: - Production readers
+
+    /// Reads the AES key from `Claude Safe Storage` / `Claude Key` via the
+    /// shared `security` CLI. The value is an ASCII base64 string used
+    /// as-is as the PBKDF2 password; we only strip the trailing newline the
+    /// CLI appends.
+    public static let defaultKeyReader: KeyReader = {
+        switch SecurityCLI.findGenericPassword(service: keychainService, account: keychainAccount) {
+        case .success(var data):
+            while let last = data.last, last == 0x0A || last == 0x0D { data.removeLast() }
+            return .success(data)
+        case .failure(.notFound):
+            return .failure(.keychainKeyUnavailable(OSStatus(errSecItemNotFound)))
+        case .failure(.accessDenied):
+            return .failure(.keychainAccessDenied)
+        case .failure(.spawn(let s)), .failure(.status(let s)):
+            return .failure(.keychainKeyUnavailable(s))
+        }
+    }
+
+    /// Reads `config.json` and returns its encrypted cache blobs. `nil`
+    /// when the file is absent/unreadable (Desktop not installed); an empty
+    /// array when present but carrying no `oauth:tokenCache*` field.
+    public static let defaultCacheReader: CacheReader = {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Claude/config.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return ["oauth:tokenCache", "oauth:tokenCacheV2"].compactMap { obj[$0] as? String }
+    }
+}

--- a/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
@@ -199,59 +199,17 @@ public struct KeychainOAuth: Sendable {
         return .failure(lastKeychainError)
     }
 
-    /// One-shot subprocess invocation with the 5-second timeout the
-    /// production keychain workflow needs. Extracted so the per-user
-    /// and legacy reads share identical error-handling.
+    /// Thin wrapper over the shared `SecurityCLI` runner, mapping its
+    /// neutral failures onto `KeychainOAuthError`. Kept so the two read
+    /// call sites above read cleanly; the subprocess + timeout logic lives
+    /// in `SecurityCLI` (shared with `DesktopOAuth`).
     private static func runSecurityCLI(args: [String]) -> Result<Data, KeychainOAuthError> {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = args
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        do {
-            try process.run()
-        } catch {
-            // Couldn't even spawn — bad PATH, missing binary, sandbox
-            // refusal. Carry the underlying CocoaError code so a log
-            // reader can route it.
-            let nsError = error as NSError
-            return .failure(.unexpectedStatus(OSStatus(nsError.code)))
-        }
-
-        // The keychain is normally unlocked at login, so the subprocess
-        // returns in well under a second. The timeout below is a safety
-        // net for the pathological "locked keychain prompts modally"
-        // case; without it, a single bad keychain state could wedge the
-        // poller actor forever.
-        let timeoutSeconds: TimeInterval = 5
-        let group = DispatchGroup()
-        group.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            group.leave()
-        }
-        if group.wait(timeout: .now() + timeoutSeconds) == .timedOut {
-            process.terminate()
-            // Drain so the kernel doesn't hold the pipes open.
-            _ = try? stdout.fileHandleForReading.readToEnd()
-            _ = try? stderr.fileHandleForReading.readToEnd()
-            return .failure(.accessDenied)
-        }
-
-        let status = process.terminationStatus
-        switch status {
-        case 0:
-            let data = (try? stdout.fileHandleForReading.readToEnd()) ?? Data()
-            return .success(data)
-        case 44:
-            return .failure(.notFound)
-        case 36, 51, 128:
-            return .failure(.accessDenied)
-        default:
-            return .failure(.unexpectedStatus(OSStatus(status)))
+        SecurityCLI.run(args).mapError { failure in
+            switch failure {
+            case .notFound:                 return .notFound
+            case .accessDenied:             return .accessDenied
+            case .spawn(let s), .status(let s): return .unexpectedStatus(s)
+            }
         }
     }
 

--- a/PacerCore/Sources/PacerCore/Auth/SecurityCLI.swift
+++ b/PacerCore/Sources/PacerCore/Auth/SecurityCLI.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Shared wrapper around `/usr/bin/security find-generic-password -w`.
+///
+/// Both `KeychainOAuth` (Claude Code's plaintext credential) and
+/// `DesktopOAuth` (Claude Desktop's safeStorage AES key) read keychain
+/// items through the Apple-signed `security` CLI rather than
+/// `SecItemCopyMatching` — see the `KeychainOAuth` type doc for the
+/// partition-list rationale (the CLI avoids the recurring prompt that a
+/// direct SecItem read from Pacer's Team ID would trigger).
+///
+/// Note: for items created by a third app with a restrictive ACL (e.g.
+/// Claude Desktop's `Claude Safe Storage`), the *first* read still pops a
+/// one-time keychain approval; "Always Allow" then makes it silent. The
+/// Claude Code item is the exception — Claude Code puts it in the
+/// `apple-tool:` partition the CLI already belongs to, so it never prompts.
+enum SecurityCLI {
+
+    /// Neutral outcome; each caller maps these onto its own domain error.
+    enum Failure: Error, Equatable {
+        /// Exit 44 — `errSecItemNotFound` (item absent).
+        case notFound
+        /// Exit 36/51/128 — user declined, non-UI context, or the 5s
+        /// modal-prompt safety timeout fired.
+        case accessDenied
+        /// Couldn't launch the subprocess (bad PATH, sandbox refusal).
+        case spawn(OSStatus)
+        /// Any other non-zero exit status.
+        case status(OSStatus)
+    }
+
+    /// Convenience for the one call shape we use everywhere.
+    static func findGenericPassword(service: String, account: String? = nil) -> Result<Data, Failure> {
+        var args = ["find-generic-password", "-s", service]
+        if let account { args += ["-a", account] }
+        args.append("-w")
+        return run(args)
+    }
+
+    /// One-shot invocation with a 5-second timeout — a safety net for the
+    /// pathological "locked keychain prompts modally" case so a bad
+    /// keychain state can't wedge a caller (e.g. the poller actor) forever.
+    static func run(_ args: [String]) -> Result<Data, Failure> {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = args
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+        } catch {
+            return .failure(.spawn(OSStatus((error as NSError).code)))
+        }
+
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            group.leave()
+        }
+        if group.wait(timeout: .now() + 5) == .timedOut {
+            process.terminate()
+            // Drain so the kernel doesn't hold the pipes open.
+            _ = try? stdout.fileHandleForReading.readToEnd()
+            _ = try? stderr.fileHandleForReading.readToEnd()
+            return .failure(.accessDenied)
+        }
+
+        switch process.terminationStatus {
+        case 0:
+            return .success((try? stdout.fileHandleForReading.readToEnd()) ?? Data())
+        case 44:
+            return .failure(.notFound)
+        case 36, 51, 128:
+            return .failure(.accessDenied)
+        case let status:
+            return .failure(.status(OSStatus(status)))
+        }
+    }
+}

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -87,17 +87,25 @@ public struct OAuthClient: Sendable {
     /// directly — workaround for Claude Code 2.x not persisting
     /// refreshed tokens to the keychain (#6).
     private let tokenOverride: @Sendable () -> String?
+    /// Claude Desktop credential source, consulted only when
+    /// `desktopEnabled()` is true (the user opted in). Read-only.
+    private let desktop: DesktopOAuth
+    private let desktopEnabled: @Sendable () -> Bool
 
     public init(
         keychain: KeychainOAuth = KeychainOAuth(),
         transport: @escaping Transport = OAuthClient.defaultTransport,
         now: @escaping @Sendable () -> Date = { Date() },
-        tokenOverride: @escaping @Sendable () -> String? = { PacerPreferences.oauthTokenOverride() }
+        tokenOverride: @escaping @Sendable () -> String? = { PacerPreferences.oauthTokenOverride() },
+        desktop: DesktopOAuth = DesktopOAuth(),
+        desktopEnabled: @escaping @Sendable () -> Bool = { PacerPreferences.desktopCredentialsEnabled() }
     ) {
         self.keychain = keychain
         self.transport = transport
         self.now = now
         self.tokenOverride = tokenOverride
+        self.desktop = desktop
+        self.desktopEnabled = desktopEnabled
     }
 
     /// Production transport: `URLSession.shared.data(for:)` plus the
@@ -134,25 +142,45 @@ public struct OAuthClient: Sendable {
                 subscriptionType: nil
             )
         } else {
+            // Gather candidates from every enabled source and use the
+            // freshest valid token. Claude Code (keychain / .credentials.json)
+            // and Claude Desktop are roughly equal — whichever has the later
+            // expiry wins, so an idle gap in one (its 8h token lapsed) is
+            // covered by the other. Desktop is read-only and consulted only
+            // when the user opted in.
+            var candidates: [OAuthCredential] = []
+            var keychainError: OAuthClientError?
             switch keychain.read() {
             case .success(let c):
-                credential = c
+                candidates.append(c)
             case .failure(.notFound):
-                return .failure(.credentialsNotFound)
+                keychainError = .credentialsNotFound
             case .failure(.accessDenied):
-                return .failure(.keychainAccessDenied)
+                keychainError = .keychainAccessDenied
             case .failure(.malformedJSON(let underlying)):
-                return .failure(.keychainMalformed(underlying))
+                keychainError = .keychainMalformed(underlying)
             case .failure(.unexpectedStatus(let status)):
-                return .failure(.keychainStatus(status))
+                keychainError = .keychainStatus(status)
+            }
+            if desktopEnabled(), case .success(let c) = desktop.read() {
+                candidates.append(c)
             }
 
-            // Step 2: skip-if-expired. Local clock gate to avoid a
-            // guaranteed 401. Server is authoritative for borderline
-            // cases (clock skew under a few minutes), so we check
-            // strict expiry only.
-            if let expiresAt = credential.expiresAt, expiresAt < now() {
-                return .failure(.tokenExpired(at: expiresAt))
+            // Step 2: prefer a non-expired token; among those, the freshest.
+            // A nil expiry (override-shaped) counts as never-expiring. The
+            // expiry gate avoids a guaranteed 401; the server stays
+            // authoritative for borderline clock skew.
+            let referenceNow = now()
+            let valid = candidates.filter { $0.expiresAt == nil || $0.expiresAt! >= referenceNow }
+            if let best = valid.max(by: { ($0.expiresAt ?? .distantFuture) < ($1.expiresAt ?? .distantFuture) }) {
+                credential = best
+            } else if let newestExpiry = candidates.compactMap({ $0.expiresAt }).max() {
+                // Every source we could read is expired — report the latest
+                // expiry (Claude Code refreshes it on next use).
+                return .failure(.tokenExpired(at: newestExpiry))
+            } else {
+                // Nothing readable anywhere — surface the keychain error.
+                return .failure(keychainError ?? .credentialsNotFound)
             }
         }
 

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -80,6 +80,12 @@ public enum PacerPreferenceKeys {
     /// keychain (see #6). Stored as a plain string; lives in the App
     /// Group UserDefaults suite alongside the rest of Pacer's prefs.
     public static let oauthTokenOverride     = "pacer.oauth.tokenOverride"
+    /// Opt-in: also read Claude Desktop's credential (decrypting its
+    /// `safeStorage` token cache) and use whichever of it / the Claude Code
+    /// keychain token is freshest. Off by default — it decrypts another
+    /// app's credential store and triggers a one-time keychain approval, so
+    /// the user turns it on deliberately. Read-only; never refreshes.
+    public static let desktopCredentialsEnabled = "pacer.desktop.credentialsEnabled"
 }
 
 /// Convenience accessor for the App Group-suite UserDefaults. Falls
@@ -115,5 +121,12 @@ public enum PacerPreferences {
         let raw = store.string(forKey: PacerPreferenceKeys.oauthTokenOverride) ?? ""
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Whether the user opted in to reading Claude Desktop's credential.
+    /// Defaults to `false` (key absent → off) so a fresh daemon never
+    /// touches the Desktop keychain item without explicit consent.
+    public static func desktopCredentialsEnabled(from store: UserDefaults = store) -> Bool {
+        store.bool(forKey: PacerPreferenceKeys.desktopCredentialsEnabled)
     }
 }

--- a/PacerCore/Tests/PacerCoreTests/DesktopOAuthTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/DesktopOAuthTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import CommonCrypto
+import CryptoKit
+import Testing
+@testable import PacerCore
+
+/// Tests for the Claude Desktop credential source. The keychain key and the
+/// config-file blobs are injected, so no real keychain/file access happens
+/// (except the explicitly-gated live test at the bottom).
+@Suite struct DesktopOAuthTests {
+
+    // Any bytes work as the safeStorage "password" for round-trip tests —
+    // the production value is an ASCII base64 string used as-is.
+    private static let testKey = Data("pacer-test-safe-storage-key".utf8)
+    private static let host = "https://api.anthropic.com"
+
+    /// Mirror of `DesktopOAuth.decrypt`'s scheme, in the encrypt direction,
+    /// so a round-trip proves the CommonCrypto wiring (PBKDF2 + AES-128-CBC
+    /// + v10 prefix + PKCS#7) is correct.
+    private func encryptV10(_ plaintext: Data, keyPassword: Data = testKey) -> String {
+        let key = DesktopOAuth.pbkdf2SHA1(
+            password: keyPassword, salt: Data("saltysalt".utf8),
+            rounds: 1003, keyLength: kCCKeySizeAES128
+        )!
+        let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+        var out = Data(count: plaintext.count + kCCBlockSizeAES128)
+        var moved = 0
+        let status = out.withUnsafeMutableBytes { o in
+            plaintext.withUnsafeBytes { p in
+                key.withUnsafeBytes { k in
+                    iv.withUnsafeBytes { v in
+                        CCCrypt(
+                            CCOperation(kCCEncrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            k.baseAddress, key.count,
+                            v.baseAddress,
+                            p.baseAddress, plaintext.count,
+                            o.baseAddress, o.count,
+                            &moved
+                        )
+                    }
+                }
+            }
+        }
+        precondition(status == kCCSuccess)
+        out.removeSubrange(moved..<out.count)
+        return (Data("v10".utf8) + out).base64EncodedString()
+    }
+
+    private func key(client: String, scopes: String) -> String {
+        "\(client):acct:\(Self.host):\(scopes)"
+    }
+
+    private func cacheData(_ entries: [(client: String, scopes: String, token: String, expiresMs: Int64)]) -> Data {
+        var dict: [String: Any] = [:]
+        for e in entries {
+            dict[key(client: e.client, scopes: e.scopes)] = [
+                "token": e.token,
+                "refreshToken": "refresh-\(e.token)",
+                "expiresAt": e.expiresMs,
+                "subscriptionType": "max",
+            ]
+        }
+        return try! JSONSerialization.data(withJSONObject: dict)
+    }
+
+    // MARK: - Decryption round-trip
+
+    @Test func decryptRoundTrip() {
+        let plain = Data(#"{"hello":"world","n":1}"#.utf8)
+        let blob = encryptV10(plain)
+        let out = DesktopOAuth.decrypt(blobBase64: blob, keyPassword: Self.testKey)
+        #expect(out == plain)
+    }
+
+    @Test func decryptRejectsBadPrefixAndGarbage() {
+        // Not base64 / no v10 prefix → nil, never a crash.
+        #expect(DesktopOAuth.decrypt(blobBase64: "not base64!!", keyPassword: Self.testKey) == nil)
+        let noPrefix = Data("hello".utf8).base64EncodedString()
+        #expect(DesktopOAuth.decrypt(blobBase64: noPrefix, keyPassword: Self.testKey) == nil)
+    }
+
+    @Test func decryptWithWrongKeyDoesNotCrash() {
+        let blob = encryptV10(Data(#"{"a":1}"#.utf8))
+        // Wrong key → PKCS#7 unpad yields garbage or fails; must not crash.
+        _ = DesktopOAuth.decrypt(blobBase64: blob, keyPassword: Data("different".utf8))
+    }
+
+    // MARK: - Freshest-profile selection
+
+    @Test func picksFreshestProfileToken() {
+        let cache = try! JSONSerialization.jsonObject(with: cacheData([
+            (client: "a", scopes: "user:inference user:profile", token: "older", expiresMs: 1_000_000),
+            (client: "b", scopes: "user:inference user:profile user:sessions:claude_code", token: "newer", expiresMs: 2_000_000),
+        ])) as! [String: Any]
+        let cred = DesktopOAuth.freshestProfileCredential(cache: cache)
+        #expect(cred?.accessToken == "newer")
+        #expect(cred?.refreshToken == "refresh-newer")
+        #expect(cred?.expiresAt == Date(timeIntervalSince1970: 2000))
+    }
+
+    @Test func ignoresNonProfileScopes() {
+        let cache = try! JSONSerialization.jsonObject(with: cacheData([
+            (client: "a", scopes: "user:inference", token: "inference-only", expiresMs: 9_999_999),
+        ])) as! [String: Any]
+        #expect(DesktopOAuth.freshestProfileCredential(cache: cache) == nil)
+    }
+
+    @Test func skipsEntryMissingToken() {
+        var dict: [String: Any] = [:]
+        dict[key(client: "a", scopes: "user:profile")] = ["expiresAt": 5_000_000] // no token
+        dict[key(client: "b", scopes: "user:profile")] = ["token": "good", "expiresAt": 1_000_000]
+        let cred = DesktopOAuth.freshestProfileCredential(cache: dict)
+        #expect(cred?.accessToken == "good")
+    }
+
+    // MARK: - read() orchestration (injected readers)
+
+    private func desktop(
+        cache: [(client: String, scopes: String, token: String, expiresMs: Int64)]?,
+        keyResult: Result<Data, DesktopOAuthError> = .success(testKey)
+    ) -> DesktopOAuth {
+        // Precompute the encrypted blobs so the @Sendable readers capture
+        // only Sendable values (no `self`).
+        let blobs: [String]? = cache.map { [encryptV10(cacheData($0))] }
+        return DesktopOAuth(
+            keyReader: { keyResult },
+            cacheReader: { blobs }
+        )
+    }
+
+    @Test func readReturnsFreshestProfileCredential() {
+        let d = desktop(cache: [
+            (client: "a", scopes: "user:inference user:profile", token: "tok-new", expiresMs: 5_000_000),
+            (client: "b", scopes: "user:inference", token: "tok-noprofile", expiresMs: 9_000_000),
+        ])
+        guard case .success(let cred) = d.read() else {
+            Issue.record("expected success"); return
+        }
+        #expect(cred.accessToken == "tok-new")
+    }
+
+    @Test func readConfigNotFoundWhenCacheReaderNil() {
+        let d = DesktopOAuth(keyReader: { .success(Self.testKey) }, cacheReader: { nil })
+        #expect(d.read() == .failure(.configNotFound))
+    }
+
+    @Test func readNoProfileTokenWhenEmptyOrNoProfile() {
+        // Empty blob list.
+        let empty = DesktopOAuth(keyReader: { .success(Self.testKey) }, cacheReader: { [] })
+        #expect(empty.read() == .failure(.noProfileToken))
+        // Decryptable but no user:profile entry.
+        let noProfile = desktop(cache: [
+            (client: "a", scopes: "user:inference", token: "x", expiresMs: 1),
+        ])
+        #expect(noProfile.read() == .failure(.noProfileToken))
+    }
+
+    @Test func readPropagatesKeyFailure() {
+        let d = desktop(cache: [(client: "a", scopes: "user:profile", token: "x", expiresMs: 1)],
+                        keyResult: .failure(.keychainAccessDenied))
+        #expect(d.read() == .failure(.keychainAccessDenied))
+    }
+
+    @Test func readDecryptFailedOnGarbageBlob() {
+        let d = DesktopOAuth(keyReader: { .success(Self.testKey) }, cacheReader: { ["not-a-real-blob"] })
+        #expect(d.read() == .failure(.decryptFailed("no cache blob decrypted to JSON")))
+    }
+
+    // MARK: - OAuthClient freshest-token-wins integration
+
+    /// Build an OAuthClient whose transport reports utilization 11 when the
+    /// Desktop token is used and 99 when the keychain token is used, so the
+    /// parsed snapshot reveals which source won.
+    private func integrationClient(
+        keychainToken: String,
+        keychainExpiry: Date?,
+        desktopToken: String,
+        desktopExpiryMs: Int64,
+        desktopEnabled: Bool,
+        now: Date
+    ) -> OAuthClient {
+        let kcBlob: [String: Any] = ["claudeAiOauth": [
+            "accessToken": keychainToken,
+            "expiresAt": Int64((keychainExpiry?.timeIntervalSince1970 ?? 0) * 1000),
+            "subscriptionType": "max",
+        ]]
+        let kcData = try! JSONSerialization.data(withJSONObject: kcBlob)
+        let kc = KeychainOAuth(rawReader: { .success(kcData) })
+        let dt = desktop(cache: [(client: "a", scopes: "user:inference user:profile", token: desktopToken, expiresMs: desktopExpiryMs)])
+        return OAuthClient(
+            keychain: kc,
+            transport: { req in
+                let bearer = req.value(forHTTPHeaderField: "Authorization") ?? ""
+                let util = bearer.contains(desktopToken) ? 11.0 : 99.0
+                let body = "{\"five_hour\":{\"utilization\":\(util)}}"
+                let resp = HTTPURLResponse(url: OAuthClient.endpoint, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: [:])!
+                return (Data(body.utf8), resp)
+            },
+            now: { now },
+            tokenOverride: { nil },
+            desktop: dt,
+            desktopEnabled: { desktopEnabled }
+        )
+    }
+
+    @Test func desktopUsedWhenKeychainExpired() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let c = integrationClient(
+            keychainToken: "sk-ant-oat01-cc",
+            keychainExpiry: now.addingTimeInterval(-3600),                 // expired
+            desktopToken: "sk-ant-oat01-desktop",
+            desktopExpiryMs: Int64(now.addingTimeInterval(3600).timeIntervalSince1970 * 1000), // fresh
+            desktopEnabled: true,
+            now: now
+        )
+        guard case .success(let snap) = await c.fetchUsage() else {
+            Issue.record("expected success"); return
+        }
+        #expect(snap.fiveHour?.usedPercentage == 11.0)  // desktop token won
+    }
+
+    @Test func keychainUsedWhenFresherThanDesktop() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let c = integrationClient(
+            keychainToken: "sk-ant-oat01-cc",
+            keychainExpiry: now.addingTimeInterval(7200),                  // fresher
+            desktopToken: "sk-ant-oat01-desktop",
+            desktopExpiryMs: Int64(now.addingTimeInterval(1800).timeIntervalSince1970 * 1000), // fresh but sooner
+            desktopEnabled: true,
+            now: now
+        )
+        guard case .success(let snap) = await c.fetchUsage() else {
+            Issue.record("expected success"); return
+        }
+        #expect(snap.fiveHour?.usedPercentage == 99.0)  // keychain token won (later expiry)
+    }
+
+    @Test func desktopIgnoredWhenDisabled() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        // Keychain expired, desktop fresh — but opt-in is off, so we must
+        // NOT consult Desktop and instead report the expired keychain token.
+        let c = integrationClient(
+            keychainToken: "sk-ant-oat01-cc",
+            keychainExpiry: now.addingTimeInterval(-3600),
+            desktopToken: "sk-ant-oat01-desktop",
+            desktopExpiryMs: Int64(now.addingTimeInterval(3600).timeIntervalSince1970 * 1000),
+            desktopEnabled: false,
+            now: now
+        )
+        guard case .failure(.tokenExpired) = await c.fetchUsage() else {
+            Issue.record("expected tokenExpired (desktop disabled)"); return
+        }
+    }
+
+    // MARK: - Live integration (gated)
+    //
+    // Set PACER_RUN_LIVE_DESKTOP_TEST=1 to decrypt the REAL Claude Desktop
+    // cache. Prints the selected token's sha256 fingerprint so it can be
+    // cross-checked against the Python harness output. Will trigger the
+    // one-time "Claude Safe Storage" keychain approval if not yet granted.
+
+    @Test func liveDesktopRead() {
+        guard ProcessInfo.processInfo.environment["PACER_RUN_LIVE_DESKTOP_TEST"] == "1" else { return }
+        switch DesktopOAuth().read() {
+        case .success(let cred):
+            let fp = SHA256.hash(data: Data(cred.accessToken.utf8))
+                .prefix(4).map { String(format: "%02x", $0) }.joined()
+            print("LIVE desktop token fp=\(fp) len=\(cred.accessToken.count) expiresAt=\(String(describing: cred.expiresAt))")
+            #expect(cred.accessToken.hasPrefix("sk-ant-"))
+        case .failure(let e):
+            Issue.record("live desktop read failed: \(e)")
+        }
+    }
+}


### PR DESCRIPTION
## Why

Pacer only worked if you used the Claude Code **CLI** (it read that token from the keychain). This makes it work for **Claude Desktop / general-chat** users too, and adds resilience for everyone.

We confirmed experimentally (see the investigation in #82's thread) that Claude Desktop's token carries the `user:profile` scope `/api/oauth/usage` requires and returns HTTP 200 — so reuse is viable.

## What

- **`DesktopOAuth`** decrypts Claude Desktop's Electron `safeStorage` token cache:
  - keychain `Claude Safe Storage` / `Claude Key` → AES key; `~/Library/Application Support/Claude/config.json` `oauth:tokenCache*` → `base64("v10" + AES-128-CBC ciphertext)`.
  - decrypt = PBKDF2-HMAC-SHA1(`saltysalt`, 1003, 16B) → AES-128-CBC (IV = 16 spaces, PKCS#7), via **CommonCrypto (no new dependency)**.
  - cache is keyed by `client:account:host:scopes`; we pick the `user:profile` entry with the latest expiry.
- **Freshest-token-wins** resolution in `OAuthClient`: gather candidates from the Claude Code keychain and (when opted in) Claude Desktop, use the non-expired token with the latest expiry. An idle gap in one source is covered by the other.
- **Opt-in toggle** in Settings → Authentication. Flipping it on runs a Test that surfaces the one-time `Claude Safe Storage` keychain approval and confirms the token works.
- **Read-only throughout** — never writes `config.json`, never refreshes Desktop's token, so it can't rotate the shared refresh token or disturb the Desktop session.
- Extracts the `/usr/bin/security` runner into a shared `SecurityCLI` (used by both `KeychainOAuth` and `DesktopOAuth`).

## Verification

- **431 tests pass** (15 new): decrypt round-trip (validates the CommonCrypto wiring), freshest-`user:profile` selection, `read()` happy/error paths, and `OAuthClient` freshest-wins integration (expired keychain → Desktop wins; fresher keychain → keychain wins; disabled → Desktop ignored).
- **Ground-truth cross-check:** the gated live test (`PACER_RUN_LIVE_DESKTOP_TEST=1`) decrypts the real cache and selects the same token (`fp=48464bf1`) as an independent Python reference — and that token returns HTTP 200 from `/api/oauth/usage`.
- Bonus: the Desktop client issues a **~1-year** `user:profile` token, so Desktop users sidestep the 8h idle-expiry gap entirely.

## Follow-ups (not in this PR)

- Guided enablement during first-run / upgrade (UI — will prototype + get sign-off).
- Honest "auth paused / using Desktop" pill instead of a frozen "Xm ago".
- (Shelved per discussion: a background `claude` launcher to keep the CC token fresh.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a7NXLY2ExtfrMpzDQUyDA