### PR TITLE
fix(pace): honest 0% idle state instead of "collecting…"

### DIFF
--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -194,6 +194,19 @@ private struct PaceChartColumn: View {
         return DisplayCycle.resolve(resetsAt: resets, duration: duration)
     }
 
+    /// Used % when we have a fresh reading but the server anchored no
+    /// reset to it — the window is idle (0% used; Anthropic's usage
+    /// endpoint returns `resets_at: null` until your first message of a
+    /// window starts the clock). This is `nil` only when there's no
+    /// sample at all, which is the genuine "still collecting the first
+    /// reading" state. We branch on it so the column shows the real
+    /// number + a calm idle note instead of the "--" / "resets unknown"
+    /// / "collecting…" trio, which reads as broken (see #100).
+    private var idleUsedPct: Double? {
+        guard let latest, latest.resetsAt == nil else { return nil }
+        return latest.usedPercentage
+    }
+
     /// Build the `PaceChartView.Data` snapshot — same shape the widget
     /// will pass in. Synthesizes a "now" tail point so the line tracks
     /// to current time even if the most-recent sample is older.
@@ -431,6 +444,22 @@ private struct PaceChartColumn: View {
         } else if let liveChartData {
             PaceChartView(data: liveChartData, style: .detailed)
                 .frame(height: 96)
+        } else if idleUsedPct != nil {
+            // A reading exists but no window is anchored yet — nothing to
+            // plot. Say so plainly instead of "collecting…", which implies
+            // Pacer is still fetching.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("No usage in this window yet")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text("The window starts when you next use Claude.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .frame(height: 96, alignment: .topLeading)
         } else {
             Text("collecting…")
                 .font(.system(size: 11))
@@ -459,6 +488,10 @@ private struct PaceChartColumn: View {
             Text(pacerResetCaption(resetsAt: resets, durationSeconds: duration))
                 .font(.system(size: 10))
                 .foregroundStyle(.secondary)
+        } else if idleUsedPct != nil {
+            Text("idle · no active window")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
         } else {
             Text("resets unknown")
                 .font(.system(size: 10))
@@ -484,6 +517,13 @@ private struct PaceChartColumn: View {
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
+        } else if let idle = idleUsedPct {
+            // Idle window: show the real reading on its own. There's no
+            // pace target to divide against (no cycle), so no "/ NN%".
+            Text("\(Int(idle.rounded()))%")
+                .font(.system(size: 26, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
         } else {
             Text("--")
                 .font(.system(size: 26, weight: .semibold, design: .rounded))

--- a/Widgets/PaceChartWidget.swift
+++ b/Widgets/PaceChartWidget.swift
@@ -23,6 +23,15 @@ struct PaceChartEntry: TimelineEntry {
     let date: Date
     let fiveHour: WindowState?
     let sevenDay: WindowState?
+    /// Used % for a window whose latest reading carries no reset time —
+    /// the window is idle (0% used; the server returns `resets_at: null`
+    /// until your first message of a window anchors the clock). Set only
+    /// when the matching `WindowState` is nil for that reason; stays nil
+    /// when there's genuinely no sample yet, so the view can tell an idle
+    /// window ("No usage yet") apart from a cold start ("collecting…").
+    /// See #100.
+    var fiveHourIdle: Double? = nil
+    var sevenDayIdle: Double? = nil
     /// User's chosen window from the widget's intent config. Drives the
     /// view's branching (full-canvas single window vs side-by-side both).
     let window: PaceWindowOption
@@ -102,10 +111,23 @@ struct PaceChartProvider: AppIntentTimelineProvider {
                                    outlook: snapshot?.fiveHour)
             let seven = Self.window(rows: rows, key: "seven_day", duration: K.sevenDaySeconds,
                                     outlook: snapshot?.sevenDay)
-            return PaceChartEntry(date: Date(), fiveHour: five, sevenDay: seven, window: window)
+            return PaceChartEntry(
+                date: Date(), fiveHour: five, sevenDay: seven,
+                fiveHourIdle: five == nil ? Self.idleUsedPct(rows: rows, key: "five_hour") : nil,
+                sevenDayIdle: seven == nil ? Self.idleUsedPct(rows: rows, key: "seven_day") : nil,
+                window: window)
         } catch {
             return PaceChartEntry(date: Date(), fiveHour: nil, sevenDay: nil, window: window)
         }
+    }
+
+    /// Used % for a window whose most-recent sample has no reset time —
+    /// an idle window the server hasn't anchored yet. `nil` when there's
+    /// no sample for the window at all (a genuine cold start), so the
+    /// view can show "No usage yet" rather than "collecting…". See #100.
+    private static func idleUsedPct(rows: [RateLimitSample], key: String) -> Double? {
+        guard let latest = rows.first(where: { $0.window == key }) else { return nil }
+        return latest.resetsAt == nil ? latest.usedPercentage : nil
     }
 
     /// Read + decode the engine's outlook export. `nil` when absent or stale
@@ -222,15 +244,33 @@ struct PaceChartWidgetView: View {
     /// where the title bar IS the only header.
     private var dualTitle: String { "RATE-LIMIT PACE" }
 
+    /// No window has anything to show — neither a chart nor an idle
+    /// reading. Drives the single cold-start empty state in medium/large.
+    private var hasNoReadings: Bool {
+        entry.fiveHour == nil && entry.sevenDay == nil
+            && entry.fiveHourIdle == nil && entry.sevenDayIdle == nil
+    }
+
+    /// The bare used % shown for an idle window — a reading exists but no
+    /// pace target to divide against (no anchored cycle), so just the
+    /// number, in `paceFraction`'s numeral styling. See #100.
+    @ViewBuilder
+    private func idleNumber(_ used: Double, large: Bool = false) -> some View {
+        Text("\(Int(used.rounded()))%")
+            .font(.system(size: large ? 22 : 16, weight: .semibold, design: .rounded))
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+    }
+
     /// Resolve the small canvas's single window. Small physically can't
     /// fit two charts, so when the user picks `.both` we fall through
     /// to 5-hour — that's the cycle people hit first and watch most.
-    private func smallTarget() -> (state: PaceChartEntry.WindowState?, title: String, duration: TimeInterval) {
+    private func smallTarget() -> (state: PaceChartEntry.WindowState?, idle: Double?, title: String, duration: TimeInterval) {
         switch entry.window {
         case .sevenDay:
-            return (entry.sevenDay, "7-DAY PACE", K.sevenDaySeconds)
+            return (entry.sevenDay, entry.sevenDayIdle, "7-DAY PACE", K.sevenDaySeconds)
         case .fiveHour, .both:
-            return (entry.fiveHour, "5-HOUR PACE", K.fiveHourSeconds)
+            return (entry.fiveHour, entry.fiveHourIdle, "5-HOUR PACE", K.fiveHourSeconds)
         }
     }
 
@@ -245,6 +285,8 @@ struct PaceChartWidgetView: View {
             ) {
                 if let s = target.state, !s.isAwaiting {
                     paceFraction(used: s.chart.usedPct, pace: s.paceEndPct, compact: true)
+                } else if let idle = target.idle {
+                    idleNumber(idle)
                 }
             }
             if let s = target.state, !s.isAwaiting {
@@ -266,6 +308,8 @@ struct PaceChartWidgetView: View {
                     .frame(maxHeight: .infinity)
             } else if awaiting {
                 WidgetEmptyState(message: "Cycle reset. Awaiting fresh sample.")
+            } else if target.idle != nil {
+                WidgetEmptyState(message: "No usage yet. The window starts when you next use Claude.")
             } else {
                 WidgetEmptyState(message: "Waiting for the first rate-limit reading.")
             }
@@ -279,24 +323,24 @@ struct PaceChartWidgetView: View {
     private var medium: some View {
         VStack(alignment: .leading, spacing: 6) {
             WidgetTitleBar(title: dualTitle)
-            if entry.fiveHour == nil && entry.sevenDay == nil {
+            if hasNoReadings {
                 WidgetEmptyState(message: "Waiting for the first rate-limit reading.")
             } else {
                 switch entry.window {
                 case .both:
                     HStack(alignment: .top, spacing: 12) {
-                        column(label: "5-hour", state: entry.fiveHour, style: .compact)
+                        column(label: "5-hour", state: entry.fiveHour, idle: entry.fiveHourIdle, style: .compact)
                         Divider()
-                        column(label: "7-day", state: entry.sevenDay, style: .compact)
+                        column(label: "7-day", state: entry.sevenDay, idle: entry.sevenDayIdle, style: .compact)
                     }
                 case .fiveHour:
                     // One window, full width — chart gets ~290pt instead
                     // of ~148pt, so we promote to `.detailed` (axis ticks
                     // + 0/50/100% labels) for a layout that mirrors the
                     // dashboard pace card.
-                    column(label: "5-hour", state: entry.fiveHour, style: .detailed)
+                    column(label: "5-hour", state: entry.fiveHour, idle: entry.fiveHourIdle, style: .detailed)
                 case .sevenDay:
-                    column(label: "7-day", state: entry.sevenDay, style: .detailed)
+                    column(label: "7-day", state: entry.sevenDay, idle: entry.sevenDayIdle, style: .detailed)
                 }
             }
         }
@@ -309,18 +353,18 @@ struct PaceChartWidgetView: View {
     private var large: some View {
         VStack(alignment: .leading, spacing: 10) {
             WidgetTitleBar(title: dualTitle)
-            if entry.fiveHour == nil && entry.sevenDay == nil {
+            if hasNoReadings {
                 WidgetEmptyState(message: "Waiting for the first rate-limit reading.")
             } else {
                 switch entry.window {
                 case .both:
-                    largeRow(label: "5-hour", state: entry.fiveHour)
+                    largeRow(label: "5-hour", state: entry.fiveHour, idle: entry.fiveHourIdle)
                     Divider()
-                    largeRow(label: "7-day", state: entry.sevenDay)
+                    largeRow(label: "7-day", state: entry.sevenDay, idle: entry.sevenDayIdle)
                 case .fiveHour:
-                    largeRow(label: "5-hour", state: entry.fiveHour)
+                    largeRow(label: "5-hour", state: entry.fiveHour, idle: entry.fiveHourIdle)
                 case .sevenDay:
-                    largeRow(label: "7-day", state: entry.sevenDay)
+                    largeRow(label: "7-day", state: entry.sevenDay, idle: entry.sevenDayIdle)
                 }
             }
         }
@@ -333,6 +377,7 @@ struct PaceChartWidgetView: View {
     private func column(
         label: String,
         state: PaceChartEntry.WindowState?,
+        idle: Double? = nil,
         style: PaceChartView.Style
     ) -> some View {
         let awaiting = state?.isAwaiting == true
@@ -369,6 +414,13 @@ struct PaceChartWidgetView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                 Spacer(minLength: 0)
+            } else if let idle {
+                idleNumber(idle)
+                Text("idle · no usage yet")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+                Spacer(minLength: 0)
             } else {
                 Text("collecting…")
                     .font(.caption2)
@@ -380,7 +432,7 @@ struct PaceChartWidgetView: View {
     }
 
     @ViewBuilder
-    private func largeRow(label: String, state: PaceChartEntry.WindowState?) -> some View {
+    private func largeRow(label: String, state: PaceChartEntry.WindowState?, idle: Double? = nil) -> some View {
         let awaiting = state?.isAwaiting == true
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
@@ -393,6 +445,8 @@ struct PaceChartWidgetView: View {
                 Spacer()
                 if let state, !state.isAwaiting {
                     paceFraction(used: state.chart.usedPct, pace: state.paceEndPct, compact: false)
+                } else if let idle {
+                    idleNumber(idle, large: true)
                 }
             }
             if let state, !state.isAwaiting {
@@ -410,6 +464,12 @@ struct PaceChartWidgetView: View {
                     .lineLimit(1)
             } else if awaiting {
                 Text("Cycle reset · awaiting first sample")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                Spacer(minLength: 0)
+            } else if idle != nil {
+                Text("No usage yet — the window starts when you next use Claude.")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)


### PR DESCRIPTION
## What you saw

The 5-hour pace column stuck on `--` / `resets unknown` / `collecting…` (the screenshot Eric reported). All three fire together whenever the latest sample for a window has **`resetsAt == nil`**.

## Root cause

When a window has **0% utilization**, Anthropic's `/api/oauth/usage` endpoint returns **`resets_at: null`** — there's no usage anchoring the window, so it has no reset time yet. Pacer stores that null faithfully, but `PaceChartColumn` treated "sample with no reset" the same as "no data at all," collapsing to the broken-looking trio.

This is **common and persistent**, not a brief blip. Querying the live store over the last 7 days:

- **five_hour: 347 / 1323 samples (26%) had `resets_at: null`** — every one at 0.0% used.
- Longest continuous run: **~7 hours** (overnight, zero usage, 2026-06-20 00:04–06:55).

At the moment of the report, the 5-hour cycle had just reset (~11:40) and three consecutive polls came back `resets_at: null` at 0% before the server re-published a reset (16:50) at 11:59.

## Fix

We already have the real reading (used %); only the reset *boundary* is unknown. Distinguish **idle** (a sample exists, no reset anchored) from a genuine **cold start** (no sample at all):

| | before | after |
|---|---|---|
| hero | `--` | `0%` (no `/ NN%` — no cycle to pace against) |
| caption | `resets unknown` | `idle · no active window` |
| chart slot | `collecting…` | `No usage in this window yet — starts when you next use Claude` |

Applied to both the dashboard `PaceChartCard` and `PaceChartWidget` (small/medium/large), which shared the identical fallthrough. No change to the healthy path, so the committed README screenshots are unaffected.

## Evidence

Rendered via the screenshot harness against a seeded idle 5-hour window (before/after montage shared with Eric in-session). 7-day column unchanged in both. `make verify` + `make install` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXC8hvAXgUpiGZjECaGNvp