### PR TITLE
fix(engine): reset-aware cycle segmentation so a global reset can't corrupt forecasts

### DIFF
--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
@@ -123,11 +123,44 @@ public enum BurnTrajectory {
         }
     }
 
+    /// A drop of at least this many utilisation points, landing at or below
+    /// `resetLowMax`, marks an *off-schedule reset* inside one anchor's samples.
+    /// Within a real cycle utilisation is monotone non-decreasing, so only a
+    /// reset produces that. (The companion to `GlobalRateLimitReset.detect`,
+    /// reading the value drop the dropped null-anchor samples leave behind.)
+    static let resetDropPoints: Double = 15
+    static let resetLowMax: Double = 5
+
+    /// First index *after* the last in-cycle reset, or 0 when the run never
+    /// resets. Used to keep only the post-reset tail of a contaminated cycle.
+    static func postResetStartIndex(
+        _ rows: [(at: Date, usedPercentage: Double, resetsAt: Date)]
+    ) -> Int {
+        guard rows.count > 1 else { return 0 }
+        var split = 0
+        for i in 1..<rows.count where
+            rows[i - 1].usedPercentage - rows[i].usedPercentage >= resetDropPoints
+            && rows[i].usedPercentage <= resetLowMax {
+            split = i
+        }
+        return split
+    }
+
     /// Segment a flat run of samples (each carrying its window's `resetsAt`)
     /// into the current partial cycle and the prior complete cycles, by
     /// grouping on the reset boundary. The group whose reset is latest is the
     /// current cycle; the rest are history for the backtest. `duration` is the
     /// window length (5h or 7d). Order-agnostic.
+    ///
+    /// Reset-aware: an off-schedule global reset can zero a window mid-cycle
+    /// while leaving its `resetsAt` anchor unchanged (Anthropic restored the
+    /// same 7-day anchor on 2026-06-20), which would otherwise fuse the pre-
+    /// and post-reset readings into one NON-MONOTONE cycle — distorting the live
+    /// fit (a bogus negative slope, an under-scaled level, the wrong band
+    /// stratum) and poisoning the completed-cycle backtest the engine learns
+    /// from. We keep only the post-reset tail of such a group and re-anchor its
+    /// start to the reset, so every cycle handed downstream is monotone from
+    /// its own start.
     public static func segment(
         samples: [(at: Date, usedPercentage: Double, resetsAt: Date)],
         duration: TimeInterval,
@@ -144,15 +177,23 @@ public enum BurnTrajectory {
 
         var history: [Cycle] = []
         var current: PartialCycle?
-        for (key, rows) in groups {
+        for (key, rowsRaw) in groups {
+            let rows = rowsRaw.sorted { $0.at < $1.at }
+            // Drop the pre-reset prefix of a contaminated cycle.
+            let split = postResetStartIndex(rows)
+            let kept = Array(rows[split...])
+            guard !kept.isEmpty else { continue }
             // Use the real reset from the readings, not the rounded group key.
-            let reset = rows.map { $0.resetsAt }.max() ?? key
-            let cycleStart = reset.addingTimeInterval(-duration)
-            let samples = rows.map { Sample(at: $0.at, usedPercentage: $0.usedPercentage) }
+            let reset = kept.map { $0.resetsAt }.max() ?? key
+            // A reset restarts the budget at the drop edge (the last reading
+            // before the collapse ≈ the reset instant, and a safe lower bound
+            // on it); an unbroken cycle begins one window-length before reset.
+            let cycleStart = split > 0 ? rows[split - 1].at : reset.addingTimeInterval(-duration)
+            let cycleSamples = kept.map { Sample(at: $0.at, usedPercentage: $0.usedPercentage) }
             if key == currentReset {
-                current = PartialCycle(samples: samples, now: now, cycleStart: cycleStart, resetsAt: reset)
+                current = PartialCycle(samples: cycleSamples, now: now, cycleStart: cycleStart, resetsAt: reset)
             } else {
-                history.append(Cycle(samples: samples, cycleStart: cycleStart, resetsAt: reset))
+                history.append(Cycle(samples: cycleSamples, cycleStart: cycleStart, resetsAt: reset))
             }
         }
         return (current, history.sorted { $0.cycleStart < $1.cycleStart })

--- a/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/BurnTrajectoryTests.swift
@@ -73,4 +73,61 @@ struct BurnTrajectoryTests {
         let linear = scores.first { $0.id == "linear-recent" }!
         #expect(linear.medianAbsPctError < 10)
     }
+
+    // MARK: - Reset-aware segmentation (the 2026-06-20 global-reset shape)
+
+    @Test func segmentTrimsCurrentCycleAtAnOffScheduleReset() throws {
+        // One 7-day anchor (reset at hour 168). Usage climbs to ~17%, then an
+        // off-schedule reset zeroes it WITHOUT moving the anchor, and it
+        // re-climbs from 0 — the live shape Anthropic produced on 2026-06-20.
+        let reset = at(168)
+        var rows: [(at: Date, usedPercentage: Double, resetsAt: Date)] = []
+        var h = 0.0
+        while h <= 110 { rows.append((at(h), min(17, h * 0.16), reset)); h += 5 }   // → 17%
+        h = 112
+        while h <= 120 { rows.append((at(h), (h - 112) * 0.4, reset)); h += 1 }      // 0 → 3.2%
+        let (current, history) = BurnTrajectory.segment(samples: rows, duration: 7 * 24 * 3600, now: at(120))
+        #expect(history.isEmpty)                                  // single anchor → nothing completed
+        let cur = try #require(current)
+        // Only the post-reset tail survives, and it's monotone non-decreasing
+        // (no fused 17%→0% drop left to distort the fit).
+        #expect(cur.samples.first!.usedPercentage <= BurnTrajectory.resetLowMax)
+        #expect(cur.usedNow <= 3.5)
+        #expect(zip(cur.samples, cur.samples.dropFirst()).allSatisfy { $0.usedPercentage <= $1.usedPercentage + 1e-9 })
+        // cycleStart re-anchored to the reset (~hour 110), not hour 0 (reset−7d),
+        // so level/cut-fraction/slope all read "just reset", not "5 days in".
+        #expect(cur.cycleStart >= at(105))
+        #expect(cur.resetsAt == reset)
+    }
+
+    @Test func segmentTrimsACompletedContaminatedCycle() throws {
+        // A completed cycle (anchor A) carries an off-schedule reset; a later
+        // anchor B is the current cycle. The completed one must enter history
+        // as its clean, monotone post-reset tail — not the fused non-monotone
+        // cycle that would poison the backtest the engine learns from.
+        let resetA = at(168), resetB = at(336)
+        var rows: [(at: Date, usedPercentage: Double, resetsAt: Date)] = []
+        var h = 0.0
+        while h <= 100 { rows.append((at(h), min(20, h * 0.2), resetA)); h += 10 }   // → 20%
+        h = 110
+        while h <= 160 { rows.append((at(h), (h - 110) * 0.2, resetA)); h += 10 }     // 0 → 10%
+        h = 170
+        while h <= 320 { rows.append((at(h), (h - 170) * 0.1, resetB)); h += 10 }     // current cycle
+        let (current, history) = BurnTrajectory.segment(samples: rows, duration: 7 * 24 * 3600, now: at(320))
+        #expect(current != nil)
+        #expect(history.count == 1)
+        let completed = try #require(history.first)
+        #expect(completed.samples.first!.usedPercentage <= BurnTrajectory.resetLowMax)
+        #expect(zip(completed.samples, completed.samples.dropFirst()).allSatisfy { $0.usedPercentage <= $1.usedPercentage + 1e-9 })
+        #expect(completed.resetsAt == resetA)
+    }
+
+    @Test func postResetStartIndexIgnoresMonotoneNoise() {
+        // Small sub-threshold wobbles in an otherwise-climbing cycle never
+        // count as a reset — only a real drop-to-near-zero does.
+        let reset = at(5)
+        let vals = [10.0, 12, 11, 30, 28, 55, 54, 80]
+        let rows = vals.enumerated().map { (at(Double($0.offset) * 0.5), $0.element, reset) }
+        #expect(BurnTrajectory.postResetStartIndex(rows) == 0)
+    }
 }


### PR DESCRIPTION
## Context

Follow-up to #89 (which fixed the *notification* miss for the 2026-06-20 global reset). This fixes how that same reset affects the **intelligence engine** — the estimates and the self-learning loop.

## The problem

Anthropic's 2026-06-20 reset zeroed the 7-day window mid-cycle but left the `resets_at` anchor unchanged (Jun 22 10:00). The engine groups rate-limit samples into cycles **by anchor**, so the pre-reset climb (→17%) and the post-reset re-climb (0→2%) fused into **one non-monotone cycle**.

Measured on the real store, before vs after this change:

| | BEFORE (merged) | AFTER (reset-trimmed) |
|---|---|---|
| samples in "current cycle" | 829 | 11 |
| used range | 0%→17% | 0%→3% |
| shape | **non-monotone** (17→0→2) | **monotone** (0→2) |
| cycle start | Jun 15 10:00 | Jun 19 23:54 |
| cut-fraction | 0.73 ("5 days in") | 0.20 ("just reset") |

### What that fused cycle broke

- **Live estimate:** a bogus *negative* descriptive slope (the recent-slope window straddled the drop), an under-scaled `DiurnalBurnModel` level (`usedNow ÷ ∫` over the whole fused Jun-15 span → projects ~flat for the wrong reason), the wrong conformal band stratum (cut-fraction 0.73 vs ~0.20), and a non-monotone pace chart. None of these false-*alarmed* (usedNow stays correct and low), but they're all structurally wrong.
- **Self-learning loop:** once the fused cycle completes it scores into `EngineEvalOutcome` with ~15pp late-cut errors for *every* model (it's asked to predict the cycle's `max()`=17% from post-reset 2% data), biasing the per-user 7-day accuracy record and `bestMethod` selection. With only ~5-6 seven-day cycles, one contaminated cycle is a large fraction.

5-hour window and all cost surfaces (EOD, monthly) are unaffected — the 5h reset just looks like an early rollover, and cost forecasts come from token JSONL, not rate-limit samples.

## The fix

`BurnTrajectory.segment` is now **reset-aware**. Within an anchor group it detects an in-cycle reset — utilisation dropping ≥15pp to ≤5%, which a real monotone cycle can't produce — keeps only the **post-reset tail**, and re-anchors `cycleStart` to the reset (the last pre-reset reading, a safe lower bound on the reset instant so the level errs toward under- not over-projection).

One change, both layers fixed: every cycle handed downstream — the live current cycle *and* completed cycles used for the backtest — is monotone from its own start. Normal monotone cycles return `split=0` and are **untouched**, so the common path and all existing segmentation behaviour are unchanged.

## Tests

`swift test` → full PacerCore suite green (**442 tests, 32 suites**). New cases:
- `segmentTrimsCurrentCycleAtAnOffScheduleReset` — the live 2026-06-20 shape: current cycle trimmed to its monotone post-reset tail, cycleStart re-anchored.
- `segmentTrimsACompletedContaminatedCycle` — a completed contaminated cycle enters history clean.
- `postResetStartIndexIgnoresMonotoneNoise` — sub-threshold wobbles never split a normal cycle.
- Existing `segmentSplitsCurrentCycleFromHistory` unchanged (proves the normal path is untouched).

## Notes / follow-ups

- Already-recorded outcomes from *prior* resets (the user said "again") stay in the record; `bestMethod` is median-based so they're diluted, and they age out. A one-time backfill could purge them if we decide it's worth it.
- The post-reset `cycleStart` uses the last pre-reset reading as the reset-instant proxy (null-anchor samples are dropped upstream, so the exact instant isn't in the engine's data). Erring early under-projects, which is the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)