### PR TITLE
fix(widgets): relaunch stale widget extension after an app update

### DIFF
--- a/App/Background/PacerAppDelegate.swift
+++ b/App/Background/PacerAppDelegate.swift
@@ -284,6 +284,11 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate {
         // the prior process scheduled but couldn't fully deliver
         // before SIGKILL during a dev-cycle quit→relaunch.
         NotificationCoordinator.shared.clearCollectionPausedNotification()
+        // If the bundle was just replaced under us (Sparkle auto-update
+        // or `make install`), the old widget extension is still running
+        // its now-stale binary and chronod won't relaunch it on its own.
+        // Bounce it here so widgets pick up the new build's code + data.
+        WidgetExtensionRelauncher.bounceIfBundleReplaced()
         backgroundService.start()
         installWindowObservers()
         installMenuBar()

--- a/App/Background/WidgetExtensionRelauncher.swift
+++ b/App/Background/WidgetExtensionRelauncher.swift
@@ -1,0 +1,127 @@
+import AppKit
+import Darwin
+import WidgetKit
+import PacerCore
+
+/// One-shot, launch-time guard against a **stale widget extension** left
+/// behind when the app bundle is replaced under a running install —
+/// Sparkle auto-update or `make install`.
+///
+/// **Why this is needed.** `PacerWidgets.appex` is a separate process
+/// owned by WidgetKit's `chronod`, not a child of the host. When the
+/// bundle is swapped, the host quits and relaunches but the extension
+/// keeps running its now-deleted old binary. `chronod` neither
+/// relaunches the orphan nor services reload requests against the
+/// version-mismatched process — it just keeps serving the orphan's
+/// frozen timeline, so placed widgets show stale data (and stale layout)
+/// until the user reboots.
+///
+/// Verified empirically 2026-06-23: after a Sparkle update bumped the
+/// host to a new build, the extension stayed on its pre-update PID, and
+/// a full OAuth-poll → `reloadTimelines` cycle did **not** revive it.
+/// Only terminating the process made `chronod` relaunch it from the
+/// fresh bundle — at which point its `getTimeline` re-read the shared
+/// store and rendered current data. So `reloadTimelines` alone is not a
+/// fix; the orphan must actually be killed.
+///
+/// **What this does.** On launch, if the host's `CFBundleVersion`
+/// differs from the build recorded on the previous launch, the bundle
+/// was just replaced — terminate any running extension process so
+/// `chronod` relaunches it from the current bundle on the next render.
+/// The extension is stateless (reads only the shared App Group store),
+/// so an unconditional kill is safe.
+///
+/// Keyed on the build number, this fires exactly once per update and is
+/// a no-op on ordinary relaunches and reboots (build unchanged → nothing
+/// to do) and on first-ever launch (no prior build → fresh install, the
+/// extension is already on this bundle).
+///
+/// **Limitation.** The *first* update onto a build that contains this
+/// guard still orphans, because the pre-update host doing the swap
+/// predates the logic. Every update from that build forward is covered.
+@MainActor
+enum WidgetExtensionRelauncher {
+
+    /// App Group-suite key holding the host build seen on the previous
+    /// launch. Lives in the shared suite (not `.standard`) only for
+    /// consistency with the rest of Pacer's preferences; nothing else
+    /// reads it.
+    private static let lastLaunchBuildKey = "pacer.widget.lastLaunchBuild"
+
+    /// Suffix of the extension executable's path. Anchored enough to
+    /// match only our appex — never the host (`…/MacOS/Pacer`) or an
+    /// unrelated process that merely mentions the bundle.
+    private static let extExecutableSuffix =
+        "/PacerWidgets.appex/Contents/MacOS/PacerWidgets"
+
+    /// `<sys/proc_info.h>` defines `PROC_PIDPATHINFO_MAXSIZE` as
+    /// `4 * MAXPATHLEN` (4096) — the documented maximum `proc_pidpath`
+    /// can write. The macro isn't surfaced into Swift's Darwin overlay,
+    /// so inline the value.
+    private static let maxPidPathSize = 4 * Int(MAXPATHLEN)
+
+    /// Call once, early in `applicationDidFinishLaunching`.
+    static func bounceIfBundleReplaced(
+        defaults: UserDefaults = PacerPreferences.store
+    ) {
+        guard let current = Bundle.main
+            .object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        else { return }
+
+        let previous = defaults.string(forKey: lastLaunchBuildKey)
+        defaults.set(current, forKey: lastLaunchBuildKey)
+
+        // nil  → first-ever launch: fresh install, extension already on
+        //        this bundle.
+        // ==   → ordinary relaunch or reboot: nothing was swapped.
+        // !=   → bundle replaced under the running extension: bounce it.
+        guard let previous, previous != current else { return }
+
+        let pids = runningWidgetExtensionPIDs()
+        for pid in pids {
+            kill(pid, SIGTERM)
+        }
+        Log.write(
+            "WidgetExtensionRelauncher",
+            "build \(previous)→\(current): terminated \(pids.count) stale extension process(es)"
+        )
+        // Prompt an immediate re-render from the relaunched extension so
+        // the user isn't left waiting for the next natural timeline
+        // request. Harmless if no widgets are placed.
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    /// PIDs of every running process whose executable is our widget
+    /// extension. Uses `libproc` rather than shelling out so there's no
+    /// subprocess and no pattern-matching ambiguity. `proc_pidpath` may
+    /// return 0 for processes we can't introspect (other users / system
+    /// procs); those are simply skipped.
+    private static func runningWidgetExtensionPIDs() -> [pid_t] {
+        // NOTE: `proc_listallpids` reports the *number of PIDs*, not a
+        // byte count — for both the sizing call (NULL buffer → an
+        // estimate) and the fill call. (Its `buffersize` argument is in
+        // bytes, but the return value is a count; mixing those up
+        // silently truncates the scan and misses processes near the end
+        // of the table.) So: treat the estimate as a count, over-
+        // allocate generously to avoid truncation under churn, and
+        // iterate the whole buffer skipping empty (<= 0) slots — which
+        // also makes the scan independent of the return value's unit.
+        let estimate = proc_listallpids(nil, 0)
+        guard estimate > 0 else { return [] }
+        let capacity = Int(estimate) + 256
+        var pids = [pid_t](repeating: 0, count: capacity)
+        let written = proc_listallpids(&pids, Int32(capacity * MemoryLayout<pid_t>.stride))
+        guard written > 0 else { return [] }
+
+        var matched: [pid_t] = []
+        var pathBuffer = [CChar](repeating: 0, count: maxPidPathSize)
+        for pid in pids where pid > 0 {
+            let length = proc_pidpath(pid, &pathBuffer, UInt32(pathBuffer.count))
+            guard length > 0 else { continue }
+            if String(cString: pathBuffer).hasSuffix(extExecutableSuffix) {
+                matched.append(pid)
+            }
+        }
+        return matched
+    }
+}


### PR DESCRIPTION
## Problem
Widgets show stale data (and stale layout) after the app updates. Root cause: `PacerWidgets.appex` is a separate `chronod`-owned process, not a child of the host. When the bundle is swapped under a running install, the host relaunches but the extension keeps running its **old binary**. `chronod` neither relaunches the orphan nor services `reloadTimelines` against the version-mismatched process — it just serves the orphan's frozen timeline until reboot.

This was **verified against a live Sparkle update** on a real machine:

| | Pre-update | Post-update |
|---|---|---|
| Installed version | 0.3.0 | **0.3.9** ✓ |
| Host process | 89946 | **18193** ✓ relaunched |
| Widget extension | 89947 | **89947** ❌ same orphan |

A full OAuth-poll → `reloadTimelines` cycle did **not** revive it (confirmed by monitoring), so `reloadAllTimelines()` alone is not a fix — the orphan must be killed.

PR #97 fixed the dev `make install` path (bounce the extension in `dev-quit-app.sh`). **This PR covers the shipping Sparkle path**, which #97 does not.

## Fix
On launch (`PacerAppDelegate.applicationDidFinishLaunching`), if `CFBundleVersion` differs from the build recorded on the previous launch, the bundle was just replaced — terminate any running extension process (found via `libproc`) and `reloadAllTimelines()`. `chronod` relaunches it from the current bundle on the next render. The extension is stateless, so the kill is safe. Fires once per update; no-op on ordinary relaunches, reboots, and first install.

## Validation
- **End-to-end in-app**: a host launch that saw a changed build found the orphaned extension and terminated it; WidgetKit respawned it fresh (`74376 → 84561`).
- **PID-finding** logic verified standalone against the live extension (caught and fixed a real bug: `proc_listallpids` returns a PID *count*, not bytes — dividing by `stride` truncated the scan and missed processes near the end of the table).
- **Kill → respawn** confirmed repeatedly.

## Limitation (documented in code)
The *first* update onto a build containing this guard still orphans — the pre-update host predates the logic. Every update from that build forward self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)