### PR TITLE
fix(engine): scope alias-driven re-canonicalization so it can't freeze the UI

### DIFF
--- a/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
+++ b/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
@@ -389,11 +389,13 @@ public final class ScanCoordinator {
         if persister == nil { persister = activePersister }
         activePersister.clearDirtyPairs()
         let changed = try activePersister.canonicalizeAffectedSamples(aliases: aliases)
-        // Mark sessions tied to any altered sample as dirty so the
-        // SessionInfo rollup catches up.
-        if changed > 0 {
-            try activePersister.markSessionsDirtyForAliasChange()
-        }
+        // `canonicalizeAffectedSamples` already folds every re-mapped
+        // sample's session id into `dirtySessionIds`, so the SessionInfo
+        // rollup below recomputes exactly the sessions that moved. The
+        // previous `markSessionsDirtyForAliasChange()` marked *every*
+        // session dirty — an O(all-sessions) rebuild (~6 s for ~450
+        // sessions on a live store) to "catch" sessions whose samples
+        // never changed, which by definition don't need rebuilding.
         let projectRecomputer = ProjectAggregateRecomputer(
             container: container, context: context, mode: configuration.costMode)
         let projectStats = try await projectRecomputer.recompute(
@@ -812,19 +814,37 @@ public final class ScanCoordinator {
         phase.metaPrepMs = tickMs()
 
         if needsPathMigration {
-            let changed = try activePersister.canonicalizeProjectPaths(aliases: aliases)
+            let changed: Int
+            if storedPathVersion != Self.currentPathCanonicalizationVersion {
+                // Code-level canonicalization rule changed: every
+                // TokenSample must be re-evaluated, and the full walk
+                // also backfills `originalProjectPath`. This fires once
+                // per version bump, so the all-rows cost is acceptable.
+                changed = try activePersister.canonicalizeProjectPaths(aliases: aliases)
+            } else {
+                // Alias-fingerprint-only change — the steady-state case,
+                // fired every time the auto-aliaser adds a row (and on
+                // any alias edit that didn't route through
+                // `runAliasMigrationOnly`). Only samples currently under
+                // an alias *source* can re-map, so fetch those by the
+                // indexed `projectPath` column instead of materializing
+                // every TokenSample. This is what turns the recurring
+                // "auto-alias added 1 row" cycle from a ~12 s full-table
+                // walk — a multi-second MainActor freeze the user sees as
+                // a scroll beachball — into a handful of indexed lookups.
+                changed = try activePersister.canonicalizeAffectedSamples(aliases: aliases)
+            }
             if changed > 0 {
                 log("integrity: canonicalized \(changed) sample(s) — worktree+alias mapping updated")
             }
-            // Even when no TokenSample.projectPath changed, the alias
-            // graph may have changed in a way that requires SessionInfo
-            // re-rollup (e.g., the source path had no samples yet, but
-            // future ones will). Mark all sessions dirty as a cheap
-            // belt-and-braces; the recomputer is idempotent and this
-            // path only fires when the user touches the alias table.
-            if storedAliasFingerprint != aliasesFingerprint {
-                try activePersister.markSessionsDirtyForAliasChange()
-            }
+            // Both canonicalize passes fold every re-mapped sample's
+            // session id into `dirtySessionIds`, so the SessionInfo
+            // rollup catches up for exactly the sessions that moved. The
+            // previous belt-and-braces `markSessionsDirtyForAliasChange()`
+            // marked *every* session dirty — an O(all-sessions) rebuild
+            // (~6 s for ~450 sessions on MainActor) to catch sessions
+            // whose samples never changed, which by definition don't need
+            // rebuilding.
         }
         phase.migrationMs = tickMs()
         let beforeStats = activePersister.stats

--- a/PacerCore/Sources/PacerCore/Persistence/SamplePersister.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/SamplePersister.swift
@@ -581,28 +581,6 @@ public final class SamplePersister {
         return changedCount
     }
 
-    /// Mirror of `canonicalizeProjectPaths` for SessionInfo rows.
-    /// SessionInfo carries its own `projectPath` column (denormalized
-    /// for fast queries) and the recomputer can rebuild it from
-    /// underlying samples — but only if the session ids are dirty.
-    /// When an alias mutates only `TokenSample.projectPath`, the
-    /// SessionInfo recomputer will pick up the new path automatically
-    /// once we mark the affected session ids dirty. This helper does
-    /// the marking; the recomputer handles the actual rewrite.
-    public func markSessionsDirtyForAliasChange() throws {
-        var descriptor = FetchDescriptor<TokenSample>()
-        descriptor.propertiesToFetch = [\.sessionId]
-        let samples = try context.fetch(descriptor)
-        for sample in samples {
-            if let sid = sample.sessionId, !sid.isEmpty {
-                dirtySessionIds.insert(sid)
-                // Alias change can shift `SessionInfo.projectPath` —
-                // pollute so the recomputer takes the full path.
-                pollutedSessionIds.insert(sid)
-            }
-        }
-    }
-
     /// User-local 0–23 hour-of-day for a `sampledAt` instant. Matches
     /// the local-zone semantics of `TokenSample.date` so a (date,
     /// hour) pair always agrees with the row it came from.

--- a/PacerCore/Tests/PacerCoreTests/ScanCoordinatorTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ScanCoordinatorTests.swift
@@ -380,6 +380,60 @@ private func makeAssistantLine(
 }
 
 @MainActor
+@Test func coordinatorAliasFingerprintMigrationRecomputesOnlyAffectedSessions() async throws {
+    // Regression: adding/auto-detecting an alias used to trigger a
+    // full-table re-canonicalization (`canonicalizeProjectPaths`) plus
+    // an all-sessions SessionInfo rebuild on the MainActor — measured at
+    // ~19 s on the live store (mig=12.2s + sessR=5.9s for ~450 sessions),
+    // which froze scrolling into a beachball. The alias-fingerprint path
+    // now scopes the canonicalization to samples under the alias source
+    // and recomputes only the sessions those samples belong to.
+    let lineA = makeAssistantLine(
+        timestamp: "2026-04-30T12:00:00.000Z",
+        messageId: "msg-a", requestId: "req-a",
+        cwd: "/Users/test/proj-a", sessionId: "sess-a"
+    )
+    let lineB = makeAssistantLine(
+        timestamp: "2026-04-30T13:00:00.000Z",
+        messageId: "msg-b", requestId: "req-b",
+        cwd: "/Users/test/proj-b", sessionId: "sess-b"
+    )
+    let root = try makeFixtureRoot(withLines: [lineA, lineB])
+    defer { try? FileManager.default.removeItem(at: root) }
+    let resolver = ClaudePathResolver(environment: ["CLAUDE_CONFIG_DIR": root.path])
+
+    let container = try makeInMemoryContainer()
+    let coordinator = ScanCoordinator(
+        container: container,
+        configuration: .init(costMode: .display, watcherMode: .manual, probeStatsCache: false),
+        resolver: resolver
+    )
+
+    // First scan ingests both sessions.
+    _ = try await coordinator.runOnce()
+    let context = ModelContext(container)
+    #expect(try context.fetchCount(FetchDescriptor<SessionInfo>()) == 2)
+
+    // Add an alias that only affects proj-a.
+    let manager = ProjectPathAliasManager(context: context)
+    try manager.upsert(
+        sourcePath: "/Users/test/proj-a",
+        canonicalPath: "/Users/test/proj-a-renamed"
+    )
+
+    // The alias-fingerprint cycle must recompute ONLY sess-a (the moved
+    // session), not both. Pre-fix this was `== 2` (every session).
+    let report = try await coordinator.runOnce()
+    #expect(report.sessionRecomputeStats.sessionsUpserted == 1)
+
+    // sess-a follows the rename; sess-b stays put.
+    let sessions = try ModelContext(container).fetch(FetchDescriptor<SessionInfo>())
+    #expect(sessions.count == 2)
+    #expect(sessions.first { $0.sessionId == "sess-a" }?.projectPath == "/Users/test/proj-a-renamed")
+    #expect(sessions.first { $0.sessionId == "sess-b" }?.projectPath == "/Users/test/proj-b")
+}
+
+@MainActor
 @Test func coordinatorWithoutOAuthClientDoesNotPoll() async throws {
     // Without an oauthClient the poller is never constructed — verify
     // by running a simple manual cycle and checking no


### PR DESCRIPTION
## What

Pacer's scan loop runs on `@MainActor`, so any slow scan cycle freezes the UI — including scrolling, which is what surfaced as a **beachball**.

Live-log diagnosis on the running build (`~/Library/Logs/Pacer/Pacer.err.log`) caught the smoking gun:

```
scan: ... sess=451 ms=18939 [autoA=45 prep=3 mig=12223 ... sessR=5915 ...]
```

A **19-second** main-thread cycle: `mig=12.2s` (full re-canonicalization of every TokenSample) + `sessR=5.9s` (rebuild of all 451 `SessionInfo` rows) — triggered because the auto-aliaser had just added **one** alias, flipping the alias fingerprint. It re-mapped exactly **1 sample**. The auto-aliaser adds a row roughly daily (~15× over the last month in the log), so this freeze recurs. The manual project-merge path (`runAliasMigrationOnly`) had the same all-sessions rebuild, logged at 11–22s per merge.

## Fix

Route alias-**fingerprint** changes through the scoped `canonicalizeAffectedSamples` (an indexed lookup on `projectPath` — the method already written for exactly this case and already used by the manual-merge fast path) instead of the full-table `canonicalizeProjectPaths` walk. Its own per-sample session dirtying drives the `SessionInfo` rollup, so the all-sessions `markSessionsDirtyForAliasChange` sweep is dropped (now unused → removed).

The full walk is kept **only** for code-level `pathCanonicalizationVersion` bumps (one-time per version, and it also backfills `originalProjectPath`).

Net: the recurring "auto-alias added 1 row" cycle goes from a ~12s full-table walk + ~6s all-sessions rebuild to a handful of indexed lookups + one session recompute.

## Safety

- All UI alias changes (merge / remove) route through `.pacerRequestImmediateScan` → `runAliasMigrationOnly`, which already used the scoped path — so the scan-cycle fingerprint branch only ever fires for the auto-aliaser's *additions*, which the scoped path handles exactly.
- The auto-aliaser's `run()` only adds aliases; deletions happen solely in `reconcileSiblingMergeAliases`, gated on a path-version bump (which keeps the full walk).

## Tests

- New regression test: an alias touching one project recomputes **only** that project's session (`sessionsUpserted == 1`), not all of them.
- Existing end-to-end `coordinatorAliasMigrationMovesSamplesAndAggregates` stays green (proves SessionInfo still follows a rename via the scoped path).
- All **443** PacerCore tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)