### PR TITLE
feat(oauth): hold our own token (keychain) + refresh-from-source + 401 fall-through

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -90,7 +90,11 @@ final class AppBackgroundService {
         // by `apple-tool:` partition membership), so reads complete
         // silently from the very first launch. See the type doc in
         // `KeychainOAuth.swift` for the partition-list rationale.
-        let oauthClient = OAuthClient()
+        // Persist the resolved token in Pacer's own keychain item so we read
+        // Claude's stores only ~once per token lifetime and keep working if
+        // the user logs out of Claude Code / removes Desktop. Tests and
+        // Settings probes use the default in-memory store (no real keychain).
+        let oauthClient = OAuthClient(heldStore: KeychainCredentialStore())
         let scanCoordinator = ScanCoordinator(
             container: container,
             configuration: ScanCoordinator.Configuration(costMode: costMode),

--- a/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
@@ -81,6 +81,25 @@ public struct DesktopOAuth: Sendable {
 
     /// Resolve the freshest `user:profile` credential from Claude Desktop.
     public func read() -> Result<OAuthCredential, DesktopOAuthError> {
+        readAll().map { $0[0] }   // readAll guarantees a non-empty array on success
+    }
+
+    /// All `user:profile` credentials in the cache, freshest first. Lets the
+    /// resolver fall through to the next-freshest if its first pick is
+    /// rejected (the cache can hold several tokens at different expiries).
+    public func readAll() -> Result<[OAuthCredential], DesktopOAuthError> {
+        switch decryptedCache() {
+        case .failure(let e):
+            return .failure(e)
+        case .success(let cache):
+            let creds = Self.profileCredentials(cache: cache)
+            return creds.isEmpty ? .failure(.noProfileToken) : .success(creds)
+        }
+    }
+
+    /// Read + decrypt + merge every cache blob into one dict. Shared by
+    /// `read()` / `readAll()`.
+    private func decryptedCache() -> Result<[String: Any], DesktopOAuthError> {
         guard let blobs = cacheReader() else { return .failure(.configNotFound) }
         if blobs.isEmpty { return .failure(.noProfileToken) }
 
@@ -102,21 +121,18 @@ public struct DesktopOAuth: Sendable {
         guard decryptedAny else {
             return .failure(.decryptFailed("no cache blob decrypted to JSON"))
         }
-        guard let credential = Self.freshestProfileCredential(cache: merged) else {
-            return .failure(.noProfileToken)
-        }
-        return .success(credential)
+        return .success(merged)
     }
 
     // MARK: - Selection (pure, unit-tested)
 
-    /// Pick the `user:profile`-scoped entry with the latest `expiresAt`.
-    /// Expiry isn't filtered here — `OAuthClient` is the single expiry
-    /// authority and compares Desktop against the keychain token. `nil`
-    /// when no entry carries `user:profile`.
-    static func freshestProfileCredential(cache: [String: Any]) -> OAuthCredential? {
-        var best: OAuthCredential?
-        var bestKey = Date.distantPast
+    /// All `user:profile`-scoped credentials, freshest first. Expiry isn't
+    /// filtered here — `OAuthClient` is the single expiry authority and
+    /// compares Desktop against the keychain token. Deterministic: sorted by
+    /// expiry descending, ties broken by the (stable) cache key, so the same
+    /// cache always yields the same order.
+    static func profileCredentials(cache: [String: Any]) -> [OAuthCredential] {
+        var rows: [(key: String, expiry: Date, cred: OAuthCredential)] = []
         for (key, value) in cache {
             guard key.contains("user:profile"),
                   let entry = value as? [String: Any],
@@ -130,14 +146,17 @@ public struct DesktopOAuth: Sendable {
                 refreshToken: entry["refreshToken"] as? String,
                 subscriptionType: entry["subscriptionType"] as? String
             )
-            // A missing expiry sorts as "never expires" so it wins.
-            let rank = expiresAt ?? .distantFuture
-            if best == nil || rank > bestKey {
-                best = cred
-                bestKey = rank
-            }
+            // A missing expiry sorts as "never expires" so it leads.
+            rows.append((key, expiresAt ?? .distantFuture, cred))
         }
-        return best
+        rows.sort { $0.expiry != $1.expiry ? $0.expiry > $1.expiry : $0.key < $1.key }
+        return rows.map(\.cred)
+    }
+
+    /// Convenience: the single freshest `user:profile` credential. `nil` when
+    /// no entry carries `user:profile`.
+    static func freshestProfileCredential(cache: [String: Any]) -> OAuthCredential? {
+        profileCredentials(cache: cache).first
     }
 
     // MARK: - Decryption (pure, unit-tested via round-trip)

--- a/PacerCore/Sources/PacerCore/Auth/HeldCredential.swift
+++ b/PacerCore/Sources/PacerCore/Auth/HeldCredential.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Security
+
+/// Pacer's own persisted copy of a working OAuth credential.
+///
+/// Why hold our own copy at all (vs. reading Claude's keychain / Desktop
+/// store on every poll):
+///   - **Fewer source reads.** Once we hold a valid token we poll the usage
+///     endpoint without touching Claude's stores until the token nears
+///     expiry — so a Desktop ~1-year token means we read its keychain item
+///     about once a year, not every 5 minutes.
+///   - **Survives logout/uninstall.** If the user signs out of Claude Code
+///     or removes Claude Desktop, a still-valid held token keeps Pacer
+///     working until it actually expires.
+///   - **Enables a future phone view.** Holding the token is the prerequisite
+///     for E2EE-syncing it to a Pacer iOS app (designed separately).
+///
+/// We store it in Pacer's OWN keychain item (app-private, not the shared
+/// items we read from Claude), which the OS already encrypts at rest
+/// (Secure-Enclave-protected on modern Macs) — so no home-grown crypto.
+public protocol HeldCredentialStoring: Sendable {
+    func load() -> OAuthCredential?
+    func save(_ credential: OAuthCredential)
+    func clear()
+}
+
+/// Production store: a generic-password item in Pacer's keychain. The app is
+/// not sandboxed, so `SecItem` uses Pacer's default (app-private) access
+/// group and reads silently — no prompt, since Pacer created the item. We
+/// deliberately use `AfterFirstUnlock` (not a biometry/passcode gate) so the
+/// background poller can read it without user interaction.
+public struct KeychainCredentialStore: HeldCredentialStoring {
+    public static let service = "com.ericandrechek.pacer.oauth.held"
+    public static let account = "primary"
+
+    public init() {}
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: Self.account,
+        ]
+    }
+
+    public func load() -> OAuthCredential? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var out: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data
+        else { return nil }
+        return try? JSONDecoder().decode(OAuthCredential.self, from: data)
+    }
+
+    public func save(_ credential: OAuthCredential) {
+        guard let data = try? JSONEncoder().encode(credential) else { return }
+        let update: [String: Any] = [kSecValueData as String: data]
+        let status = SecItemUpdate(baseQuery as CFDictionary, update as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = baseQuery
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            SecItemAdd(add as CFDictionary, nil)
+        }
+    }
+
+    public func clear() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+}
+
+/// In-memory store. The default for `OAuthClient`, so tests and the Settings
+/// probes never touch the real keychain; production opts into
+/// `KeychainCredentialStore` at the poller's construction site.
+public final class EphemeralCredentialStore: HeldCredentialStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var credential: OAuthCredential?
+
+    public init(_ credential: OAuthCredential? = nil) { self.credential = credential }
+
+    public func load() -> OAuthCredential? {
+        lock.lock(); defer { lock.unlock() }
+        return credential
+    }
+    public func save(_ credential: OAuthCredential) {
+        lock.lock(); self.credential = credential; lock.unlock()
+    }
+    public func clear() {
+        lock.lock(); credential = nil; lock.unlock()
+    }
+}
+
+/// In-memory record of access tokens the server has rejected (401), so the
+/// resolver won't re-pick a revoked token within this process's lifetime — a
+/// token that 401s won't become valid again. Lets resolution fall through to
+/// the next-freshest candidate instead of wedging on a stale "freshest" pick.
+/// Tokens are held in memory only and never logged.
+public final class RejectedTokens: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tokens: Set<String> = []
+
+    public init() {}
+
+    public func reject(_ token: String) {
+        lock.lock(); tokens.insert(token); lock.unlock()
+    }
+    public func isRejected(_ token: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return tokens.contains(token)
+    }
+}

--- a/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/KeychainOAuth.swift
@@ -6,7 +6,7 @@ import Security
 /// Claude Code itself writes the entry on interactive login; Pacer
 /// reads it on every poll and (optionally, on the user's request) does
 /// its own refresh via `OAuthClient.refresh` — see #6.
-public struct OAuthCredential: Sendable, Equatable {
+public struct OAuthCredential: Sendable, Equatable, Codable {
     public let accessToken: String
     /// Server-side expiry. The endpoint will return 401 if we send an
     /// expired token, so we treat this as advisory — useful for skipping

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -91,6 +91,18 @@ public struct OAuthClient: Sendable {
     /// `desktopEnabled()` is true (the user opted in). Read-only.
     private let desktop: DesktopOAuth
     private let desktopEnabled: @Sendable () -> Bool
+    /// Pacer's own persisted copy of a working token. Defaults to an
+    /// in-memory store so tests and Settings probes never touch the real
+    /// keychain; production passes `KeychainCredentialStore()` to persist.
+    private let heldStore: HeldCredentialStoring
+    /// Tokens the server has 401'd this process, so resolution won't re-pick
+    /// a revoked one and instead falls through to the next-freshest.
+    private let rejected: RejectedTokens
+
+    /// How long before a held token's expiry we go back to the sources for a
+    /// fresher one. Until then we serve the held copy without touching
+    /// Claude's keychain / Desktop store at all.
+    private static let refreshLeadTime: TimeInterval = 10 * 60
 
     public init(
         keychain: KeychainOAuth = KeychainOAuth(),
@@ -98,7 +110,9 @@ public struct OAuthClient: Sendable {
         now: @escaping @Sendable () -> Date = { Date() },
         tokenOverride: @escaping @Sendable () -> String? = { PacerPreferences.oauthTokenOverride() },
         desktop: DesktopOAuth = DesktopOAuth(),
-        desktopEnabled: @escaping @Sendable () -> Bool = { PacerPreferences.desktopCredentialsEnabled() }
+        desktopEnabled: @escaping @Sendable () -> Bool = { PacerPreferences.desktopCredentialsEnabled() },
+        heldStore: HeldCredentialStoring = EphemeralCredentialStore(),
+        rejected: RejectedTokens = RejectedTokens()
     ) {
         self.keychain = keychain
         self.transport = transport
@@ -106,6 +120,8 @@ public struct OAuthClient: Sendable {
         self.tokenOverride = tokenOverride
         self.desktop = desktop
         self.desktopEnabled = desktopEnabled
+        self.heldStore = heldStore
+        self.rejected = rejected
     }
 
     /// Production transport: `URLSession.shared.data(for:)` plus the
@@ -131,57 +147,13 @@ public struct OAuthClient: Sendable {
         // mapping its errors to ours so the caller switches on one
         // error type.
         let credential: OAuthCredential
-        if let override = tokenOverride() {
-            // Skip the expiresAt gate too — we have no local expiry
-            // for an override, so the server is the only authority.
-            // A stale override surfaces as `.unauthorized` on the next
-            // poll, which the transition logger reports clearly.
-            credential = OAuthCredential(
-                accessToken: override,
-                expiresAt: nil,
-                subscriptionType: nil
-            )
-        } else {
-            // Gather candidates from every enabled source and use the
-            // freshest valid token. Claude Code (keychain / .credentials.json)
-            // and Claude Desktop are roughly equal — whichever has the later
-            // expiry wins, so an idle gap in one (its 8h token lapsed) is
-            // covered by the other. Desktop is read-only and consulted only
-            // when the user opted in.
-            var candidates: [OAuthCredential] = []
-            var keychainError: OAuthClientError?
-            switch keychain.read() {
-            case .success(let c):
-                candidates.append(c)
-            case .failure(.notFound):
-                keychainError = .credentialsNotFound
-            case .failure(.accessDenied):
-                keychainError = .keychainAccessDenied
-            case .failure(.malformedJSON(let underlying)):
-                keychainError = .keychainMalformed(underlying)
-            case .failure(.unexpectedStatus(let status)):
-                keychainError = .keychainStatus(status)
-            }
-            if desktopEnabled(), case .success(let c) = desktop.read() {
-                candidates.append(c)
-            }
-
-            // Step 2: prefer a non-expired token; among those, the freshest.
-            // A nil expiry (override-shaped) counts as never-expiring. The
-            // expiry gate avoids a guaranteed 401; the server stays
-            // authoritative for borderline clock skew.
-            let referenceNow = now()
-            let valid = candidates.filter { $0.expiresAt == nil || $0.expiresAt! >= referenceNow }
-            if let best = valid.max(by: { ($0.expiresAt ?? .distantFuture) < ($1.expiresAt ?? .distantFuture) }) {
-                credential = best
-            } else if let newestExpiry = candidates.compactMap({ $0.expiresAt }).max() {
-                // Every source we could read is expired — report the latest
-                // expiry (Claude Code refreshes it on next use).
-                return .failure(.tokenExpired(at: newestExpiry))
-            } else {
-                // Nothing readable anywhere — surface the keychain error.
-                return .failure(keychainError ?? .credentialsNotFound)
-            }
+        let fromHeldStore: Bool
+        switch resolveCredential() {
+        case .success(let resolution):
+            credential = resolution.credential
+            fromHeldStore = resolution.fromHeldStore
+        case .failure(let error):
+            return .failure(error)
         }
 
         // Step 3: build request.
@@ -210,6 +182,14 @@ public struct OAuthClient: Sendable {
         case 200..<300:
             break // fall through to decode
         case 401:
+            // This token is bad. Blocklist it so resolution falls through to
+            // the next-freshest candidate, and drop our held copy so the next
+            // poll re-derives from the sources. (`fromHeldStore` is logged
+            // intent; we clear regardless since the held copy may equal the
+            // rejected token.)
+            _ = fromHeldStore
+            rejected.reject(credential.accessToken)
+            heldStore.clear()
             return .failure(.unauthorized(body: truncate(body, max: 200)))
         case 429:
             return .failure(.rateLimited(
@@ -229,6 +209,73 @@ public struct OAuthClient: Sendable {
             return .failure(.responseSchemaMismatch(error.localizedDescription))
         }
         return .success(snapshot)
+    }
+
+    // MARK: - Credential resolution
+
+    /// Resolve which token to send, and whether it came from our held store.
+    ///
+    /// Fast path: a comfortably-valid, non-rejected held token is used
+    /// directly — no read of Claude's keychain / Desktop store. Slow path
+    /// (no held token, near expiry, or rejected): gather candidates from the
+    /// sources (Claude Code keychain + opted-in Desktop) plus the held token
+    /// as a fallback, use the freshest non-expired non-rejected one, and
+    /// cache it. So we touch Claude's stores about once per token lifetime,
+    /// and a still-valid held token keeps us alive even if the user logged
+    /// out of Claude Code / removed Desktop.
+    private func resolveCredential() -> Result<(credential: OAuthCredential, fromHeldStore: Bool), OAuthClientError> {
+        // Manual override wins outright and is never cached.
+        if let override = tokenOverride() {
+            return .success((OAuthCredential(accessToken: override, expiresAt: nil, subscriptionType: nil), false))
+        }
+
+        let referenceNow = now()
+        let held = heldStore.load()
+
+        // Fast path.
+        if let held, !rejected.isRejected(held.accessToken),
+           let expiresAt = held.expiresAt,
+           expiresAt >= referenceNow.addingTimeInterval(Self.refreshLeadTime) {
+            return .success((held, true))
+        }
+
+        // Slow path: read the sources.
+        var candidates: [OAuthCredential] = []
+        var keychainError: OAuthClientError?
+        switch keychain.read() {
+        case .success(let c):                    candidates.append(c)
+        case .failure(.notFound):                keychainError = .credentialsNotFound
+        case .failure(.accessDenied):            keychainError = .keychainAccessDenied
+        case .failure(.malformedJSON(let u)):    keychainError = .keychainMalformed(u)
+        case .failure(.unexpectedStatus(let s)): keychainError = .keychainStatus(s)
+        }
+        if desktopEnabled(), case .success(let creds) = desktop.readAll() {
+            candidates.append(contentsOf: creds)
+        }
+        // The held token competes too — it serves as the fallback when the
+        // sources are unreadable (logged out / Desktop removed).
+        if let held { candidates.append(held) }
+
+        let usable = candidates.filter {
+            !rejected.isRejected($0.accessToken) && ($0.expiresAt == nil || $0.expiresAt! >= referenceNow)
+        }
+        // Deterministic freshest-wins: latest expiry, ties broken by token.
+        let best = usable.sorted {
+            let a = $0.expiresAt ?? .distantFuture
+            let b = $1.expiresAt ?? .distantFuture
+            return a != b ? a > b : $0.accessToken < $1.accessToken
+        }.first
+
+        if let best {
+            if best.accessToken != held?.accessToken { heldStore.save(best) }
+            return .success((best, best.accessToken == held?.accessToken))
+        }
+        if let newestExpiry = candidates.compactMap({ $0.expiresAt }).max() {
+            // Everything readable is expired — report the latest expiry
+            // (Claude Code refreshes its token on next use).
+            return .failure(.tokenExpired(at: newestExpiry))
+        }
+        return .failure(keychainError ?? .credentialsNotFound)
     }
 
     // MARK: - Decode

--- a/PacerCore/Tests/PacerCoreTests/DesktopOAuthTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/DesktopOAuthTests.swift
@@ -254,6 +254,139 @@ import Testing
         }
     }
 
+    // MARK: - Held-store resolution
+
+    final class CallCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var n = 0
+        func bump() { lock.lock(); n += 1; lock.unlock() }
+        var count: Int { lock.lock(); defer { lock.unlock() }; return n }
+    }
+
+    /// Keychain whose reads are counted, so a test can assert the fast path
+    /// did NOT touch the source.
+    private func countingKeychain(token: String?, expiry: Date?, counter: CallCounter) -> KeychainOAuth {
+        if let token {
+            let blob: [String: Any] = ["claudeAiOauth": [
+                "accessToken": token,
+                "expiresAt": Int64((expiry?.timeIntervalSince1970 ?? 0) * 1000),
+                "subscriptionType": "max",
+            ]]
+            let data = try! JSONSerialization.data(withJSONObject: blob)
+            return KeychainOAuth(rawReader: { counter.bump(); return .success(data) })
+        }
+        return KeychainOAuth(rawReader: { counter.bump(); return .failure(.notFound) })
+    }
+
+    /// OAuthClient wired with an injectable held store and a transport that
+    /// maps each bearer token to a (status, utilization) so the test can tell
+    /// which token was used and simulate 401s.
+    private func resolvingClient(
+        keychain: KeychainOAuth,
+        desktop dt: DesktopOAuth? = nil,
+        desktopEnabled: Bool = false,
+        held: OAuthCredential? = nil,
+        rejected: RejectedTokens = RejectedTokens(),
+        now: Date,
+        respond: @escaping @Sendable (String) -> (status: Int, util: Double)
+    ) -> (OAuthClient, EphemeralCredentialStore) {
+        let store = EphemeralCredentialStore(held)
+        let desktopSource = dt ?? DesktopOAuth(keyReader: { .failure(.configNotFound) }, cacheReader: { nil })
+        let client = OAuthClient(
+            keychain: keychain,
+            transport: { req in
+                let bearer = (req.value(forHTTPHeaderField: "Authorization") ?? "")
+                    .replacingOccurrences(of: "Bearer ", with: "")
+                let (status, util) = respond(bearer)
+                let body = "{\"five_hour\":{\"utilization\":\(util)}}"
+                let resp = HTTPURLResponse(url: OAuthClient.endpoint, statusCode: status, httpVersion: "HTTP/1.1", headerFields: [:])!
+                return (Data(body.utf8), resp)
+            },
+            now: { now },
+            tokenOverride: { nil },
+            desktop: desktopSource,
+            desktopEnabled: { desktopEnabled },
+            heldStore: store,
+            rejected: rejected
+        )
+        return (client, store)
+    }
+
+    @Test func heldTokenFastPathSkipsSources() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let counter = CallCounter()
+        let held = OAuthCredential(accessToken: "held-tok", expiresAt: now.addingTimeInterval(3600), subscriptionType: "max")
+        // Keychain has an even-fresher token, but the fast path must not look.
+        let kc = countingKeychain(token: "cc-tok", expiry: now.addingTimeInterval(7200), counter: counter)
+        let (client, _) = resolvingClient(keychain: kc, held: held, now: now) { tok in (200, tok == "held-tok" ? 11 : 99) }
+        guard case .success(let snap) = await client.fetchUsage() else { Issue.record("expected success"); return }
+        #expect(snap.fiveHour?.usedPercentage == 11)  // held token used
+        #expect(counter.count == 0)                   // sources never read
+    }
+
+    @Test func slowPathPersistsResolvedToken() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let counter = CallCounter()
+        let kc = countingKeychain(token: "cc-tok", expiry: now.addingTimeInterval(7200), counter: counter)
+        let (client, store) = resolvingClient(keychain: kc, now: now) { _ in (200, 5) }  // no held token
+        _ = await client.fetchUsage()
+        #expect(counter.count == 1)                          // read sources
+        #expect(store.load()?.accessToken == "cc-tok")       // cached the winner
+    }
+
+    @Test func nearExpiryRefreshesFromSource() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let counter = CallCounter()
+        // Held expires in 2 min (< lead time) → must go back to the source.
+        let held = OAuthCredential(accessToken: "old-held", expiresAt: now.addingTimeInterval(120), subscriptionType: "max")
+        let kc = countingKeychain(token: "fresh-cc", expiry: now.addingTimeInterval(7200), counter: counter)
+        let (client, store) = resolvingClient(keychain: kc, held: held, now: now) { tok in (200, tok == "fresh-cc" ? 7 : 99) }
+        guard case .success(let snap) = await client.fetchUsage() else { Issue.record("expected success"); return }
+        #expect(counter.count == 1)                          // re-read sources
+        #expect(snap.fiveHour?.usedPercentage == 7)          // fresher source used
+        #expect(store.load()?.accessToken == "fresh-cc")     // held replaced
+    }
+
+    @Test func heldTokenServesAsFallbackWhenSourcesLost() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let counter = CallCounter()
+        // Held near-expiry (forces slow path), but sources are gone (logged
+        // out). The still-valid held token must carry us.
+        let held = OAuthCredential(accessToken: "held-tok", expiresAt: now.addingTimeInterval(120), subscriptionType: "max")
+        let kc = countingKeychain(token: nil, expiry: nil, counter: counter)  // notFound
+        let (client, _) = resolvingClient(keychain: kc, held: held, now: now) { tok in (200, tok == "held-tok" ? 22 : 0) }
+        guard case .success(let snap) = await client.fetchUsage() else { Issue.record("expected success"); return }
+        #expect(counter.count == 1)                          // tried sources, none
+        #expect(snap.fiveHour?.usedPercentage == 22)         // fell back to held
+    }
+
+    @Test func rejectedTokenFallsThroughToNextCandidate() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let rejected = RejectedTokens()
+        // Desktop holds the freshest token (bad) plus an older valid one.
+        let dt = desktop(cache: [
+            (client: "a", scopes: "user:inference user:profile", token: "bad-tok",
+             expiresMs: Int64(now.addingTimeInterval(99_999).timeIntervalSince1970 * 1000)),
+            (client: "b", scopes: "user:inference user:profile", token: "good-tok",
+             expiresMs: Int64(now.addingTimeInterval(50_000).timeIntervalSince1970 * 1000)),
+        ])
+        let held = OAuthCredential(accessToken: "bad-tok", expiresAt: now.addingTimeInterval(99_999), subscriptionType: "max")
+        let kc = countingKeychain(token: nil, expiry: nil, counter: CallCounter())
+        let (client, store) = resolvingClient(
+            keychain: kc, desktop: dt, desktopEnabled: true, held: held, rejected: rejected, now: now
+        ) { tok in tok == "bad-tok" ? (401, 0) : (200, 13) }
+
+        // Poll 1: uses the freshest (bad) held token → 401 → reject + clear.
+        guard case .failure(.unauthorized) = await client.fetchUsage() else { Issue.record("expected 401"); return }
+        #expect(rejected.isRejected("bad-tok"))
+        #expect(store.load() == nil)
+
+        // Poll 2: bad-tok excluded → falls through to good-tok → 200.
+        guard case .success(let snap) = await client.fetchUsage() else { Issue.record("expected success"); return }
+        #expect(snap.fiveHour?.usedPercentage == 13)
+        #expect(store.load()?.accessToken == "good-tok")
+    }
+
     // MARK: - Live integration (gated)
     //
     // Set PACER_RUN_LIVE_DESKTOP_TEST=1 to decrypt the REAL Claude Desktop


### PR DESCRIPTION
## Why (Phase A of the credential work)

Per discussion: holding our own copy of a working token earns its keep for two reasons reading-on-demand can't give us —
1. **Resilience:** a still-valid held token (esp. Desktop's ~1-year one) keeps Pacer working even after the user logs out of Claude Code or removes Desktop.
2. **Foundation for a phone view:** holding the token is the prerequisite for E2EE-syncing it to a future Pacer iOS app (designed separately as Phase B).

It also means we poll Claude's stores **far** less (about once per token lifetime, not every 5 min).

## What

`OAuthClient.resolveCredential`:
- **Fast path** — a comfortably-valid, non-rejected held token is served directly, no keychain/Desktop read.
- **Slow path** (no held / within 10 min of expiry / rejected) — gather candidates from the Claude Code keychain + opted-in Desktop (+ the held token as fallback), use the **freshest non-expired non-rejected**, cache it. Deterministic tie-break (expiry desc, then token).
- Manual override still wins and is never cached.
- **401 → blocklist + drop held**, so resolution **falls through** to the next-freshest candidate instead of wedging on a stale/revoked pick (`DesktopOAuth` now exposes *all* `user:profile` tokens, freshest-first, for exactly this).

**Storage:** Pacer's own app-private keychain item via `SecItem` — OS-encrypted at rest (Secure-Enclave-protected on modern Macs), no home-grown crypto. `AfterFirstUnlock`, no biometry gate (silent background read). Default store is **in-memory** so tests + Settings probes never touch the real keychain; production opts into `KeychainCredentialStore` at the one construction site. `OAuthCredential` is now `Codable`.

## Verification

- **436 tests pass** (5 new): fast-path-skips-sources (asserts the source is never read), slow-path-persists, near-expiry-refresh, source-loss fallback (held carries us when logged out), and 401 fall-through to the next candidate.
- **Installed-app check:** Pacer created its `com.ericandrechek.pacer.oauth.held` keychain item on the first poll (confirms `SecItemAdd` works in the signed build) and the poller stays healthy with no keychain errors.

## Not in this PR
- **Phase B:** E2EE token sync to a Pacer iOS app (phone-SE keypair, transport, pairing) — its own project.
- Phase 2 guided onboarding/upgrade enablement; Phase 3 honest "auth paused" pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a7NXLY2ExtfrMpzDQUyDA