### PR TITLE
fix(ui): Desktop nudge "Not now" dismisses for good; point to Settings

### DIFF
--- a/App/Settings/PacerSettings.swift
+++ b/App/Settings/PacerSettings.swift
@@ -137,6 +137,7 @@ public enum PacerSettings {
         public static let projectsSort           = PacerPreferenceKeys.projectsSort
         public static let oauthTokenOverride     = PacerPreferenceKeys.oauthTokenOverride
         public static let desktopCredentialsEnabled = PacerPreferenceKeys.desktopCredentialsEnabled
+        public static let desktopOnboardingDismissed = PacerPreferenceKeys.desktopOnboardingDismissed
     }
 
     // MARK: - Defaults
@@ -172,6 +173,7 @@ public enum PacerSettings {
         Key.projectsSort:          "cost",
         Key.oauthTokenOverride:    "",
         Key.desktopCredentialsEnabled: false,
+        Key.desktopOnboardingDismissed: false,
     ]
 
     /// Register the defaults dict on first launch — `@AppStorage`'s

--- a/App/Views/DesktopCredentialPrompt.swift
+++ b/App/Views/DesktopCredentialPrompt.swift
@@ -11,21 +11,22 @@ import PacerUI
 ///     background to surface the one-time "Claude Safe Storage" keychain
 ///     approval in context (the system dialog is the approval UI; Settings →
 ///     Authentication is the recovery path if denied).
-///   - **Not now** hides it for *this session only* — it reappears on the
-///     next launch, so someone who isn't ready gets reminded rather than
-///     losing the option silently.
+///   - **Not now** dismisses it permanently (the nudge never reappears). The
+///     feature stays reachable in Settings → Authentication, which the copy
+///     points to — so nothing is lost silently.
 ///
 /// Suppressed in screenshot mode so it never leaks into README shots.
 struct DesktopCredentialPrompt: View {
     @AppStorage(PacerSettings.Key.desktopCredentialsEnabled, store: PacerSettings.store)
     private var enabled: Bool = false
-    @State private var dismissedThisSession = false
+    @AppStorage(PacerSettings.Key.desktopOnboardingDismissed, store: PacerSettings.store)
+    private var dismissed: Bool = false
 
     // Cheap, file-only check (no keychain prompt); snapshot once per view.
     private let desktopAvailable = DesktopOAuth.isClaudeDesktopAvailable
 
     var body: some View {
-        if enabled || dismissedThisSession || !desktopAvailable || ScreenshotMode.isActive {
+        if enabled || dismissed || !desktopAvailable || ScreenshotMode.isActive {
             EmptyView()
         } else {
             banner
@@ -42,14 +43,14 @@ struct DesktopCredentialPrompt: View {
                 Text("Also track Claude Desktop")
                     .font(.title3)
                     .fontWeight(.semibold)
-                Text("Read its credential (read-only) so Pacer keeps updating outside the Claude Code CLI. One-time keychain approval.")
+                Text("Read its credential (read-only) so Pacer keeps updating outside the Claude Code CLI. One-time keychain approval — turn it on or off anytime in Settings → Authentication.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 10) {
                     Button("Enable") { enable() }
                         .buttonStyle(.borderedProminent)
-                    Button("Not now") { dismissedThisSession = true }
+                    Button("Not now") { dismissed = true }
                         .buttonStyle(.bordered)
                 }
                 .padding(.top, 2)

--- a/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
+++ b/PacerCore/Sources/PacerCore/Settings/PacerPreferenceKeys.swift
@@ -86,6 +86,10 @@ public enum PacerPreferenceKeys {
     /// app's credential store and triggers a one-time keychain approval, so
     /// the user turns it on deliberately. Read-only; never refreshes.
     public static let desktopCredentialsEnabled = "pacer.desktop.credentialsEnabled"
+    /// Set when the user dismisses the first-run "Also track Claude Desktop"
+    /// nudge with "Not now" — so it never reappears. The feature itself stays
+    /// reachable in Settings → Authentication; this only silences the banner.
+    public static let desktopOnboardingDismissed = "pacer.desktop.onboardingDismissed"
 }
 
 /// Convenience accessor for the App Group-suite UserDefaults. Falls


### PR DESCRIPTION
Per review:
- **"Not now" now permanently dismisses** the banner (persisted `desktopOnboardingDismissed`) — no more re-asking each launch.
- The copy now makes the location explicit so nothing is lost silently: *"… one-time keychain approval — turn it on or off anytime in Settings → Authentication."*
- "Enable" still turns it on for good; screenshot suppression unchanged (`ScreenshotMode.isActive`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a7NXLY2ExtfrMpzDQUyDA