### PR TITLE
fix(ui): tighten Desktop nudge copy; "Not now" snoozes for the session

### DIFF
--- a/App/Background/ScreenshotMode.swift
+++ b/App/Background/ScreenshotMode.swift
@@ -83,11 +83,6 @@ enum ScreenshotMode {
             forKey: PacerSettings.Key.menuBarChips
         )
 
-        // Suppress the first-run "Also track Claude Desktop" nudge — it keys
-        // off whether Claude Desktop is installed on the *real* machine, which
-        // would otherwise leak the banner into README screenshots.
-        PacerSettings.store.set(true, forKey: PacerSettings.Key.desktopOnboardingOffered)
-
         // Window scenes — framed like a real macOS window screenshot:
         // traffic-light titlebar, rounded corners, a soft drop shadow on
         // a transparent margin.

--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -137,7 +137,6 @@ public enum PacerSettings {
         public static let projectsSort           = PacerPreferenceKeys.projectsSort
         public static let oauthTokenOverride     = PacerPreferenceKeys.oauthTokenOverride
         public static let desktopCredentialsEnabled = PacerPreferenceKeys.desktopCredentialsEnabled
-        public static let desktopOnboardingOffered = PacerPreferenceKeys.desktopOnboardingOffered
     }
 
     // MARK: - Defaults
@@ -173,7 +172,6 @@ public enum PacerSettings {
         Key.projectsSort:          "cost",
         Key.oauthTokenOverride:    "",
         Key.desktopCredentialsEnabled: false,
-        Key.desktopOnboardingOffered:  false,
     ]
 
     /// Register the defaults dict on first launch — `@AppStorage`'s

--- a/App/Views/DesktopCredentialPrompt.swift
+++ b/App/Views/DesktopCredentialPrompt.swift
@@ -4,31 +4,28 @@ import PacerUI
 
 /// First-run / post-upgrade nudge to turn on Claude Desktop credentials.
 ///
-/// Renders a tinted banner at the top of the dashboard (mirroring
-/// `WelcomeCard`) when ALL of:
-///   - we haven't offered it yet (`desktopOnboardingOffered` is false — so
-///     fresh installs AND existing users upgrading into this build see it
-///     exactly once),
-///   - Claude Desktop is installed with a token cache, and
-///   - the toggle isn't already on.
+/// A tinted dashboard banner (like `WelcomeCard`) shown when Claude Desktop
+/// is installed with a token cache but the toggle is off.
 ///
-/// Either action marks it offered so it never nags again. "Enable" flips the
-/// toggle and reads Desktop once in the background to surface the one-time
-/// "Claude Safe Storage" keychain approval in context; if the user denies it,
-/// the toggle is still on and they can re-approve via the Settings → Authentication
-/// "Test" button (the system dialog, not this banner, is the approval UI).
+///   - **Enable** turns it on for good and reads Desktop once in the
+///     background to surface the one-time "Claude Safe Storage" keychain
+///     approval in context (the system dialog is the approval UI; Settings →
+///     Authentication is the recovery path if denied).
+///   - **Not now** hides it for *this session only* — it reappears on the
+///     next launch, so someone who isn't ready gets reminded rather than
+///     losing the option silently.
+///
+/// Suppressed in screenshot mode so it never leaks into README shots.
 struct DesktopCredentialPrompt: View {
     @AppStorage(PacerSettings.Key.desktopCredentialsEnabled, store: PacerSettings.store)
     private var enabled: Bool = false
-    @AppStorage(PacerSettings.Key.desktopOnboardingOffered, store: PacerSettings.store)
-    private var offered: Bool = false
+    @State private var dismissedThisSession = false
 
-    // Snapshot the (cheap, file-only) availability check once per view so
-    // body re-evaluations don't re-stat the config file.
+    // Cheap, file-only check (no keychain prompt); snapshot once per view.
     private let desktopAvailable = DesktopOAuth.isClaudeDesktopAvailable
 
     var body: some View {
-        if offered || enabled || !desktopAvailable {
+        if enabled || dismissedThisSession || !desktopAvailable || ScreenshotMode.isActive {
             EmptyView()
         } else {
             banner
@@ -45,14 +42,14 @@ struct DesktopCredentialPrompt: View {
                 Text("Also track Claude Desktop")
                     .font(.title3)
                     .fontWeight(.semibold)
-                Text("You have Claude Desktop installed. Let Pacer read its credential (read-only) so your usage keeps updating even when you're not using the Claude Code CLI — and stays live through Claude Code's token gaps. It triggers a one-time keychain approval; you can change this any time in Settings → Authentication.")
+                Text("Read its credential (read-only) so Pacer keeps updating outside the Claude Code CLI. One-time keychain approval.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 10) {
                     Button("Enable") { enable() }
                         .buttonStyle(.borderedProminent)
-                    Button("Not now") { offered = true }
+                    Button("Not now") { dismissedThisSession = true }
                         .buttonStyle(.bordered)
                 }
                 .padding(.top, 2)
@@ -73,12 +70,10 @@ struct DesktopCredentialPrompt: View {
 
     private func enable() {
         enabled = true
-        offered = true
-        // Surface the one-time keychain approval now, in context. The read's
-        // result is immaterial here — the toggle is already on; the poller
-        // will use Desktop once approved, and Settings → Authentication is the
-        // recovery path if the user denies. Run off-main so the (briefly
-        // blocking) `security` subprocess doesn't stall the UI.
+        // Surface the one-time keychain approval now, in context. Result is
+        // immaterial — the toggle is on; the poller uses Desktop once approved
+        // and Settings → Authentication is the recovery path. Off-main so the
+        // briefly-blocking `security` subprocess doesn't stall the UI.
         DispatchQueue.global(qos: .userInitiated).async {
             _ = DesktopOAuth().read()
         }

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -86,11 +86,6 @@ public enum PacerPreferenceKeys {
     /// app's credential store and triggers a one-time keychain approval, so
     /// the user turns it on deliberately. Read-only; never refreshes.
     public static let desktopCredentialsEnabled = "pacer.desktop.credentialsEnabled"
-    /// Whether we've already offered Desktop-credential enablement via the
-    /// first-run / post-upgrade dashboard prompt. Set once either action is
-    /// taken so the nudge never repeats. Absent (false) on a fresh install
-    /// AND for existing users upgrading into this build → they see it once.
-    public static let desktopOnboardingOffered = "pacer.desktop.onboardingOffered"
 }
 
 /// Convenience accessor for the App Group-suite UserDefaults. Falls


### PR DESCRIPTION
Follow-ups to the Desktop onboarding banner (#86), per review:

- **Copy** trimmed to one line: *"Read its credential (read-only) so Pacer keeps updating outside the Claude Code CLI. One-time keychain approval."*
- **"Not now" behavior fixed.** It was permanent (didn't match the label). Now it hides the banner for the **current session only** and it reappears on the **next launch** — so someone who isn't ready gets reminded rather than losing the option silently. "Enable" still turns it on for good.
- Screenshot suppression switched from a seeded pref to a direct `ScreenshotMode.isActive` check, so the now-unused `desktopOnboardingOffered` pref is **removed entirely**. Verified the regenerated dashboard shot is still banner-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a7NXLY2ExtfrMpzDQUyDA