### PR TITLE
fix(install): bounce widget extension on reinstall so widgets don't freeze

### DIFF
--- a/bin/dev-quit-app.sh
+++ b/bin/dev-quit-app.sh
@@ -2,7 +2,7 @@
 # Quit the running Pacer.app GUI (if any) so the install script can
 # safely replace the bundle. Tries AppleScript quit first (so SwiftUI
 # termination handlers run cleanly), falls back to SIGKILL after a
-# bounded wait.
+# bounded wait. Also terminates the WidgetKit extension (see below).
 #
 # Stdout: "1" if the app was running and has been stopped; "0" if it
 # was not running. The install script captures this to decide whether
@@ -13,6 +13,30 @@ set -euo pipefail
 # $-anchored so only the actual GUI binary matches, not e.g. a
 # `tail -F .../Pacer.log` shell line that happened to mention the path.
 APP_PATH_REGEX='/Pacer\.app/Contents/MacOS/Pacer$'
+
+# The widget extension (PacerWidgets.appex) is a SEPARATE process owned
+# by WidgetKit's chronod, NOT a child of the host GUI — quitting the app
+# above does not touch it. On a bundle swap macOS leaves the old appex
+# running its now-replaced binary; chronod keeps serving that orphaned
+# process's frozen timeline, so placed widgets show stale data until the
+# user reboots or hand-kills it. (Diagnosed 2026-06-23: after a reinstall
+# the pace widgets sat on days-old rate-limit data because the appex
+# process predated the new bundle and the host's reloadTimelines requests
+# never revived it.) Killing it here forces chronod to relaunch it from
+# the fresh bundle on the next render — harmless, since the extension is
+# stateless and reads only the shared store. This is what makes
+# dev-install.sh's "OLD app/widget processes are guaranteed quit"
+# invariant actually hold. Always runs, even when the host GUI is not:
+# the appex can outlive the app.
+WIDGET_PATH_REGEX='/PacerWidgets\.appex/Contents/MacOS/PacerWidgets$'
+if pgrep -f "${WIDGET_PATH_REGEX}" >/dev/null 2>&1; then
+    echo "    Terminating PacerWidgets extension (forces relaunch from new bundle)" >&2
+    pkill -TERM -f "${WIDGET_PATH_REGEX}" 2>/dev/null || true
+    sleep 1
+    # Belt-and-suspenders: a wedged extension that ignored SIGTERM would
+    # otherwise survive into the new bundle. SIGKILL is safe here.
+    pkill -KILL -f "${WIDGET_PATH_REGEX}" 2>/dev/null || true
+fi
 
 if ! pgrep -f "${APP_PATH_REGEX}" >/dev/null 2>&1; then
     echo 0


### PR DESCRIPTION
## Symptom
The 5h/7d **pace widgets** showed rate-limit data from days ago even though the app was running and writing fresh `RateLimitSample` rows every ~5 min.

## Root cause
`make install` quits only the host GUI (`bin/dev-quit-app.sh` matches `…/MacOS/Pacer$`, which excludes the extension). `PacerWidgets.appex` is a separate WidgetKit/`chronod`-owned process that **survives the bundle swap**. macOS keeps serving the orphaned extension's frozen timeline, and the new host's `reloadTimelines(ofKind:)` requests don't revive the stale process — so placed widgets sit on whatever data they last rendered until a reboot or a manual kill.

Diagnosed live: the running `PacerWidgets` process predated the latest reinstall by 2d21h. Killing it made WidgetKit relaunch from the current bundle and the widget immediately read fresh data.

## Fix
`dev-quit-app.sh` now terminates the extension alongside the host (TERM then KILL), unconditionally — the appex can outlive the GUI. This makes `dev-install.sh`'s existing *"OLD app/widget processes are guaranteed quit (step 3a)"* invariant actually true. The `"0"`/`"1"` app-was-running stdout contract is preserved (extension status → stderr).

## Validation
- Reproduced: stale Jun-20 extension → killed → WidgetKit respawned from current bundle → widget read the latest sample.
- New quit script: `bash -n` clean; exercised standalone — terminates the extension and preserves the stdout contract.

## Follow-up (not in this PR)
Worth verifying whether the **Sparkle auto-update path** for end users has the same orphaned-extension problem — this dev-script fix only covers local `make install`. If Sparkle's bundle replacement doesn't trigger plugin re-registration, shipped updates may also need to bounce the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)