### PR TITLE
perf(engine): run the scan loop off the main thread (@ScanActor)

### DIFF
--- a/PacerCore/Sources/PacerCore/Coordination/ScanActor.swift
+++ b/PacerCore/Sources/PacerCore/Coordination/ScanActor.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Serial background executor for Pacer's scan pipeline.
+///
+/// Everything that touches the scan-loop `ModelContext` — the
+/// `ScanCoordinator`, the `SamplePersister`, the per-pair recomputers,
+/// the auto-aliaser, and the stats-cache probe — is isolated to this one
+/// global actor so the entire scan cycle runs off the main thread on a
+/// **single serial executor**. The serial part is mandatory: SwiftData's
+/// `ModelContext` is thread-affine, so the context can only be created
+/// and used from one consistent isolation domain.
+///
+/// Why a custom global actor instead of `@MainActor`: the scan loop used
+/// to run on `@MainActor`, so any slow cycle (a big migration, a busy
+/// insert cycle whose `await` resumed behind the previous save's
+/// `@Query` refresh fan-out) stalled scrolling. Moving the loop here
+/// frees the main thread entirely.
+///
+/// Why not per-object `@ModelActor`s: the per-pair recompute fast path
+/// must read the persister's *uncommitted* inserts within the same
+/// cycle, which only works if they share one context — i.e. one
+/// executor. The `@ModelActor` bulk workers (separate context,
+/// save-first) keep their own executors and are awaited from here; their
+/// saves already prove SwiftData fans committed changes out to MainActor
+/// `@Query` subscribers at the container level, independent of which
+/// executor did the save.
+@globalActor
+public actor ScanActor {
+    public static let shared = ScanActor()
+}

--- a/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
+++ b/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
@@ -16,7 +16,7 @@ import SwiftData
 /// when the on-disk version doesn't match this binary's
 /// `currentScanVersion`, we wipe cursors so every JSONL gets re-read
 /// (the persister still rejects existing rows by dedupKey).
-@MainActor
+@ScanActor
 public final class ScanCoordinator {
 
     /// Bump this constant when a parser/aggregation change requires
@@ -234,7 +234,18 @@ public final class ScanCoordinator {
     }
 
     private let container: ModelContainer
-    private let context: ModelContext
+    /// Scan-loop context, lazily created on first `@ScanActor` access.
+    /// `ModelContext` is thread-affine, so it must be born on the same
+    /// executor that uses it — deferring creation past the (nonisolated)
+    /// init guarantees it's created on `ScanActor`, not on whatever
+    /// thread happened to call the initializer.
+    private var _context: ModelContext?
+    private var context: ModelContext {
+        if let _context { return _context }
+        let c = ModelContext(container)
+        _context = c
+        return c
+    }
     private let configuration: Configuration
     private let scanner: JSONLScanner
     private let watcher: JSONLWatcher
@@ -306,7 +317,11 @@ public final class ScanCoordinator {
     /// backstop scan interval.
     private static let autoAliasInterval: TimeInterval = 60
 
-    public init(
+    /// Nonisolated so the driver (`AppBackgroundService`, on MainActor)
+    /// can construct the coordinator without an `await` hop. The
+    /// `ModelContext` is intentionally NOT created here — it's lazily
+    /// born on `ScanActor` on first use (see `context`).
+    public nonisolated init(
         container: ModelContainer,
         configuration: Configuration = Configuration(),
         statsCacheURL: URL? = nil,
@@ -314,7 +329,6 @@ public final class ScanCoordinator {
         oauthClient: OAuthClient? = nil
     ) {
         self.container = container
-        self.context = ModelContext(container)
         self.configuration = configuration
         self.scanner = JSONLScanner()
         self.watcher = JSONLWatcher(mode: configuration.watcherMode)
@@ -414,9 +428,12 @@ public final class ScanCoordinator {
         // so `samplesChanged` stays false; widgets that key off totals
         // / sessions still re-pull via `projectAttributionChanged`.
         if changed > 0 {
-            postScanCycleSummary(ScanCycleSummary(
-                projectAttributionChanged: true
-            ))
+            // Fire-and-forget onto main: the post must run on the main
+            // thread (observers register on `.main`), but the scan cycle
+            // shouldn't block waiting for a free main-thread moment just
+            // to hand off a UI-refresh hint.
+            let summary = ScanCycleSummary(projectAttributionChanged: true)
+            Task { @MainActor in postScanCycleSummary(summary) }
         }
         let report = AliasMigrationReport(
             aliasesChanged: true,
@@ -466,7 +483,8 @@ public final class ScanCoordinator {
         // a login-at-launch invocation has no window, so this widens
         // the watcher's FSEvent latency immediately and saves wakeups
         // until the user actually opens the dashboard.
-        applyVisibilityCadence(visible: PacerWindowVisibility.shared.isMainWindowVisible)
+        let initialVisible = await MainActor.run { PacerWindowVisibility.shared.isMainWindowVisible }
+        applyVisibilityCadence(visible: initialVisible)
         installVisibilityObserver()
 
         // OAuth poller runs independently from the JSONL watcher loop.
@@ -566,7 +584,7 @@ public final class ScanCoordinator {
                 } onChange: {
                     // No body — the loop re-enters and re-reads.
                 }
-                self?.applyVisibilityCadence(visible: visible)
+                await self?.applyVisibilityCadence(visible: visible)
                 // Suspend until the next change. We use a small
                 // continuation-style park by awaiting a one-shot Task
                 // that completes when the observation onChange fires.
@@ -1062,10 +1080,14 @@ public final class ScanCoordinator {
         // alias-driven re-attribution refreshes the project columns
         // even when no new TokenSamples landed.
         if cycleDidWork {
-            postScanCycleSummary(ScanCycleSummary(
+            // Fire-and-forget onto main (see `runAliasMigrationOnly`):
+            // the post must run on main, but the cycle shouldn't wait on
+            // main-thread availability to deliver a refresh hint.
+            let summary = ScanCycleSummary(
                 samplesChanged: true,
                 projectAttributionChanged: needsPathMigration
-            ))
+            )
+            Task { @MainActor in postScanCycleSummary(summary) }
         }
         phase.notifMs = tickMs()
 
@@ -1211,7 +1233,7 @@ public final class ScanCoordinator {
     /// process restarts; changes whenever any key/value differs. Used
     /// to detect "user changed an alias" between scans without
     /// requiring the UI to flip a meta flag.
-    static func fingerprint(aliases: [String: String]) -> String {
+    nonisolated static func fingerprint(aliases: [String: String]) -> String {
         if aliases.isEmpty { return "empty" }
         // Sort the pairs so insertion order doesn't matter.
         let sorted = aliases.sorted { $0.key < $1.key }
@@ -1226,7 +1248,7 @@ public final class ScanCoordinator {
 
     /// FNV-1a 64-bit hash of the joined string, rendered as hex. Tiny,
     /// stable across processes, no external dependency.
-    private static func fnv1aHex(_ s: String) -> String {
+    nonisolated private static func fnv1aHex(_ s: String) -> String {
         var hash: UInt64 = 0xcbf2_9ce4_8422_2325
         for byte in s.utf8 {
             hash ^= UInt64(byte)
@@ -1354,7 +1376,7 @@ private final class InsertSink: @unchecked Sendable {
     /// persister and surfaces the first error. Called by ScanCoordinator
     /// once after `scanner.scan` returns. One MainActor pass instead of
     /// one-hop-per-entry is the entire point of this design.
-    @MainActor
+    @ScanActor
     func flush() throws {
         lock.lock()
         let toInsert = collected

--- a/PacerCore/Sources/PacerCore/Coordination/ScanCycleNotification.swift
+++ b/PacerCore/Sources/PacerCore/Coordination/ScanCycleNotification.swift
@@ -82,6 +82,14 @@ public struct ScanCycleSummary: Sendable {
 /// No-op when `summary.hasAnyChanges == false`. The save-skip path in
 /// `ScanCoordinator` already filters out idle cycles, but this is a
 /// belt-and-suspenders guard against future call sites that don't.
+///
+/// `@MainActor` is load-bearing now that `ScanCoordinator` runs on
+/// `ScanActor` (a background executor): posting from that background
+/// thread delivered the `queue: .main` observer blocks cross-thread,
+/// which measured at multi-second `notif` phases (and would run any
+/// no-queue observer on the scan thread). The coordinator `await`s this
+/// so the post — a sub-ms call — hops to main exactly as it did when the
+/// whole loop was `@MainActor`.
 @MainActor
 public func postScanCycleSummary(_ summary: ScanCycleSummary) {
     guard summary.hasAnyChanges else { return }

--- a/PacerCore/Sources/PacerCore/Parsing/ClaudePathResolver.swift
+++ b/PacerCore/Sources/PacerCore/Parsing/ClaudePathResolver.swift
@@ -17,7 +17,11 @@ import Foundation
 ///      the default location undocumentedly, and 2.1.x still writes to
 ///      `~/.claude` on macOS in practice — the union is the only way to
 ///      stay correct across both layouts.
-public struct ClaudePathResolver {
+public struct ClaudePathResolver: @unchecked Sendable {
+    // @unchecked: immutable value type; the only non-Sendable stored
+    // member is `FileManager`, and `FileManager.default` is documented
+    // thread-safe. Lets `ScanCoordinator`'s nonisolated init store it.
+
 
     public enum ResolutionError: Error, Sendable, Equatable {
         /// `CLAUDE_CONFIG_DIR` was set, but every comma-separated path was

--- a/PacerCore/Sources/PacerCore/Persistence/AggregateRecomputer.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/AggregateRecomputer.swift
@@ -18,7 +18,7 @@ import SwiftData
 ///    `tieredCost` would mis-attribute the boundary — e.g. ten 100k
 ///    calls would look like one 1M call. ccusage iterates entries the
 ///    same way (`data-loader.ts:638-678`).
-@MainActor
+@ScanActor
 public final class AggregateRecomputer {
 
     private let container: ModelContainer

--- a/PacerCore/Sources/PacerCore/Persistence/HourlyAggregateRecomputer.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/HourlyAggregateRecomputer.swift
@@ -10,7 +10,7 @@ import SwiftData
 /// dimension. Same cost-mode semantics (per-entry decision, ccusage
 /// parity on tier boundaries — see that file for the why), same
 /// per-pair / bulk-actor split keyed off `bulkRecomputeThreshold`.
-@MainActor
+@ScanActor
 public final class HourlyAggregateRecomputer {
 
     private let container: ModelContainer

--- a/PacerCore/Sources/PacerCore/Persistence/ProjectAggregateRecomputer.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/ProjectAggregateRecomputer.swift
@@ -10,7 +10,7 @@ import SwiftData
 /// but keyed by project rather than model. Together they keep the
 /// view-side rollups instant — Projects view reads
 /// `ProjectDailyAggregate` directly, no per-sample iteration.
-@MainActor
+@ScanActor
 public final class ProjectAggregateRecomputer {
 
     private let container: ModelContainer

--- a/PacerCore/Sources/PacerCore/Persistence/ProjectGitRootAutoAliaser.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/ProjectGitRootAutoAliaser.swift
@@ -29,7 +29,7 @@ import SwiftData
 /// (pure heuristics) and `ProjectPathAliasManager` (the alias
 /// writer). Lives in the persistence layer because it writes to
 /// multiple tables and needs the `ModelContext`.
-@MainActor
+@ScanActor
 public final class ProjectGitRootAutoAliaser {
     private let context: ModelContext
 

--- a/PacerCore/Sources/PacerCore/Persistence/ProjectPathAliasManager.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/ProjectPathAliasManager.swift
@@ -18,7 +18,6 @@ import SwiftData
 /// after the user clicks "Merge") can call
 /// `scanCoordinator.runOnce()` themselves; otherwise the next scan
 /// cycle picks it up on its own.
-@MainActor
 public final class ProjectPathAliasManager {
 
     public enum AliasError: Error, Equatable, Sendable {

--- a/PacerCore/Sources/PacerCore/Persistence/SamplePersister.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/SamplePersister.swift
@@ -59,7 +59,7 @@ public struct DateHourModelTriple: Hashable, Sendable {
 /// duplicate counting on the small fraction of pre-`requestId` lines; we
 /// accept it because the alternative (matching on timestamp + token
 /// counts) creates false-positive collisions.
-@MainActor
+@ScanActor
 public final class SamplePersister {
 
     private let context: ModelContext

--- a/PacerCore/Sources/PacerCore/Persistence/SessionInfoRecomputer.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/SessionInfoRecomputer.swift
@@ -11,7 +11,7 @@ import SwiftData
 /// the sessions list instantly. Without it, the detail view had to
 /// drop into a `RollupWorker` and iterate every TokenSample for the
 /// project on each scan tick — measurable lag on a populated install.
-@MainActor
+@ScanActor
 public final class SessionInfoRecomputer {
 
     private let container: ModelContainer

--- a/PacerCore/Sources/PacerCore/Probes/StatsCacheProbe.swift
+++ b/PacerCore/Sources/PacerCore/Probes/StatsCacheProbe.swift
@@ -101,7 +101,7 @@ public struct StatsCacheProbe: Sendable {
     /// Run the probe and write its result into `ClaudeCodeMeta`. Used
     /// by the daemon at scan time. Returns the result so callers can
     /// log without re-reading the meta table.
-    @MainActor
+    @ScanActor
     public func probeAndStore(in context: ModelContext) throws -> ProbeResult {
         let result = try probe()
         try writeMeta(context: context, key: ClaudeCodeMetaKey.statsCacheVersion,
@@ -115,7 +115,7 @@ public struct StatsCacheProbe: Sendable {
         return result
     }
 
-    @MainActor
+    @ScanActor
     private func writeMeta(context: ModelContext, key: String, value: String) throws {
         // Upsert via @Attribute(.unique) on key. We fetch-existing-first
         // and mutate rather than insert-and-let-uniqueness-overwrite —

--- a/PacerCore/Tests/PacerCoreTests/HourlyAggregateTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/HourlyAggregateTests.swift
@@ -65,7 +65,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
 
 // MARK: - Dirty-set tracking
 
-@MainActor
+@ScanActor
 @Test func samplePersisterMarksHourBucketDirtyOnInsert() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -86,7 +86,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
     #expect(buckets.contains(where: { $0.hour == 15 }))
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterClearDirtyAlsoClearsHourBuckets() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -103,7 +103,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
 
 // MARK: - Recomputer
 
-@MainActor
+@ScanActor
 @Test func recomputerWritesOneRowPerHourBucket() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -143,7 +143,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
     #expect(h15?.sampleCount == 1)
 }
 
-@MainActor
+@ScanActor
 @Test func recomputerSplitsByModelWithinSameHour() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -169,7 +169,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
     #expect(Set(rows.map(\.model)) == ["claude-opus-4-7", "claude-sonnet-4-6"])
 }
 
-@MainActor
+@ScanActor
 @Test func recomputerUpsertsExistingRowOnSecondPass() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -206,7 +206,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
 
 // MARK: - Missing-bucket recovery (bootstrap path)
 
-@MainActor
+@ScanActor
 @Test func missingHourBucketsDetectedAtPreload() throws {
     // Seed the container with samples but no HourlyAggregate rows,
     // then construct a fresh persister and verify it surfaces every
@@ -233,7 +233,7 @@ private func sortedByKey(_ rows: [HourlyAggregate]) -> [HourlyAggregate] {
     #expect(second.consumeMissingHourBuckets().isEmpty)
 }
 
-@MainActor
+@ScanActor
 @Test func recomputerEmptyBucketSetIsNoop() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)

--- a/PacerCore/Tests/PacerCoreTests/PersistenceTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PersistenceTests.swift
@@ -54,7 +54,7 @@ private func makeEntry(
 
 // MARK: - SamplePersister
 
-@MainActor
+@ScanActor
 @Test func samplePersisterInsertsNewEntries() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -69,7 +69,7 @@ private func makeEntry(
     #expect(persister.stats.skippedAsDuplicate == 0)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterDedupesByKey() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -86,7 +86,7 @@ private func makeEntry(
     #expect(persister.stats.skippedAsDuplicate == 2)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterAcceptsAllNilDedupEntries() throws {
     // The "no dedup key, accept everything" path. We deliberately
     // accept duplicates here rather than guess at heuristic dedup —
@@ -104,7 +104,7 @@ private func makeEntry(
     #expect(persister.stats.skippedAsDuplicate == 0)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterPreloadsExistingDedupKeys() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -122,7 +122,7 @@ private func makeEntry(
     #expect(try context.fetchCount(FetchDescriptor<TokenSample>()) == 2)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterRecoversMissingAggregatePairs() async throws {
     // Reproduces the bug where a re-scan after a DailyAggregate-loss
     // event (clean wipe of just the aggregate table, partial recompute
@@ -172,7 +172,7 @@ private func makeEntry(
     #expect(try context.fetchCount(FetchDescriptor<DailyAggregate>()) == 3)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterRecoveryEmptyOnHealthyStore() throws {
     // Healthy store: every (date, model) pair already has an aggregate.
     // Recovery set should be empty so the first scan cycle is a no-op.
@@ -189,7 +189,7 @@ private func makeEntry(
     #expect(persister.consumeMissingAggregatePairs().isEmpty)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterTracksDirtyPairs() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -206,7 +206,7 @@ private func makeEntry(
     #expect(persister.dirtyPairs.count == 3)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterSavesEveryBatch() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -229,7 +229,7 @@ private func makeEntry(
 // time because SwiftData can't put a TERNARY on the left side of IN.
 // Mix matching, non-matching, and nil-projectPath rows so the
 // per-source iteration has to filter all three.
-@MainActor
+@ScanActor
 @Test func samplePersisterCanonicalizesAffectedSamplesWithManySources() throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -262,7 +262,7 @@ private func makeEntry(
 
 // MARK: - AggregateRecomputer
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerRollsUpDailySums() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -286,7 +286,7 @@ private func makeEntry(
     #expect(aggs[0].outputTokens == 130)
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerSplitsByModel() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -309,7 +309,7 @@ private func makeEntry(
     #expect(aggs[1].inputTokens == 50)
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerUpsertsOnSecondPass() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -331,7 +331,7 @@ private func makeEntry(
     #expect(aggs[0].inputTokens == 150)
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerSumsAllFiveCacheCategories() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -355,7 +355,7 @@ private func makeEntry(
     #expect(agg.cacheCreation1hTokens == 55)
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerDisplayModeSumsStoredCosts() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -375,7 +375,7 @@ private func makeEntry(
     #expect(abs(agg.totalCostUSD - 0.40) < 0.0001)
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerDeletesEmptyBucket() async throws {
     // Edge case: a (date, model) pair gets passed in with no underlying
     // samples. Shouldn't happen in normal flow but defensive: the
@@ -397,7 +397,7 @@ private func makeEntry(
 
 // MARK: - AggregateRecomputer incremental fast path
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerFastPathAddsDeltaToExistingRow() async throws {
     // Verifies the incremental fast path is engaged AND produces a
     // numerically identical result to the legacy full-recompute path
@@ -442,7 +442,7 @@ private func makeEntry(
     #expect(abs(agg.totalCostUSD - 0.70) < 1e-9)
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerFastPathRespectsPollutedPair() async throws {
     // When ScanCoordinator folds a recovery pair into the dirty set
     // (via `addDirtyPairs`), the pair is polluted and must NOT take
@@ -498,13 +498,13 @@ private struct AggregateSnapshot: Sendable {
     let totalCostUSD: Double
 }
 
-@MainActor
+@ScanActor
 @Test func aggregateRecomputerFastPathProducesSameResultAsFullPath() async throws {
     // Property: the fast path and the full-recompute path agree on
     // the resulting `DailyAggregate` for the same input. Run both
     // against equivalent contexts and compare token totals.
     let dayInstant = Date(timeIntervalSince1970: 1_756_800_000)
-    let runScenario = { @MainActor (forceFullPath: Bool) async throws -> AggregateSnapshot in
+    let runScenario = { @ScanActor (forceFullPath: Bool) async throws -> AggregateSnapshot in
         let container = try makeInMemoryContainer()
         let context = ModelContext(container)
         let persister = try SamplePersister(context: context)
@@ -557,7 +557,7 @@ private struct AggregateSnapshot: Sendable {
 
 // MARK: - ProjectAggregateRecomputer
 
-@MainActor
+@ScanActor
 @Test func projectAggregateRecomputerUpsertsBucket() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -599,7 +599,7 @@ private struct AggregateSnapshot: Sendable {
     #expect(abs(repoB.totalCostUSD - 0.20) < 0.0001)
 }
 
-@MainActor
+@ScanActor
 @Test func projectAggregateRecomputerHandlesMissingProjectPath() async throws {
     // Samples with `projectPath == nil` land in the "(unknown)" bucket
     // so they still show up in the Projects list.
@@ -620,7 +620,7 @@ private struct AggregateSnapshot: Sendable {
     #expect(aggregates.first?.projectPath == ProjectDailyAggregate.unknownProjectPath)
 }
 
-@MainActor
+@ScanActor
 @Test func projectAggregateRecomputerBulkPathBackfill() async throws {
     // 64+ dirty pairs should take the bulk path: one fetch + group
     // instead of N small fetches. Verify it produces the same rows
@@ -651,7 +651,7 @@ private struct AggregateSnapshot: Sendable {
 
 // MARK: - SessionInfoRecomputer
 
-@MainActor
+@ScanActor
 @Test func sessionRecomputerRollsUpPerSession() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -705,7 +705,7 @@ private struct AggregateSnapshot: Sendable {
     #expect(b.topModel == "claude-opus-4-7")
 }
 
-@MainActor
+@ScanActor
 @Test func sessionRecomputerSkipsEntriesWithoutSessionId() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -724,7 +724,7 @@ private struct AggregateSnapshot: Sendable {
     #expect(try context.fetchCount(FetchDescriptor<SessionInfo>()) == 0)
 }
 
-@MainActor
+@ScanActor
 @Test func sessionRecomputerUpsertsOnSecondPass() async throws {
     let container = try makeInMemoryContainer()
     let context = ModelContext(container)
@@ -752,7 +752,7 @@ private struct AggregateSnapshot: Sendable {
     #expect(sessions[0].lastSeenAt == later)
 }
 
-@MainActor
+@ScanActor
 @Test func sessionRecomputerBulkPathBackfill() async throws {
     // 64+ dirty session ids should take the bulk path: one fetch +
     // group instead of N small fetches. Verify we still get all
@@ -779,7 +779,7 @@ private struct AggregateSnapshot: Sendable {
     #expect(try context.fetchCount(FetchDescriptor<SessionInfo>()) == 70)
 }
 
-@MainActor
+@ScanActor
 @Test func samplePersisterRecoversMissingSessionIds() throws {
     // Backfill case: TokenSamples already exist with sessionIds but
     // there are no SessionInfo rows. The persister should surface
@@ -810,7 +810,7 @@ private struct AggregateSnapshot: Sendable {
 
 // MARK: - missing-project-aggregate recovery (existing test below)
 
-@MainActor
+@ScanActor
 @Test func samplePersisterRecoversMissingProjectAggregatePairs() throws {
     // Backfill check: when ProjectDailyAggregate is empty but
     // TokenSamples already exist (the upgrade case), the persister

--- a/PacerCore/Tests/PacerCoreTests/ProjectGitRootAutoAliaserTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ProjectGitRootAutoAliaserTests.swift
@@ -3,7 +3,7 @@ import SwiftData
 import Testing
 @testable import PacerCore
 
-@MainActor
+@ScanActor
 @Suite struct ProjectGitRootAutoAliaserTests {
 
     // MARK: - sibling-merge canonical selection

--- a/PacerCore/Tests/PacerCoreTests/ProjectPathAliasManagerTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ProjectPathAliasManagerTests.swift
@@ -19,7 +19,7 @@ private func makeInMemoryContainer() throws -> ModelContainer {
     )
 }
 
-@MainActor
+@ScanActor
 @Suite struct ProjectPathAliasManagerTests {
 
     @Test func upsertInsertsNewAlias() throws {

--- a/PacerCore/Tests/PacerCoreTests/ScanCoordinatorTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ScanCoordinatorTests.swift
@@ -75,7 +75,7 @@ private func makeAssistantLine(
     return String(data: try! JSONSerialization.data(withJSONObject: cleaned), encoding: .utf8)!
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorRunOnceFullScanInsertsAndAggregates() async throws {
     let line1 = makeAssistantLine(
         timestamp: "2026-04-30T12:00:00.000Z",
@@ -120,7 +120,7 @@ private func makeAssistantLine(
     #expect(abs(aggs[0].totalCostUSD - 0.30) < 0.0001)
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorSecondRunIsIncremental() async throws {
     let line = makeAssistantLine(
         timestamp: "2026-04-30T12:00:00.000Z",
@@ -145,7 +145,7 @@ private func makeAssistantLine(
     #expect(second.wasFullScan == false)
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorDedupesAcrossRuns() async throws {
     // The full scan inserts one row; a second full scan (which would
     // happen after a parser version bump) should NOT duplicate it
@@ -190,7 +190,7 @@ private func makeAssistantLine(
     #expect(try ModelContext(container).fetchCount(FetchDescriptor<TokenSample>()) == 1)
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorWritesScanMetaFields() async throws {
     let line = makeAssistantLine(
         timestamp: "2026-04-30T12:00:00.000Z",
@@ -216,7 +216,7 @@ private func makeAssistantLine(
     #expect(byKey[ClaudeCodeMetaKey.lastIncrementalScanAt] != nil)
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorSkipsSyntheticAndUnparseable() async throws {
     let assistant = makeAssistantLine(
         timestamp: "2026-04-30T12:00:00.000Z",
@@ -242,7 +242,7 @@ private func makeAssistantLine(
     #expect(report.persisterStats.inserted == 1)
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorRunForeverStartsAndStopsOAuthPoller() async throws {
     // Wire-in test: when an OAuthClient is provided, runForever() should
     // start the poller alongside the watcher and writes will accumulate
@@ -309,7 +309,7 @@ private func makeAssistantLine(
     #expect(count >= 2, "expected the poller to insert at least one snapshot's worth of rows")
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorAliasMigrationMovesSamplesAndAggregates() async throws {
     // End-to-end: persist samples under /old/path, add an alias
     // /old/path → /new/path, run another cycle, verify samples and
@@ -379,7 +379,7 @@ private func makeAssistantLine(
     #expect(samplesFinal[0].projectPath == "/Users/test/new-name")
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorAliasFingerprintMigrationRecomputesOnlyAffectedSessions() async throws {
     // Regression: adding/auto-detecting an alias used to trigger a
     // full-table re-canonicalization (`canonicalizeProjectPaths`) plus
@@ -433,7 +433,7 @@ private func makeAssistantLine(
     #expect(sessions.first { $0.sessionId == "sess-b" }?.projectPath == "/Users/test/proj-b")
 }
 
-@MainActor
+@ScanActor
 @Test func coordinatorWithoutOAuthClientDoesNotPoll() async throws {
     // Without an oauthClient the poller is never constructed — verify
     // by running a simple manual cycle and checking no

--- a/PacerCore/Tests/PacerCoreTests/StatsCacheProbeTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/StatsCacheProbeTests.swift
@@ -93,7 +93,7 @@ private func writeFixture(_ json: String) throws -> URL {
     #expect(result.totalMessages == nil)
 }
 
-@MainActor
+@ScanActor
 @Test func probeAndStoreWritesMetaKeys() throws {
     let url = try writeFixture("""
     {
@@ -117,7 +117,7 @@ private func writeFixture(_ json: String) throws -> URL {
     #expect(byKey[ClaudeCodeMetaKey.statsCacheTotalMessages] == "1000")
 }
 
-@MainActor
+@ScanActor
 @Test func probeAndStoreUpsertsOnRepeat() throws {
     // First probe writes "3", second probe with different value
     // overwrites the row (no duplicate row).

--- a/docs/perf-tuning.md
+++ b/docs/perf-tuning.md
@@ -122,30 +122,40 @@ persistent-history toggle directly. Approaches:
   from a maintenance pass. Same Core Data FFI requirement. Safer than
   disabling outright.
 
-**Queue #6 — Move scan loop off MainActor.** The biggest remaining win
-and the deferred refactor. `ScanCoordinator` is `@MainActor`-bound
-because the scan-loop ModelContext is the same one views observe.
-Moving off would:
-- Drop the p90 cycle latency variance (currently ~1100 ms tail caused
-  by MainActor-resume queueing behind `@Query` refresh fanout).
-- Let scan cycles run during heavy UI work without blocking the UI.
+**Queue #6 — Move scan loop off MainActor. ✅ DONE (2026-06-20).** The
+whole scan pipeline now runs on a custom serial global actor,
+`@ScanActor` (`Coordination/ScanActor.swift`), instead of `@MainActor`:
+`ScanCoordinator`, `SamplePersister`, all four per-pair recomputers,
+`ProjectGitRootAutoAliaser`, and `StatsCacheProbe.probeAndStore`. The
+main thread is now free during every cycle, so no scan cycle — however
+slow — can stall scrolling. Measured: steady-state cycle dropped from
+the ~300 ms–1.4 s MainActor-resume tail to ~21 ms wall-clock on the
+background actor; the one-time ~7 s persister preload at launch also
+moved off-main (it used to freeze the dashboard on open).
 
-The refactor:
-1. Give `ScanCoordinator` its own non-MainActor `ModelContext` (one
-   per coordinator).
-2. The recomputers' per-pair (≤64 dirty pairs) path is currently
-   `@MainActor` — move it to the same background context.
-3. SwiftData fans cross-context changes to MainActor `@Query`
-   subscribers via `NSManagedObjectContextDidSave` notifications;
-   verify those reach `@Query` correctly. The bulk-recomputer
-   `@ModelActor` path already works this way, so the wiring is
-   proven.
-4. The `cursorsCache` field is currently bare; with the coordinator
-   off MainActor it needs Sendable handling (likely an actor or
-   lock-protected box, same pattern as `JSONLWatcher.changedPaths`).
+How it landed (vs. the original plan above):
+- `ScanCoordinator`'s `ModelContext` was *already* a separate context
+  from the views' `@Query` mainContext (it constructs
+  `ModelContext(container)`), so cross-context propagation to `@Query`
+  was already the live mechanism — the refactor only moved that
+  context's executor to the background. `@Query` refresh topology is
+  unchanged.
+- The context is created lazily on first `@ScanActor` access (not in
+  the now-`nonisolated` init) so it's born on the actor that uses it —
+  `ModelContext` is thread-affine.
+- `cursorsCache` and the other bare fields became `@ScanActor`-isolated
+  actor state for free (no separate lock needed) since the whole class
+  is on one serial executor.
+- **Gotcha worth remembering:** `postScanCycleSummary` MUST run on
+  `@MainActor` (its `queue: .main` observers, and any future no-queue
+  observer, otherwise deliver on the scan thread). Posting it from the
+  background actor measured `notif` phases up to ~16 s. It's now
+  fire-and-forget onto main (`Task { @MainActor in … }`) so the cycle
+  never blocks on main-thread availability for a refresh hint.
 
-This is a careful refactor (~few hours), better done while the user
-is awake to verify the dashboard updates correctly post-change.
+Remaining nit: the launch-time `prep` preload (~7 s: build the
+dedup Set from every TokenSample + prune stale cursors) is one-time and
+off-main, but could be chunked/yielded if it ever matters.
 
 ## Known correctness items
 


### PR DESCRIPTION
## What

Follow-up to #91. The alias-migration fix killed the multi-second beachball, but a residual remained: the scan loop ran on `@MainActor`, so any cycle's work (and its `await scanner.scan` resume queueing behind the previous save's `@Query` fanout) competed with the UI. Live phase logs showed steady-state insert cycles at **300 ms–1.4 s**, and a one-time **~7 s** persister preload that froze the dashboard on launch.

This is the perf doc's deferred "Queue #6 — move scan loop off MainActor," the documented "biggest remaining win."

## How

Move the entire scan pipeline onto a custom **serial global actor**, `@ScanActor` (`Coordination/ScanActor.swift`): `ScanCoordinator`, `SamplePersister`, the four per-pair recomputers, `ProjectGitRootAutoAliaser`, and `StatsCacheProbe`. The main thread is now free during every cycle — no scan cycle, however slow, can stall scrolling.

- The coordinator **already** used a separate `ModelContext` from the views' `@Query` mainContext, so cross-context propagation to `@Query` was already the live mechanism (same as the `@ModelActor` bulk workers). This only moves that context's *executor* to the background — `@Query` refresh topology is unchanged.
- Context is created **lazily** on first `@ScanActor` access (init is now `nonisolated`) so it's born on the actor that uses it — `ModelContext` is thread-affine. `ClaudePathResolver` made `Sendable` so the nonisolated init can store it.
- `postScanCycleSummary` stays `@MainActor` and is now **fire-and-forget** onto main (`Task { @MainActor }`). Posting it from the background actor delivered its `queue: .main` observers cross-thread and measured `notif` phases up to **~16 s**; fire-and-forget keeps the cycle from ever blocking on the main thread for a refresh hint.
- `fingerprint`/`fnv1aHex` made `nonisolated` (pure); `ProjectPathAliasManager` made `nonisolated` (pure context CRUD, used from both UI and `ScanActor`).

## Measured (after install, live store)

| | before | after |
|---|---|---|
| steady-state cycle | 300 ms–1.4 s | **~21 ms** |
| `notif` phase | up to 16 s | **0** |
| launch preload | ~7 s on MainActor (froze UI) | ~7 s off-main |
| idle CPU | 0% | 0% |

No crashes or data races. All **443** PacerCore tests pass (pipeline tests moved to `@ScanActor`).

## Verification note

`@Query` cross-context propagation is unchanged (the scan context was always separate from the view context), and the end-to-end alias-migration test proves cross-context visibility. Confirming the live dashboard updates as expected before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)