### PR TITLE
fix(notify): detect early resets that null the reset anchor

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -424,7 +424,21 @@ final class AppBackgroundService {
                     resetsAt: $0.resetsAt
                 )
             }
-            guard let detection = GlobalRateLimitReset.detect(observations) else { continue }
+            // Window-aware gates. The 5-hour window rolls over constantly and
+            // naturally touches 0%, so keep its high bar (25%) and a short
+            // cut-short lead. The 7-day window hitting 0% is rare and almost
+            // always a real reset, so a lower bar (15%) catches a modest-but-
+            // genuine early reset (Anthropic's 2026-06-20 reset dropped 7-day
+            // from ~17% and nulled the anchor), and a larger lead (10% of the
+            // window) keeps a sleep-gap rollover from masquerading as one.
+            let windowDuration = PaceMath.windowDuration(for: window) ?? (7 * 24 * 3600)
+            let highWatermark: Double = window == RateLimitWindowName.sevenDay ? 15 : 25
+            let minAnchorLead = max(GlobalRateLimitReset.defaultMinAnchorLead, windowDuration * 0.1)
+            guard let detection = GlobalRateLimitReset.detect(
+                observations,
+                highWatermark: highWatermark,
+                minAnchorLead: minAnchorLead
+            ) else { continue }
             await NotificationCoordinator.shared.handleGlobalRateLimitReset(
                 window: window,
                 detection: detection,

--- a/PacerCore/Sources/PacerCore/RateLimit/GlobalRateLimitReset.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/GlobalRateLimitReset.swift
@@ -5,7 +5,14 @@ import Foundation
 /// cycle boundary (they've done this a few times, usually before they
 /// announce it). The fingerprint that distinguishes it from an ordinary
 /// rollover: utilization collapses from a meaningful level to near-zero
-/// while the `resetsAt` cycle anchor does **not** move forward.
+/// while the cycle was **not** due to end — the pre-reset `resetsAt`
+/// anchor sat comfortably in the future at the drop, and across the
+/// collapse that anchor either stays put OR is **cleared to null**.
+/// (Anthropic's 2026-06-20 reset nulled the anchor and dropped the 7-day
+/// window from a modest ~17%; an earlier reset left the anchor in place
+/// at a higher level — this detector handles both.) A normal rollover, by
+/// contrast, lands *at* the anchor and advances it; that's the separate
+/// rollover path in `NotificationCoordinator`.
 ///
 /// Contrast with the normal-rollover path in `NotificationCoordinator`
 /// (`handleRateLimitReset`), which fires only when `resetsAt` advances.
@@ -69,10 +76,19 @@ public enum GlobalRateLimitReset {
 
     // MARK: - Tunables
 
-    /// The drop edge must have been at least this high for the collapse
-    /// to be worth reporting. A window sitting at 8% ticking to 0% isn't
-    /// a meaningful "you got headroom back" event.
+    /// Default floor on how high the drop edge must have been for the
+    /// collapse to be worth reporting. A window sitting at 8% ticking to
+    /// 0% isn't a meaningful "you got headroom back" event. The caller
+    /// overrides this per window — the 7-day window hitting 0% is rare
+    /// and significant, so it uses a lower bar than the chatty 5-hour one.
     public static let highWatermark: Double = 25
+    /// Default lower bound on how far in the future the pre-reset anchor
+    /// must sit at the drop edge for the collapse to count as an *early*
+    /// reset and not a normal rollover. A rollover lands *at* its anchor
+    /// (lead ≈ one poll), so any real lead cleanly separates the two; this
+    /// is also what stops the brief 0%/null window right after an ordinary
+    /// rollover from reading as an early reset. Overridable per window.
+    public static let defaultMinAnchorLead: TimeInterval = 30 * 60
     /// Post-reset utilization must be at or below this to count as a
     /// collapse to (near) zero.
     public static let lowWatermark: Double = 5
@@ -90,29 +106,34 @@ public enum GlobalRateLimitReset {
     public static let minConfirmDuration: TimeInterval = 4 * 60
 
     /// Returns a `Detection` if the most recent observations show a
-    /// sustained, anchor-stable collapse to near-zero preceded by a
-    /// meaningfully high reading on the same cycle anchor. Otherwise nil.
-    public static func detect(_ observations: [Observation]) -> Detection? {
+    /// sustained collapse to near-zero preceded by a meaningfully high
+    /// reading whose cycle anchor was still in the future — and the anchor
+    /// did not roll forward across the collapse (it stayed put or was
+    /// cleared to null). Otherwise nil.
+    public static func detect(
+        _ observations: [Observation],
+        highWatermark: Double = GlobalRateLimitReset.highWatermark,
+        minAnchorLead: TimeInterval = GlobalRateLimitReset.defaultMinAnchorLead
+    ) -> Detection? {
         let series = observations.sorted { $0.sampledAt < $1.sampledAt }
         // Need at least the confirming low run plus one drop-edge sample.
         guard series.count >= minConfirmingSamples + 1 else { return nil }
 
-        // The newest sample must currently be low and carry a cycle
-        // anchor we can compare against (we can't prove "anchor didn't
-        // move" without one).
+        // The newest sample must currently be low. Unlike the original
+        // detector we do NOT require it to carry an anchor: a global reset
+        // can clear `resets_at` to null, and that's exactly the case we
+        // most need to catch. We prove "the cycle didn't roll" off the
+        // drop-edge anchor instead (below).
         guard let newest = series.last,
-              newest.usedPercentage <= lowWatermark,
-              let anchor = newest.resetsAt else { return nil }
+              newest.usedPercentage <= lowWatermark else { return nil }
 
         // Walk back from the newest sample collecting the maximal suffix
-        // of anchor-stable low readings — the confirming low run.
+        // of low readings — the confirming low run. Anchors are checked
+        // against the drop edge afterward, so a cleared (null) anchor
+        // doesn't truncate the run here.
         var startIdx = series.count - 1
         var i = series.count - 1
-        while i >= 0 {
-            let s = series[i]
-            guard s.usedPercentage <= lowWatermark,
-                  let r = s.resetsAt,
-                  abs(r.timeIntervalSince(anchor)) <= anchorTolerance else { break }
+        while i >= 0, series[i].usedPercentage <= lowWatermark {
             startIdx = i
             i -= 1
         }
@@ -125,25 +146,44 @@ public enum GlobalRateLimitReset {
         }
 
         // There must be a sample immediately before the low run to act
-        // as the drop edge.
+        // as the drop edge, and it must itself be meaningfully high.
         guard startIdx > 0 else { return nil }
         let before = series[startIdx - 1]
-
-        // The drop edge must itself be meaningfully high…
         guard before.usedPercentage >= highWatermark else { return nil }
-        // …and carry the SAME cycle anchor as the low run. If its anchor
-        // is earlier, the cycle rolled over → normal reset, not this.
-        // (This is also what keeps a long gap honest: a drop edge from
-        // before a normal rollover carries the old anchor and is
-        // rejected here, so we never mistake a rollover for an early
-        // reset no matter how far back we look.)
-        guard let beforeAnchor = before.resetsAt,
-              abs(beforeAnchor.timeIntervalSince(anchor)) <= anchorTolerance else { return nil }
+
+        // The drop edge must carry a cycle anchor (the pre-reset reset
+        // day) — without it we can't tell an early reset from a rollover.
+        guard let beforeAnchor = before.resetsAt else { return nil }
+
+        // Cut short: the cycle was NOT due to end at the drop — its anchor
+        // sat comfortably in the future. A normal rollover lands *at* its
+        // anchor (lead ≈ one poll), so this is what rejects the brief
+        // 0%/null window that follows an ordinary rollover.
+        guard beforeAnchor.timeIntervalSince(before.sampledAt) >= minAnchorLead else {
+            return nil
+        }
+
+        // The anchor did NOT roll forward across the low run: every
+        // confirming sample's anchor is either cleared (null) or still the
+        // pre-reset anchor within jitter tolerance. A forward jump means a
+        // real rollover began → not an early reset. (This also keeps a long
+        // gap honest: a drop edge from before a rollover carries the old
+        // anchor while the low run carries the advanced one, and is
+        // rejected here no matter how far back we look.)
+        for s in lowRun {
+            if let r = s.resetsAt,
+               abs(r.timeIntervalSince(beforeAnchor)) > anchorTolerance {
+                return nil
+            }
+        }
 
         return Detection(
             droppedFrom: before.usedPercentage,
             droppedTo: newest.usedPercentage,
-            resetsAt: anchor,
+            // Report the stable pre-reset anchor — non-null even when the
+            // live one was cleared — so the caller's per-cycle dedup key
+            // doesn't churn across the null-anchor window.
+            resetsAt: beforeAnchor,
             confirmedAt: newest.sampledAt
         )
     }

--- a/PacerCore/Tests/PacerCoreTests/GlobalRateLimitResetTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/GlobalRateLimitResetTests.swift
@@ -146,11 +146,67 @@ struct GlobalRateLimitResetTests {
         #expect(GlobalRateLimitReset.detect(series) == nil)
     }
 
-    @Test func rejectsWhenAnchorMissing() {
-        // No cycle anchor on the low samples — can't prove "anchor
-        // didn't move", so we don't claim an early reset.
+    @Test func detectsWhenAnchorClearedAcrossReset() {
+        // The real 2026-06-20 signature: high on a far-future anchor, then
+        // a sustained collapse to 0% with the anchor CLEARED to null.
+        // Anthropic nulls `resets_at` on a global reset; the drop-edge
+        // anchor (still in the future) proves the cycle was cut short, so
+        // we detect and report that pre-reset anchor as the stable key.
         let series = [
             obs(minutesAgo: 15, pct: 60, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: nil),
+            obs(minutesAgo: 5, pct: 0, anchor: nil),
+            obs(minutesAgo: 0, pct: 0, anchor: nil),
+        ]
+        let d = GlobalRateLimitReset.detect(series)
+        #expect(d != nil)
+        #expect(d?.droppedFrom == 60)
+        #expect(d?.resetsAt == anchor)
+    }
+
+    @Test func rejectsWhenDropEdgeAnchorMissing() {
+        // The drop edge ALSO has no anchor — with no pre-reset reset day to
+        // anchor on, we can't tell an early reset from a rollover, so bail.
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: nil),
+            obs(minutesAgo: 10, pct: 0, anchor: nil),
+            obs(minutesAgo: 5, pct: 0, anchor: nil),
+            obs(minutesAgo: 0, pct: 0, anchor: nil),
+        ]
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+    }
+
+    @Test func detectsSevenDayModestDropWithClearedAnchor() {
+        // Exactly what shipped overnight on the 7-day window: a drop from a
+        // *modest* 17% (below the default 25% bar) to a sustained 0% with a
+        // far-future anchor cleared to null. The caller lowers the bar to
+        // 15% for the 7-day window, which is rare to ever hit 0%.
+        let series = [
+            obs(minutesAgo: 15, pct: 17, anchor: anchor),
+            obs(minutesAgo: 10, pct: 0, anchor: nil),
+            obs(minutesAgo: 5, pct: 0, anchor: nil),
+            obs(minutesAgo: 0, pct: 0, anchor: nil),
+        ]
+        // With the default 25% bar it's (correctly) below threshold…
+        #expect(GlobalRateLimitReset.detect(series) == nil)
+        // …but with the 7-day window's lower bar it fires.
+        let d = GlobalRateLimitReset.detect(series, highWatermark: 15)
+        #expect(d?.droppedFrom == 17)
+        #expect(d?.droppedTo == 0)
+        #expect(d?.resetsAt == anchor)
+    }
+
+    @Test func rejectsBriefNullAnchorAfterOrdinaryRollover() {
+        // A normal rollover lands *at* its anchor, then briefly reads 0%
+        // with a null anchor before the next anchor appears (observed live
+        // on the 5-hour window). The drop-edge anchor is only ~2 min ahead
+        // of its sample — the cycle wasn't cut short — so this must NOT read
+        // as an early reset.
+        let base = Date(timeIntervalSince1970: 1_749_000_000)
+        // Drop edge sampled 15 min before base; its anchor sits 2 min later.
+        let nearAnchor = base.addingTimeInterval(-15 * 60 + 2 * 60)
+        let series = [
+            obs(minutesAgo: 15, pct: 60, anchor: nearAnchor),
             obs(minutesAgo: 10, pct: 0, anchor: nil),
             obs(minutesAgo: 5, pct: 0, anchor: nil),
             obs(minutesAgo: 0, pct: 0, anchor: nil),


### PR DESCRIPTION
## What happened

Last night (2026-06-20 **00:00:04 UTC**) Anthropic did a global rate-limit reset: both windows dropped to 0% *and* their `resets_at` anchor was **cleared to null** in the same instant. The 7-day window fell from a modest **17% → 0%**. No early-reset notification fired.

Investigation (against the live store + logs) showed:
- **Pacer's collection was healthy** — one OAuth sample every ~5 min, no gaps, no 401/429 across the whole night, straight through the reset.
- The miss was purely in detection: `GlobalRateLimitReset.detect` required the newest sample to carry a **non-null** anchor (`let anchor = newest.resetsAt else { return nil }`) and the drop edge to be **≥25%**. Anthropic nulled the anchor and the 7-day drop was only 17%, so it matched neither the early-reset nor the normal-rollover path.

The detector was modeled on a *previous* global reset where Anthropic left the anchor in place at a high level. This one nulled it off modest usage — a shape it couldn't represent.

## The fix

`detect()` now proves "the cycle didn't roll" off the **drop-edge (pre-reset) anchor** instead of the newest sample's:

- Accepts a sustained low run whose anchor was **cleared to null**.
- Requires the pre-reset anchor to have been **comfortably in the future** at the drop (the cycle was *cut short*) — this is what rejects the brief 0%/null window that legitimately follows an ordinary rollover.
- Rejects any **forward anchor jump** across the low run (that's a real rollover).
- Reports the stable pre-reset anchor as `Detection.resetsAt`, so the per-cycle dedup key doesn't churn while the live anchor is null.

Thresholds are now **window-aware** (two new `detect` params, set by the caller):
- **7-day** → 15% bar (it hitting 0% is rare and almost always a real reset) + larger cut-short lead (10% of the window).
- **5-hour** → keeps the conservative 25% + short lead (it rolls over constantly and naturally touches 0%).

With this, last night's reset would have notified ~6 minutes after it happened.

## Tests

`swift test --filter GlobalRateLimitResetTests` → 15/15 pass, including:
- `detectsWhenAnchorClearedAcrossReset` — the null-anchor signature (was the flipped `rejectsWhenAnchorMissing`, which had locked in the bug).
- `detectsSevenDayModestDropWithClearedAnchor` — last night's exact 17%→0%/null shape; confirms it's below the default 25% bar but fires at the 7-day window's 15%.
- `rejectsBriefNullAnchorAfterOrdinaryRollover` — guards the false positive: a normal 5-hour rollover's short-lived 0%/null window must *not* read as an early reset.
- `rejectsWhenDropEdgeAnchorMissing` — if even the drop edge has no anchor, we still can't prove an early reset, so bail.

## Not in scope (confirmed *not* Pacer)

The Claude Code 401 / `/login` / `/status` rate-limit you saw is independent: Pacer is strictly read-only on Claude's credentials (it only writes its own keychain item; never refreshes/rotates). It rode the long-lived **Desktop** token all night — which is exactly why its polling survived while the CLI session's ~8h token expired and failed to refresh. That's the documented single-use-refresh-token behavior (anthropics/claude-code #48786/#24317), coincident with the reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)