### PR TITLE
fix(auth): read Claude Desktop's keychain only when its tokens change

### DIFF
--- a/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
@@ -261,4 +261,53 @@ public struct DesktopOAuth: Sendable {
         else { return nil }
         return ["oauth:tokenCache", "oauth:tokenCacheV2"].compactMap { obj[$0] as? String }
     }
+
+    /// A cheap, prompt-free fingerprint of the on-disk token cache — a hash of
+    /// the encrypted blobs from `config.json`, which change only when Desktop
+    /// rotates its tokens. `nil` when the config is absent. Reads no keychain,
+    /// so it never prompts; `OAuthClient` uses it to avoid re-reading (and
+    /// re-prompting on) the keychain when Desktop's tokens haven't changed.
+    public func cacheFingerprint() -> String? {
+        guard let blobs = cacheReader() else { return nil }
+        // hashValue is per-process-stable, which is all the gate needs (it
+        // only ever compares fingerprints within one run), and it avoids
+        // retaining the ciphertext.
+        return String(blobs.joined(separator: "\u{0}").hashValue)
+    }
+}
+
+/// Tracks the fingerprint of Claude Desktop's token cache at our last read of
+/// its keychain item, so `OAuthClient` re-reads it — and risks re-popping the
+/// macOS approval prompt — only when Desktop's tokens have actually changed.
+///
+/// Why this exists: the `Claude Safe Storage` item is owned by Claude Desktop,
+/// and macOS does not reliably persist "Always Allow" for a foreign app's
+/// item, so every read can re-prompt. Re-reading an unchanged token file would
+/// just re-derive the same credential — so we read it once, then stay quiet
+/// until the file changes (a token refresh) or the app restarts. This is the
+/// backstop for the cases the held-token fast path can't cover (a Desktop
+/// token that's been revoked and cleared from our held store).
+public final class DesktopReadGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lastFingerprint: String?
+
+    public init() {}
+
+    /// Whether to read Desktop's keychain, given the current cache
+    /// fingerprint. Reads when we've never read or the cache changed since. A
+    /// `nil` fingerprint (config unreadable) lets the attempt proceed — it
+    /// short-circuits on `configNotFound` before touching the keychain, so it
+    /// can't prompt anyway.
+    func shouldRead(fingerprint: String?) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard let fingerprint else { return true }
+        return fingerprint != lastFingerprint
+    }
+
+    /// Record the fingerprint we just read at. Success and a declined prompt
+    /// both count — a decline shouldn't re-prompt every poll either; we wait
+    /// for the cache to change (or an app restart) before asking again.
+    func record(fingerprint: String?) {
+        lock.lock(); lastFingerprint = fingerprint; lock.unlock()
+    }
 }

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -98,6 +98,11 @@ public struct OAuthClient: Sendable {
     /// Tokens the server has 401'd this process, so resolution won't re-pick
     /// a revoked one and instead falls through to the next-freshest.
     private let rejected: RejectedTokens
+    /// Tracks Claude Desktop's token-file fingerprint so we re-read its
+    /// keychain item — which can pop a macOS prompt "Always Allow" won't
+    /// reliably silence — only when its tokens actually changed. See
+    /// `DesktopReadGate`.
+    private let desktopGate: DesktopReadGate
 
     /// How long before a held token's expiry we go back to the sources for a
     /// fresher one. Until then we serve the held copy without touching
@@ -112,7 +117,8 @@ public struct OAuthClient: Sendable {
         desktop: DesktopOAuth = DesktopOAuth(),
         desktopEnabled: @escaping @Sendable () -> Bool = { PacerPreferences.desktopCredentialsEnabled() },
         heldStore: HeldCredentialStoring = EphemeralCredentialStore(),
-        rejected: RejectedTokens = RejectedTokens()
+        rejected: RejectedTokens = RejectedTokens(),
+        desktopGate: DesktopReadGate = DesktopReadGate()
     ) {
         self.keychain = keychain
         self.transport = transport
@@ -122,6 +128,7 @@ public struct OAuthClient: Sendable {
         self.desktopEnabled = desktopEnabled
         self.heldStore = heldStore
         self.rejected = rejected
+        self.desktopGate = desktopGate
     }
 
     /// Production transport: `URLSession.shared.data(for:)` plus the
@@ -232,14 +239,18 @@ public struct OAuthClient: Sendable {
         let referenceNow = now()
         let held = heldStore.load()
 
-        // Fast path.
+        // Fast path: a comfortably-valid held token is served directly,
+        // without touching Claude's stores.
         if let held, !rejected.isRejected(held.accessToken),
            let expiresAt = held.expiresAt,
            expiresAt >= referenceNow.addingTimeInterval(Self.refreshLeadTime) {
             return .success((held, true))
         }
 
-        // Slow path: read the sources.
+        // Slow path: read the sources. The Claude Code keychain read is
+        // silent (apple-tool: partition), so we always do it; the held token
+        // competes too, serving as the fallback when the sources are
+        // unreadable (logged out / Desktop removed).
         var candidates: [OAuthCredential] = []
         var keychainError: OAuthClientError?
         switch keychain.read() {
@@ -249,18 +260,38 @@ public struct OAuthClient: Sendable {
         case .failure(.malformedJSON(let u)):    keychainError = .keychainMalformed(u)
         case .failure(.unexpectedStatus(let s)): keychainError = .keychainStatus(s)
         }
-        if desktopEnabled(), case .success(let creds) = desktop.readAll() {
-            candidates.append(contentsOf: creds)
-        }
-        // The held token competes too — it serves as the fallback when the
-        // sources are unreadable (logged out / Desktop removed).
         if let held { candidates.append(held) }
 
-        let usable = candidates.filter {
-            !rejected.isRejected($0.accessToken) && ($0.expiresAt == nil || $0.expiresAt! >= referenceNow)
+        // Claude Desktop's `Claude Safe Storage` item is NOT in the
+        // `apple-tool:` partition the `security` CLI reads silently, so each
+        // read can pop a macOS approval prompt that "Always Allow" won't
+        // reliably persist for a foreign app's item. The failure mode this
+        // guards against: when Claude Code's token goes stale and isn't
+        // refreshed into the keychain, resolution drops to this slow path on
+        // EVERY poll — and reading Desktop here unconditionally re-prompts
+        // every few minutes. Two conditions keep the read rare: (1) skip it
+        // when we already hold a usable token, and (2) read only when
+        // Desktop's token file has actually changed since we last read it —
+        // re-reading an unchanged file just re-derives the same credential (or
+        // re-fails the same way) and re-prompts for nothing. So we read once,
+        // then stay quiet until Desktop writes a new token.
+        let usable: (OAuthCredential) -> Bool = { [rejected] cred in
+            !rejected.isRejected(cred.accessToken)
+                && (cred.expiresAt == nil || cred.expiresAt! >= referenceNow)
         }
+        if desktopEnabled(), !candidates.contains(where: usable) {
+            let fingerprint = desktop.cacheFingerprint()
+            if desktopGate.shouldRead(fingerprint: fingerprint) {
+                desktopGate.record(fingerprint: fingerprint)
+                if case .success(let creds) = desktop.readAll() {
+                    candidates.append(contentsOf: creds)
+                }
+            }
+        }
+
+        let usableCandidates = candidates.filter(usable)
         // Deterministic freshest-wins: latest expiry, ties broken by token.
-        let best = usable.sorted {
+        let best = usableCandidates.sorted {
             let a = $0.expiresAt ?? .distantFuture
             let b = $1.expiresAt ?? .distantFuture
             return a != b ? a > b : $0.accessToken < $1.accessToken

--- a/PacerCore/Tests/PacerCoreTests/DesktopOAuthTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/DesktopOAuthTests.swift
@@ -387,6 +387,157 @@ import Testing
         #expect(store.load()?.accessToken == "good-tok")
     }
 
+    // MARK: - Desktop read frequency (the "keeps asking for my password" bug)
+    //
+    // The Desktop `Claude Safe Storage` keychain read can pop a macOS prompt
+    // that "Always Allow" won't reliably persist, so resolution must touch it
+    // rarely. These pin the read count — counted via the keyReader, which is
+    // exactly what triggers the prompt.
+
+    /// Desktop source whose keychain key read is counted (each call is one
+    /// approval-prompt opportunity), so a test can assert it was NOT touched.
+    private func countingDesktop(
+        cache: [(client: String, scopes: String, token: String, expiresMs: Int64)],
+        counter: CallCounter
+    ) -> DesktopOAuth {
+        let blobs: [String]? = [encryptV10(cacheData(cache))]
+        return DesktopOAuth(
+            keyReader: { counter.bump(); return .success(Self.testKey) },
+            cacheReader: { blobs }
+        )
+    }
+
+    /// Like `countingDesktop`, but the cache entry carries NO `expiresAt`, so
+    /// the resolved credential has `expiresAt == nil` — the case that never
+    /// satisfies the held-token fast path and used to re-read every poll.
+    private func countingDesktopNoExpiry(token: String, counter: CallCounter) -> DesktopOAuth {
+        let dict: [String: Any] = [
+            key(client: "a", scopes: "user:inference user:profile"): ["token": token, "refreshToken": "r"],
+        ]
+        let blob = encryptV10(try! JSONSerialization.data(withJSONObject: dict))
+        return DesktopOAuth(
+            keyReader: { counter.bump(); return .success(Self.testKey) },
+            cacheReader: { [blob] }
+        )
+    }
+
+    /// A still-valid held token (even one with no expiry) must be served
+    /// without consulting Desktop — Desktop's keychain stays untouched.
+    @Test func usableHeldTokenSkipsDesktopRead() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let counter = CallCounter()
+        let held = OAuthCredential(accessToken: "desk-held", expiresAt: nil, subscriptionType: "max")
+        let dt = countingDesktop(cache: [
+            (client: "a", scopes: "user:inference user:profile", token: "desk-fresh",
+             expiresMs: Int64(now.addingTimeInterval(9999).timeIntervalSince1970 * 1000)),
+        ], counter: counter)
+        let kc = countingKeychain(token: nil, expiry: nil, counter: CallCounter())  // notFound
+        let (client, _) = resolvingClient(
+            keychain: kc, desktop: dt, desktopEnabled: true, held: held, now: now
+        ) { tok in (200, tok == "desk-held" ? 11 : 99) }
+        guard case .success(let snap) = await client.fetchUsage() else { Issue.record("expected success"); return }
+        #expect(snap.fiveHour?.usedPercentage == 11)  // held token used
+        #expect(counter.count == 0)                   // Desktop keychain NOT read
+    }
+
+    /// The regression for "asks every few minutes": a Desktop token with no
+    /// `expiresAt` is read once, cached, then served from the held store on
+    /// subsequent polls — NOT re-read (re-prompted) every cycle.
+    @Test func noExpiryDesktopTokenReadOnceNotEveryPoll() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let counter = CallCounter()
+        let dt = countingDesktopNoExpiry(token: "desk-tok", counter: counter)
+        let kc = countingKeychain(token: nil, expiry: nil, counter: CallCounter())  // Desktop-only user
+        let (client, store) = resolvingClient(
+            keychain: kc, desktop: dt, desktopEnabled: true, now: now
+        ) { _ in (200, 5) }
+        for _ in 0..<3 { _ = await client.fetchUsage() }  // three back-to-back polls
+        #expect(counter.count == 1)                       // read once, then held serves
+        #expect(store.load()?.accessToken == "desk-tok")  // cached
+    }
+
+    /// Even when nothing usable can be served — a Desktop token that 401s and
+    /// is cleared from the held store each poll — we don't re-read (re-prompt
+    /// on) Desktop's keychain while its token file is unchanged. We re-read
+    /// only once the file changes (Desktop wrote a new token), and recover.
+    @Test func revokedDesktopTokenDoesNotRePromptUntilCacheChanges() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let keyReads = CallCounter()
+        let expiry = Int64(now.addingTimeInterval(9999).timeIntervalSince1970 * 1000)
+        // A mutable encrypted-cache source: starts with a token the server 401s.
+        let blobs = Box<[String]?>([encryptV10(cacheData([
+            (client: "a", scopes: "user:inference user:profile", token: "bad-tok", expiresMs: expiry),
+        ]))])
+        let dt = DesktopOAuth(
+            keyReader: { keyReads.bump(); return .success(Self.testKey) },
+            cacheReader: { blobs.value }
+        )
+        let kc = countingKeychain(token: nil, expiry: nil, counter: CallCounter())  // notFound
+        let store = EphemeralCredentialStore(nil)
+        let client = OAuthClient(
+            keychain: kc,
+            transport: { req in
+                let bearer = (req.value(forHTTPHeaderField: "Authorization") ?? "")
+                    .replacingOccurrences(of: "Bearer ", with: "")
+                let status = bearer == "bad-tok" ? 401 : 200
+                let resp = HTTPURLResponse(url: OAuthClient.endpoint, statusCode: status, httpVersion: "HTTP/1.1", headerFields: [:])!
+                return (Data("{\"five_hour\":{\"utilization\":7}}".utf8), resp)
+            },
+            now: { now },
+            tokenOverride: { nil },
+            desktop: dt,
+            desktopEnabled: { true },
+            heldStore: store,
+            rejected: RejectedTokens()
+        )
+        // Poll 1: reads Desktop → token 401s → rejected + held cleared.
+        _ = await client.fetchUsage()
+        #expect(keyReads.count == 1)
+        // Polls 2–3: cache unchanged → no re-read, no re-prompt, even though
+        // nothing usable can be served.
+        _ = await client.fetchUsage()
+        _ = await client.fetchUsage()
+        #expect(keyReads.count == 1)
+        // Desktop refreshes its token (the cache file changes) → we read again
+        // and recover on the next poll.
+        blobs.value = [encryptV10(cacheData([
+            (client: "a", scopes: "user:inference user:profile", token: "good-tok", expiresMs: expiry),
+        ]))]
+        guard case .success(let snap) = await client.fetchUsage() else { Issue.record("expected success"); return }
+        #expect(keyReads.count == 2)
+        #expect(snap.fiveHour?.usedPercentage == 7)
+        #expect(store.load()?.accessToken == "good-tok")
+    }
+
+    /// The reported bug, modelled directly: Claude Code's token is expired and
+    /// never refreshed (issue #6), so resolution drops to the slow path every
+    /// poll, and the Desktop read keeps failing (declined / 5s timeout) so no
+    /// valid token is ever cached. The Desktop keychain must still be read only
+    /// ONCE while its file is unchanged — not re-prompted on every poll.
+    @Test func expiredKeychainTokenDoesNotRePromptDesktopEveryPoll() async {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let keyReads = CallCounter()
+        let kc = countingKeychain(token: "cc-expired", expiry: now.addingTimeInterval(-3600), counter: CallCounter())
+        let dt = DesktopOAuth(
+            keyReader: { keyReads.bump(); return .failure(.keychainAccessDenied) },  // declined / timed out
+            cacheReader: { ["unchanging-blob"] }
+        )
+        let (client, _) = resolvingClient(keychain: kc, desktop: dt, desktopEnabled: true, now: now) { _ in (200, 5) }
+        for _ in 0..<4 { _ = await client.fetchUsage() }
+        #expect(keyReads.count == 1)  // read once; not once per poll
+    }
+
+    /// A minimal thread-safe mutable holder for tests.
+    final class Box<T>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var v: T
+        init(_ v: T) { self.v = v }
+        var value: T {
+            get { lock.lock(); defer { lock.unlock() }; return v }
+            set { lock.lock(); v = newValue; lock.unlock() }
+        }
+    }
+
     // MARK: - Live integration (gated)
     //
     // Set PACER_RUN_LIVE_DESKTOP_TEST=1 to decrypt the REAL Claude Desktop


### PR DESCRIPTION
## The report

A user with the **Claude Desktop opt-in** enabled was prompted for the macOS keychain password *every few minutes*, and **Always Allow** never made it stop.

## Confirmed root cause (from his logs)

Not the expiry-parsing or caching theories from earlier revisions of this PR — his logs are the smoking gun:

```
[OAuthPoller] access token expired — Claude Code must refresh it
[OAuthPoller] access token expired — Claude Code must refresh it
...
```

His **Claude Code access token keeps expiring without being refreshed into the keychain** (Claude Code 2.x's known behavior — our issue #6). So credential resolution can't serve a cached token and drops to the **slow path on essentially every poll**. And the released slow path reads Claude Desktop's `Claude Safe Storage` keychain item **unconditionally** whenever it runs:

```swift
if desktopEnabled(), case .success(let creds) = desktop.readAll() { ... }   // ← the prompt
```

That item, unlike Claude Code's, isn't in the `apple-tool:` partition the `security` CLI reads silently, and macOS won't persist "Always Allow" for a foreign app's item. So **a perpetually-stale Claude Code token forces the slow path every ~5 min, and the slow path pokes Desktop's keychain every single time.** Whatever keeps a valid Desktop token from sticking (a declined prompt, or the 5-second read timeout firing before he can click) holds him in that loop. A normal install never hits it because its Claude Code token isn't expiring like his.

## The fix

Gate the Desktop read on a cheap, **prompt-free fingerprint of its token file**. We read its keychain only when (1) we have no usable token already, and (2) the file actually changed since our last read — re-reading an unchanged file just re-derives the same credential (or re-fails the same way) and re-prompts for nothing. So the prompt drops from **every poll** to **once per Desktop token rotation**; approve it once and the long-lived Desktop token caches and serves via the fast path.

> An earlier revision of this PR mis-diagnosed the cause as a missing `expiresAt` and added a held-token fast-path branch plus a 30-min cooldown. **Both are removed** — the file-fingerprint gate is the actual fix.

## Honest scope

This stops the **storm**. The deeper issue — his Claude Code token not refreshing into the keychain — is Claude Code's (issue #6); the Desktop feature exists to paper over exactly that, and post-fix it can, *if* his Desktop read succeeds. If he keeps missing the now-occasional prompt (5s window), that's a separate follow-up (lengthen the read timeout for the interactive case). Confirming his Desktop tokens are actually valid/200 would tell us whether he gets data or just storm-relief after this.

## Tests (all green, 455 total)

- `expiredKeychainTokenDoesNotRePromptDesktopEveryPoll` — his exact case: expired CC token + Desktop enabled → Desktop keychain read **once**, not per poll.
- `revokedDesktopTokenDoesNotRePromptUntilCacheChanges` — a 401ing Desktop token doesn't re-prompt while its file is unchanged; recovers when it changes.
- `usableHeldTokenSkipsDesktopRead` — a usable held token skips the Desktop read entirely.

Built, signed, notarized (Accepted), reinstalled via `make install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)