### PR TITLE
feat(ui): guided Claude Desktop enablement on first run + upgrade

### DIFF
--- a/App/Background/ScreenshotMode.swift
+++ b/App/Background/ScreenshotMode.swift
@@ -83,6 +83,11 @@ enum ScreenshotMode {
             forKey: PacerSettings.Key.menuBarChips
         )
 
+        // Suppress the first-run "Also track Claude Desktop" nudge — it keys
+        // off whether Claude Desktop is installed on the *real* machine, which
+        // would otherwise leak the banner into README screenshots.
+        PacerSettings.store.set(true, forKey: PacerSettings.Key.desktopOnboardingOffered)
+
         // Window scenes — framed like a real macOS window screenshot:
         // traffic-light titlebar, rounded corners, a soft drop shadow on
         // a transparent margin.

--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -137,6 +137,7 @@ public enum PacerSettings {
         public static let projectsSort           = PacerPreferenceKeys.projectsSort
         public static let oauthTokenOverride     = PacerPreferenceKeys.oauthTokenOverride
         public static let desktopCredentialsEnabled = PacerPreferenceKeys.desktopCredentialsEnabled
+        public static let desktopOnboardingOffered = PacerPreferenceKeys.desktopOnboardingOffered
     }
 
     // MARK: - Defaults
@@ -172,6 +173,7 @@ public enum PacerSettings {
         Key.projectsSort:          "cost",
         Key.oauthTokenOverride:    "",
         Key.desktopCredentialsEnabled: false,
+        Key.desktopOnboardingOffered:  false,
     ]
 
     /// Register the defaults dict on first launch — `@AppStorage`'s

--- a/App/Views/DashboardView.swift
+++ b/App/Views/DashboardView.swift
@@ -32,6 +32,7 @@ struct DashboardView: View {
             }
         ) {
             WelcomeCard()
+            DesktopCredentialPrompt()
             NowStrip(
                 onTodayTap: openToday,
                 onSessionTap: { sessionId, displayName in

--- a/App/Views/DesktopCredentialPrompt.swift
+++ b/App/Views/DesktopCredentialPrompt.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import PacerCore
+import PacerUI
+
+/// First-run / post-upgrade nudge to turn on Claude Desktop credentials.
+///
+/// Renders a tinted banner at the top of the dashboard (mirroring
+/// `WelcomeCard`) when ALL of:
+///   - we haven't offered it yet (`desktopOnboardingOffered` is false — so
+///     fresh installs AND existing users upgrading into this build see it
+///     exactly once),
+///   - Claude Desktop is installed with a token cache, and
+///   - the toggle isn't already on.
+///
+/// Either action marks it offered so it never nags again. "Enable" flips the
+/// toggle and reads Desktop once in the background to surface the one-time
+/// "Claude Safe Storage" keychain approval in context; if the user denies it,
+/// the toggle is still on and they can re-approve via the Settings → Authentication
+/// "Test" button (the system dialog, not this banner, is the approval UI).
+struct DesktopCredentialPrompt: View {
+    @AppStorage(PacerSettings.Key.desktopCredentialsEnabled, store: PacerSettings.store)
+    private var enabled: Bool = false
+    @AppStorage(PacerSettings.Key.desktopOnboardingOffered, store: PacerSettings.store)
+    private var offered: Bool = false
+
+    // Snapshot the (cheap, file-only) availability check once per view so
+    // body re-evaluations don't re-stat the config file.
+    private let desktopAvailable = DesktopOAuth.isClaudeDesktopAvailable
+
+    var body: some View {
+        if offered || enabled || !desktopAvailable {
+            EmptyView()
+        } else {
+            banner
+        }
+    }
+
+    private var banner: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "desktopcomputer")
+                .font(.system(size: 26))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 40)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Also track Claude Desktop")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                Text("You have Claude Desktop installed. Let Pacer read its credential (read-only) so your usage keeps updating even when you're not using the Claude Code CLI — and stays live through Claude Code's token gaps. It triggers a one-time keychain approval; you can change this any time in Settings → Authentication.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 10) {
+                    Button("Enable") { enable() }
+                        .buttonStyle(.borderedProminent)
+                    Button("Not now") { offered = true }
+                        .buttonStyle(.bordered)
+                }
+                .padding(.top, 2)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: PacerDesign.cardCornerRadius, style: .continuous)
+                .fill(Color.accentColor.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: PacerDesign.cardCornerRadius, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.18), lineWidth: 1)
+        )
+    }
+
+    private func enable() {
+        enabled = true
+        offered = true
+        // Surface the one-time keychain approval now, in context. The read's
+        // result is immaterial here — the toggle is already on; the poller
+        // will use Desktop once approved, and Settings → Authentication is the
+        // recovery path if the user denies. Run off-main so the (briefly
+        // blocking) `security` subprocess doesn't stall the UI.
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = DesktopOAuth().read()
+        }
+    }
+}

--- a/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
@@ -77,6 +77,14 @@ public struct DesktopOAuth: Sendable {
         self.cacheReader = cacheReader
     }
 
+    /// Whether Claude Desktop is installed with a token cache worth reading —
+    /// a cheap file-only check (`config.json` present with an `oauth:tokenCache*`
+    /// field). Does NOT touch the keychain, so it never triggers a prompt;
+    /// used to decide whether to surface the enablement nudge.
+    public static var isClaudeDesktopAvailable: Bool {
+        defaultCacheReader()?.isEmpty == false
+    }
+
     // MARK: - Read
 
     /// Resolve the freshest `user:profile` credential from Claude Desktop.

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -86,6 +86,11 @@ public enum PacerPreferenceKeys {
     /// app's credential store and triggers a one-time keychain approval, so
     /// the user turns it on deliberately. Read-only; never refreshes.
     public static let desktopCredentialsEnabled = "pacer.desktop.credentialsEnabled"
+    /// Whether we've already offered Desktop-credential enablement via the
+    /// first-run / post-upgrade dashboard prompt. Set once either action is
+    /// taken so the nudge never repeats. Absent (false) on a fresh install
+    /// AND for existing users upgrading into this build → they see it once.
+    public static let desktopOnboardingOffered = "pacer.desktop.onboardingOffered"
 }
 
 /// Convenience accessor for the App Group-suite UserDefaults. Falls


### PR DESCRIPTION
## Why (Phase 2)

Make most people turn on Claude Desktop credentials right away — including existing users upgrading into the build that shipped the feature.

## What

A dashboard nudge (`DesktopCredentialPrompt`, styled like the existing `WelcomeCard`) that shows when **all** of:
- we haven't offered it yet (`desktopOnboardingOffered` false — so fresh installs *and* existing users on their first launch of this build see it exactly once),
- Claude Desktop is installed with a token cache (`DesktopOAuth.isClaudeDesktopAvailable` — a cheap file-only check, no keychain prompt), and
- the toggle isn't already on.

- **Enable** flips the toggle and reads Desktop once in the background to surface the one-time "Claude Safe Storage" keychain approval *in context* (the system dialog is the approval UI; Settings → Authentication is the recovery path if denied).
- **Not now** dismisses. Either action sets the offered flag → never nags again.

Screenshot mode seeds `desktopOnboardingOffered = true` so the banner (which keys off whether Desktop is installed on the *real* machine) never leaks into README screenshots.

## Verification

- 436 tests pass.
- Installed; confirmed the banner's conditions hold on a machine with Desktop installed + toggle off.
- Regenerated screenshots and **visually confirmed the dashboard shot is banner-free** (suppression works), so README screenshots are unchanged.

## Review note

This is a user-facing dashboard banner — it's live in the installed build now, so take a look and tell me if you want copy/placement/behavior tweaks; happy to fast-follow.

## Status of the plan
- Phase 1 (Desktop source), held-token store, and this (Phase 2 onboarding) are done.
- **Phase 3 (honest "auth paused / using Desktop" pill): dropped** per your call — neither you nor users care about the source, and the held-token + freshest-wins work already removed the staleness it was meant to address.
- Phase B (E2EE phone sync) remains a separate future project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a7NXLY2ExtfrMpzDQUyDA