### PR TITLE
feat(api): per-model + per-day usage history endpoints

### DIFF
--- a/App/Background/PacerHTTPServer.swift
+++ b/App/Background/PacerHTTPServer.swift
@@ -221,7 +221,9 @@ final class PacerHTTPServer: @unchecked Sendable {
         }
         let method = String(parts[0])
         let rawPath = String(parts[1])
-        let path = rawPath.split(separator: "?").first.map(String.init) ?? rawPath
+        let pathQuery = rawPath.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+        let path = pathQuery.first.map(String.init) ?? rawPath
+        let query = Self.parseQuery(pathQuery.count > 1 ? String(pathQuery[1]) : "")
 
         var headers: [String: String] = [:]
         for line in lines.dropFirst() {
@@ -235,10 +237,10 @@ final class PacerHTTPServer: @unchecked Sendable {
             respond(client, status: 405, contentType: "text/plain", body: Data("Method Not Allowed\n".utf8))
             return
         }
-        route(path: path, headers: headers, client: client)
+        route(path: path, query: query, headers: headers, client: client)
     }
 
-    private func route(path: String, headers: [String: String], client: ClientConnection) {
+    private func route(path: String, query: [String: String], headers: [String: String], client: ClientConnection) {
         switch path {
         case "/healthz":
             respond(client, status: 200, contentType: "text/plain", body: Data("ok\n".utf8))
@@ -250,12 +252,27 @@ final class PacerHTTPServer: @unchecked Sendable {
                 return respond(client, status: 503, contentType: "text/plain", body: Data("No data yet\n".utf8))
             }
             respond(client, status: 200, contentType: "application/json; charset=utf-8", body: Data(json.utf8))
+        case "/v1/usage/daily":
+            guard authorized(headers) else { return unauthorized(client) }
+            let days = query["days"].flatMap { Int($0) } ?? 30
+            guard let usage = try? PacerUsageBuilder.daily(days: days), let json = try? usage.encodedJSON() else {
+                return respond(client, status: 503, contentType: "text/plain", body: Data("No data yet\n".utf8))
+            }
+            respond(client, status: 200, contentType: "application/json; charset=utf-8", body: Data(json.utf8))
+        case "/v1/usage/models":
+            guard authorized(headers) else { return unauthorized(client) }
+            guard let usage = try? PacerUsageBuilder.models(), let json = try? usage.encodedJSON() else {
+                return respond(client, status: 503, contentType: "text/plain", body: Data("No data yet\n".utf8))
+            }
+            respond(client, status: 200, contentType: "application/json; charset=utf-8", body: Data(json.utf8))
         case "/metrics":
             guard authorized(headers) else { return unauthorized(client) }
             guard let payload = currentPayload() else {
                 return respond(client, status: 503, contentType: "text/plain", body: Data("# no data yet\n".utf8))
             }
-            let text = PacerMetrics(snapshot: payload, version: appVersion, build: appBuild).prometheusText()
+            let todayModels = (try? PacerUsageBuilder.todayByModel()) ?? []
+            let text = PacerMetrics(snapshot: payload, todayModels: todayModels,
+                                    version: appVersion, build: appBuild).prometheusText()
             respond(client, status: 200, contentType: "text/plain; version=0.0.4; charset=utf-8", body: Data(text.utf8))
         case "/v1/stream":
             guard authorized(headers) else { return unauthorized(client) }
@@ -263,6 +280,19 @@ final class PacerHTTPServer: @unchecked Sendable {
         default:
             respond(client, status: 404, contentType: "text/plain", body: Data("Not Found\n".utf8))
         }
+    }
+
+    /// Parse a URL query string (`a=1&b=2`) into a dict, percent-decoding values.
+    private static func parseQuery(_ raw: String) -> [String: String] {
+        var out: [String: String] = [:]
+        for pair in raw.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            let key = String(kv[0])
+            guard !key.isEmpty else { continue }
+            let value = kv.count > 1 ? String(kv[1]) : ""
+            out[key] = value.removingPercentEncoding ?? value
+        }
+        return out
     }
 
     // MARK: - Auth
@@ -390,7 +420,7 @@ final class PacerHTTPServer: @unchecked Sendable {
             "version": appVersion,
             "build": appBuild,
             "schemaVersion": 1,
-            "endpoints": ["/v1/snapshot", "/v1/stream", "/metrics", "/healthz"],
+            "endpoints": ["/v1/snapshot", "/v1/usage/daily", "/v1/usage/models", "/v1/stream", "/metrics", "/healthz"],
         ]
         return (try? JSONSerialization.data(withJSONObject: info, options: [.prettyPrinted, .sortedKeys]))
             ?? Data("{}".utf8)

--- a/PacerCore/Sources/PacerCore/API/PacerMetrics.swift
+++ b/PacerCore/Sources/PacerCore/API/PacerMetrics.swift
@@ -44,7 +44,9 @@ public struct PacerMetric: Sendable, Equatable {
 public struct PacerMetrics: Sendable {
     public let points: [PacerMetric]
 
-    public init(snapshot s: PacerSnapshotPayload, version: String, build: String) {
+    public init(snapshot s: PacerSnapshotPayload,
+                todayModels: [PacerDailyUsage.Row] = [],
+                version: String, build: String) {
         var m: [PacerMetric] = []
 
         func windowMetrics(_ key: String, _ w: PacerSnapshotPayload.Limits.Window?) {
@@ -107,6 +109,20 @@ public struct PacerMetrics: Sendable {
         }
         m.append(PacerMetric("pacer_forecast_fresh", s.dataSource.forecastFresh ? 1 : 0,
                              help: "1 if a fresh engine projection backs the forecast metrics, else 0."))
+
+        // Per-model breakdown for today (omitted when no usage yet).
+        let modelCostHelp = "Today's spend per model in USD."
+        let modelTokHelp = "Today's token counts per model by kind."
+        for row in todayModels {
+            m.append(PacerMetric("pacer_model_cost_usd", row.costUSD, help: modelCostHelp,
+                                 labels: [("model", row.model)]))
+            m.append(PacerMetric("pacer_model_tokens", Double(row.input), help: modelTokHelp,
+                                 labels: [("model", row.model), ("kind", "input")]))
+            m.append(PacerMetric("pacer_model_tokens", Double(row.output), help: modelTokHelp,
+                                 labels: [("model", row.model), ("kind", "output")]))
+            m.append(PacerMetric("pacer_model_tokens", Double(row.cacheRead), help: modelTokHelp,
+                                 labels: [("model", row.model), ("kind", "cache_read")]))
+        }
 
         m.append(PacerMetric("pacer_up", 1, help: "Always 1 while the Pacer API is responding."))
         m.append(PacerMetric("pacer_build_info", 1,

--- a/PacerCore/Sources/PacerCore/API/PacerUsageHistory.swift
+++ b/PacerCore/Sources/PacerCore/API/PacerUsageHistory.swift
@@ -1,0 +1,143 @@
+import Foundation
+import SwiftData
+
+/// Shared JSON encoding for the API surface (ISO-8601 dates, stable key order).
+func pacerAPIEncodedJSON<T: Encodable>(_ value: T) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    return String(decoding: try encoder.encode(value), as: UTF8.self)
+}
+
+/// Per-day, per-model token + cost history — the full-fidelity view a consumer
+/// needs to reproduce a daily/per-model breakdown (all five token categories,
+/// not just the snapshot's compact "today" aggregate).
+///
+/// **Today is live.** The row whose `date == today` is an in-progress partial
+/// that updates as Pacer ingests new JSONL (same source as
+/// `PacerSnapshotPayload.tokens.todayTotal`), and is flagged `inProgress`.
+/// Dates are local-day keys (`yyyy-MM-dd`), matching how the app rolls "today"
+/// over at local midnight.
+public struct PacerDailyUsage: Codable, Sendable {
+    public let schemaVersion: Int
+    public let generatedAt: Date
+    /// Local-day key for "today" — the `inProgress` row, if any usage so far.
+    public let today: String
+    public let rows: [Row]
+
+    public struct Row: Codable, Sendable {
+        public let date: String
+        public let model: String
+        public let input: Int
+        public let output: Int
+        public let cacheRead: Int
+        public let cacheCreation5m: Int
+        public let cacheCreation1h: Int
+        public let costUSD: Double
+        /// True for the still-accumulating current local day.
+        public let inProgress: Bool
+    }
+
+    public func encodedJSON() throws -> String { try pacerAPIEncodedJSON(self) }
+}
+
+/// Per-model lifetime totals (all five token categories + cost), aggregated
+/// across Pacer's full retained daily history.
+public struct PacerModelUsage: Codable, Sendable {
+    public let schemaVersion: Int
+    public let generatedAt: Date
+    public let models: [Row]
+
+    public struct Row: Codable, Sendable {
+        public let model: String
+        public let input: Int
+        public let output: Int
+        public let cacheRead: Int
+        public let cacheCreation5m: Int
+        public let cacheCreation1h: Int
+        public let costUSD: Double
+        public let firstDate: String
+        public let lastDate: String
+    }
+
+    public func encodedJSON() throws -> String { try pacerAPIEncodedJSON(self) }
+}
+
+/// Builders for the usage-history endpoints. `nonisolated` + self-contained
+/// (own short-lived `ModelContext`), like `PacerSnapshotBuilder`, so the HTTP
+/// server reads them off its background queue.
+public enum PacerUsageBuilder {
+
+    /// Per-day, per-model rows for the last `days` local days (inclusive of
+    /// today). `days` is clamped to 1…3650.
+    public nonisolated static func daily(days: Int, now: Date = Date()) throws -> PacerDailyUsage {
+        let span = min(max(days, 1), 3650)
+        let container = try PacerStore.sharedModelContainer()
+        let context = ModelContext(container)
+        let calendar = Calendar.current
+        let todayKey = TokenSample.formatDate(now)
+        let cutoffDate = calendar.date(byAdding: .day, value: -(span - 1), to: now) ?? now
+        let cutoffKey = TokenSample.formatDate(cutoffDate)
+
+        let all = (try? context.fetch(FetchDescriptor<DailyAggregate>())) ?? []
+        let filtered = all.filter { $0.date >= cutoffKey }
+        let sorted = filtered.sorted { $0.date != $1.date ? $0.date < $1.date : $0.model < $1.model }
+        var rows: [PacerDailyUsage.Row] = []
+        rows.reserveCapacity(sorted.count)
+        for agg in sorted {
+            rows.append(PacerDailyUsage.Row(
+                date: agg.date,
+                model: agg.model,
+                input: Int(agg.inputTokens),
+                output: Int(agg.outputTokens),
+                cacheRead: Int(agg.cacheReadTokens),
+                cacheCreation5m: Int(agg.cacheCreation5mTokens),
+                cacheCreation1h: Int(agg.cacheCreation1hTokens),
+                costUSD: agg.totalCostUSD,
+                inProgress: agg.date == todayKey))
+        }
+        return PacerDailyUsage(schemaVersion: 1, generatedAt: now, today: todayKey, rows: rows)
+    }
+
+    /// Today's per-model rows only — the live, in-progress slice. Used for the
+    /// `pacer_model_*` Prometheus series.
+    public nonisolated static func todayByModel(now: Date = Date()) throws -> [PacerDailyUsage.Row] {
+        try daily(days: 1, now: now).rows.filter { $0.inProgress }
+    }
+
+    /// Per-model lifetime totals across all retained daily history.
+    public nonisolated static func models(now: Date = Date()) throws -> PacerModelUsage {
+        let container = try PacerStore.sharedModelContainer()
+        let context = ModelContext(container)
+        let all = (try? context.fetch(FetchDescriptor<DailyAggregate>())) ?? []
+
+        struct Accumulator {
+            var input: Int64 = 0, output: Int64 = 0, cacheRead: Int64 = 0
+            var c5m: Int64 = 0, c1h: Int64 = 0, cost: Double = 0
+            var firstDate = "", lastDate = ""
+        }
+        var byModel: [String: Accumulator] = [:]
+        for agg in all {
+            var acc = byModel[agg.model] ?? Accumulator()
+            acc.input += agg.inputTokens
+            acc.output += agg.outputTokens
+            acc.cacheRead += agg.cacheReadTokens
+            acc.c5m += agg.cacheCreation5mTokens
+            acc.c1h += agg.cacheCreation1hTokens
+            acc.cost += agg.totalCostUSD
+            if acc.firstDate.isEmpty || agg.date < acc.firstDate { acc.firstDate = agg.date }
+            if acc.lastDate.isEmpty || agg.date > acc.lastDate { acc.lastDate = agg.date }
+            byModel[agg.model] = acc
+        }
+        let models = byModel
+            .map { model, acc in
+                PacerModelUsage.Row(
+                    model: model,
+                    input: Int(acc.input), output: Int(acc.output), cacheRead: Int(acc.cacheRead),
+                    cacheCreation5m: Int(acc.c5m), cacheCreation1h: Int(acc.c1h),
+                    costUSD: acc.cost, firstDate: acc.firstDate, lastDate: acc.lastDate)
+            }
+            .sorted { $0.costUSD > $1.costUSD }
+        return PacerModelUsage(schemaVersion: 1, generatedAt: now, models: models)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/PacerUsageTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PacerUsageTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Pacer usage history API")
+struct PacerUsageTests {
+
+    private func row(date: String, model: String, inProgress: Bool) -> PacerDailyUsage.Row {
+        PacerDailyUsage.Row(date: date, model: model, input: 100, output: 200, cacheRead: 300,
+                            cacheCreation5m: 10, cacheCreation1h: 5, costUSD: 1.25, inProgress: inProgress)
+    }
+
+    @Test func dailyEncodesAllFiveCategoriesAndInProgressFlag() throws {
+        let usage = PacerDailyUsage(
+            schemaVersion: 1,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            today: "2026-06-22",
+            rows: [row(date: "2026-06-21", model: "claude-opus-4-8", inProgress: false),
+                   row(date: "2026-06-22", model: "claude-opus-4-8", inProgress: true)])
+        let json = try usage.encodedJSON()
+        #expect(json.contains("\"cacheCreation5m\" : 10"))
+        #expect(json.contains("\"cacheCreation1h\" : 5"))
+        #expect(json.contains("\"inProgress\" : true"))
+        #expect(json.contains("\"inProgress\" : false"))
+        #expect(json.contains("\"today\" : \"2026-06-22\""))
+    }
+
+    @Test func modelsEncodeLifetimeRow() throws {
+        let usage = PacerModelUsage(
+            schemaVersion: 1,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            models: [PacerModelUsage.Row(model: "claude-opus-4-8", input: 1000, output: 2000,
+                                         cacheRead: 3000, cacheCreation5m: 100, cacheCreation1h: 50,
+                                         costUSD: 42.5, firstDate: "2026-01-01", lastDate: "2026-06-22")])
+        let json = try usage.encodedJSON()
+        #expect(json.contains("\"model\" : \"claude-opus-4-8\""))
+        #expect(json.contains("\"firstDate\" : \"2026-01-01\""))
+        #expect(json.contains("\"costUSD\" : 42.5"))
+    }
+
+    @Test func metricsEmitPerModelSeriesWhenTodayModelsProvided() {
+        let snapshot = PacerSnapshotPayload(
+            schemaVersion: 1, generatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            limits: .init(fiveHour: nil, sevenDay: nil),
+            cost: .init(todayUSD: 0, weekUSD: 0, monthUSD: 0, allTimeUSD: 0,
+                        projectedTodayUSD: nil, projectedTodayLowUSD: nil, projectedTodayHighUSD: nil,
+                        projectedMonthUSD: nil, projectedMonthLowUSD: nil, projectedMonthHighUSD: nil),
+            tokens: .init(todayInput: 0, todayOutput: 0, todayCacheRead: 0, todayTotal: 0),
+            pace: .init(percentile: nil, status: nil),
+            session: nil, overageUSD: 0,
+            dataSource: .init(source: nil, lastSampleAt: nil, ageSeconds: nil, forecastFresh: false))
+        let text = PacerMetrics(snapshot: snapshot,
+                                todayModels: [row(date: "2026-06-22", model: "claude-opus-4-8", inProgress: true)],
+                                version: "1.0", build: "1").prometheusText()
+        #expect(text.contains("pacer_model_cost_usd{model=\"claude-opus-4-8\"} 1.25"))
+        #expect(text.contains("pacer_model_tokens{model=\"claude-opus-4-8\",kind=\"input\"} 100"))
+    }
+}


### PR DESCRIPTION
## What

Closes the token-fidelity gap identified while wiring a Stream Deck plugin to Pacer: the snapshot only exposes a compact "today, all models, 3 categories" view, but Pacer's store has full per-model, per-day, 5-category, lifetime detail (+ cost). This exposes it, so a consumer can retire its own JSONL scanner **and** pricing table and source everything from Pacer at full fidelity.

| Endpoint | Returns |
|---|---|
| `GET /v1/usage/daily?days=N` | per-day, per-model rows: all 5 token categories (input, output, cache_read, cache_creation_5m, cache_creation_1h) + cost. **Today is a live in-progress row** (`inProgress: true`). |
| `GET /v1/usage/models` | per-model lifetime totals (5 categories + cost + first/last date) |
| `/metrics` (extended) | per-model today series: `pacer_model_cost_usd{model}`, `pacer_model_tokens{model,kind}` |

### The "is today live?" question (answered)
Today's row is sourced from the same `DailyAggregate` rows Pacer's FSEvents scan loop updates continuously — the exact source behind `snapshot.tokens.todayTotal`. So it never freezes at session-end, and it's flagged `inProgress`. **Verified consistent live:** daily's today row (input+output across models) = `770248` = `snapshot.tokens.todayTotal` = `770248`.

Recommended consumer pattern: drive the live "today" figure / sparkline tip from the SSE `snapshot` push (`tokens.todayTotal`); pull `/v1/usage/daily` for history + per-model detail (its today row is live too, but you don't need to poll it for the live number).

## Design
- Sourced entirely from existing aggregates — no new data plumbing. Builders are `nonisolated` (own short-lived `ModelContext`), like `PacerSnapshotBuilder`, so the server reads them off its background queue.
- Same schema-versioned JSON, ISO-8601 dates, bearer auth as the rest of the API. Dates are local-day keys (matches the app's day-rollover handling).
- Per-model metrics keep the transport-agnostic metric model intact (still OTLP-ready).

## Test
- `make test` — 451 pass, incl. new usage-encoding + per-model-metric tests.
- `make verify` / `make install` — clean build.
- **Verified live** against the real store (server temporarily enabled, then reverted): both endpoints, the `inProgress` flag on today vs past days, daily/snapshot consistency, per-model `/metrics` series, `/` endpoint listing, and 401 on the new paths without a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)