### PR TITLE
6h silent auto-updates; add Token Pacer to README comparison

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 Eric Andrechek</string>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
@@ -33,6 +35,6 @@
 	<key>SUPublicEDKey</key>
 	<string>iCjiSrk4yhkum2eWbamefoJ9vxQh2oDhGIQwo+pEHLY=</string>
 	<key>SUScheduledCheckInterval</key>
-	<integer>86400</integer>
+	<integer>21600</integer>
 </dict>
 </plist>

--- a/App/PacerApp.swift
+++ b/App/PacerApp.swift
@@ -10,7 +10,7 @@ struct PacerApp: App {
     /// just project the container into their own environments.
     @NSApplicationDelegateAdaptor(PacerAppDelegate.self) private var appDelegate
 
-    /// Sparkle 2.x updater. `init()` starts the on-launch check + 24h
+    /// Sparkle 2.x updater. `init()` starts the on-launch check + 6h
     /// recurrence using the SUFeedURL declared in Info.plist. Owned
     /// here so its lifetime matches the app's, and so the "Check for
     /// Updates…" menu item can bind to its KVO-observable

--- a/App/Update/PacerUpdater.swift
+++ b/App/Update/PacerUpdater.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// Sparkle 2.x wrapper. `SPUStandardUpdaterController` owns an
 /// `SPUUpdater` and a `SPUStandardUserDriver` and handles the on-launch
-/// check + 24-hour scheduled checks automatically when `startingUpdater`
+/// check + 6-hour scheduled checks automatically when `startingUpdater`
 /// is true. The wrapper exists so SwiftUI can `@StateObject` it and so
 /// the Check-for-Updates menu item can disable while a check is in
 /// flight (`canCheckForUpdates` is KVO-observable, which the
@@ -27,7 +27,7 @@ final class PacerUpdater: ObservableObject {
     #endif
 
     init() {
-        // `startingUpdater: true` schedules the on-launch check + 24h
+        // `startingUpdater: true` schedules the on-launch check + 6h
         // recurrence using the feed URL and interval declared in
         // Info.plist (SUFeedURL, SUScheduledCheckInterval). No extra
         // wiring needed here.

--- a/README.md
+++ b/README.md
@@ -104,30 +104,35 @@ ships, it offers to install it for you — no re-downloading, no reinstalling.
 
 You've got options for keeping an eye on Claude Code usage — Claude Code's own
 `/usage`, the popular [`ccusage`](https://github.com/ryoppippi/ccusage) CLI, and
-several menu-bar apps, the closest being [Claude God](https://claudegod.app) and
+several menu-bar apps — the closest being [Token Pacer](https://tokenpacer.app),
+a paid, closed-source namesake, plus [Claude God](https://claudegod.app) and
 [ccseva](https://github.com/Iamshankhadeep/ccseva). They're good tools; here's
 the honest lay of the land.
 
-| | **Pacer** | **[Claude God](https://claudegod.app)** | **[ccseva](https://github.com/Iamshankhadeep/ccseva)** | **[ccusage](https://github.com/ryoppippi/ccusage)** | **CC `/usage`** |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Form factor | Menu-bar app | Menu-bar app | Menu-bar app | CLI | In-terminal |
-| Native macOS (not Electron) | ✓ | ✓ | – (Electron) | – | – |
-| Always-on, glanceable | ✓ | ✓ | ✓ | – | – |
-| Live limit % from Anthropic's API | ✓ | ✓ | ✦ | ✦ | ✓ |
-| Pace vs. ideal-burn line | ✓ | – | – | – | – |
-| End-of-day spend projection | ✓ | ✓ | ✓ | – | – |
-| Activity heatmap (6 months) | ✓ | – | – | – | – |
-| Per-project & per-model breakdown | ✓ | ✓ | ✓ | ✓ | – |
-| Home-screen / Notification Center widgets | ✓ | ✓ | – | – | – |
-| Threshold / budget notifications | ✓ | ✓ | ✓ | – | – |
-| CSV export | ✓ | ✓ | – | ✓ | – |
-| ROI: cost vs. git commits | – | ✓ | – | – | – |
-| Claude Code plugin marketplace | – | ✓ | – | – | – |
-| Free & open source | ✓ | ✓ | ✓ | ✓ | – |
+| | **Pacer** | **[Token Pacer](https://tokenpacer.app)** | **[Claude God](https://claudegod.app)** | **[ccseva](https://github.com/Iamshankhadeep/ccseva)** | **[ccusage](https://github.com/ryoppippi/ccusage)** | **CC `/usage`** |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Form factor | Menu-bar app | Menu-bar app | Menu-bar app | Menu-bar app | CLI | In-terminal |
+| Native macOS (not Electron) | ✓ | ✓ | ✓ | – (Electron) | – | – |
+| Always-on, glanceable | ✓ | ✓ | ✓ | ✓ | – | – |
+| Live limit % from Anthropic's API | ✓ | ✦ | ✓ | ✦ | ✦ | ✓ |
+| Pace vs. ideal-burn line | ✓ | – | – | – | – | – |
+| End-of-day spend projection | ✓ | ✓ | ✓ | ✓ | – | – |
+| Activity heatmap (6 months) | ✓ | – | – | – | – | – |
+| Per-project & per-model breakdown | ✓ | ✓ | ✓ | ✓ | ✓ | – |
+| Beyond Claude Code (Codex, opencode, …) | – | ✓ | – | – | – | – |
+| Home-screen / Notification Center widgets | ✓ | – | ✓ | – | – | – |
+| Threshold / budget notifications | ✓ | ✓ | ✓ | ✓ | – | – |
+| CSV export | ✓ | ✓ | ✓ | – | ✓ | – |
+| ROI: cost vs. git commits | – | – | ✓ | – | – | – |
+| Claude Code plugin marketplace | – | – | ✓ | – | – | – |
+| Price | Free | $29 one-time | Free | Free | Free | Included |
+| Free & open source | ✓ | – | ✓ | ✓ | ✓ | – |
 
 <sub>✦ estimates the windows from your local JSONL logs rather than reading
-Anthropic's usage API. Best-effort as of June 2026 — these tools all move fast,
-so corrections are welcome via an issue or PR.</sub>
+Anthropic's usage API. Token Pacer is a paid, closed-source app, so its column is
+read from its public site rather than its source — and some of its features (CSV
+export, custom model pricing) are Pro-tier. Best-effort as of June 2026 — these
+tools all move fast, so corrections are welcome via an issue or PR.</sub>
 
 **The gist:**
 
@@ -144,6 +149,13 @@ so corrections are welcome via an issue or PR.</sub>
   self-update; Claude God goes further on ROI/git correlation and a plugin
   marketplace, and ccseva on its glassy UI. Pick the one that thinks about your
   usage the way you do — they coexist happily.
+- **vs. Token Pacer** — the close namesake, and the nearest thing to a direct
+  rival: also a native, local-first macOS menu-bar tracker, and it reaches
+  *wider* — covering Codex and opencode alongside Claude Code, with "next action"
+  nudges. The trade-offs: it's **$29 and closed-source**, where Pacer is free and
+  open; Pacer reads your *real* limit % from Anthropic and adds the ideal-burn
+  pacing line, the 6-month heatmap, and widgets. Multi-agent and willing to pay?
+  Fair pick. Claude Code-first and value open source? Pacer.
 
 ## Privacy
 
@@ -158,7 +170,9 @@ The **only** network connections Pacer makes are:
 
 - `api.anthropic.com` — to check your rate-limit windows (~12 small requests an
   hour while it's running).
-- `github.com` — to check for app updates (once at launch, then every 24 hours).
+- `github.com` — to check for, download, and install app updates (at launch,
+  then every 6 hours; installs happen in the background when automatic updates
+  are on).
 
 **No analytics, no telemetry, no third parties.** Your data stays on your Mac in
 `~/Library/Group Containers/…/pacer.sqlite`, and it persists across app updates.

--- a/project.yml
+++ b/project.yml
@@ -61,7 +61,7 @@ packages:
   Sparkle:
     # Sparkle 2.x auto-update framework. Released DMGs ship a signed
     # appcast (EdDSA / Ed25519) hosted on GitHub Pages; the app polls
-    # it on launch and every 24h via SPUStandardUpdaterController.
+    # it on launch and every 6h via SPUStandardUpdaterController.
     # See docs/releasing.md for the keypair + secrets setup.
     url: https://github.com/sparkle-project/Sparkle
     from: 2.6.0
@@ -119,11 +119,15 @@ targets:
         # maintainer's Keychain under `ed25519`. See docs/releasing.md
         # if you need to rotate.
         SUPublicEDKey: iCjiSrk4yhkum2eWbamefoJ9vxQh2oDhGIQwo+pEHLY=
-        # Check on launch and every 24h thereafter. The user can override
+        # Check on launch and every 6h thereafter. The user can override
         # both in the in-app updater prefs (rendered by Sparkle's standard
         # UI) and via `defaults write com.ericandrechek.pacer SUEnableAutomaticChecks 0`.
         SUEnableAutomaticChecks: true
-        SUScheduledCheckInterval: 86400
+        SUScheduledCheckInterval: 21600
+        # Download + install updates silently in the background by default
+        # (Sparkle applies them on the agent's next relaunch). Users who turn
+        # off automatic updates in the updater prefs keep the prompt-first flow.
+        SUAutomaticallyUpdate: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.ericandrechek.pacer


### PR DESCRIPTION
Two self-contained changes (separable if you'd rather split them):

### Update mechanism
- **`SUScheduledCheckInterval` 86400 → 21600** — check at launch, then every **6h**. With several releases a day, fixes reach users far sooner.
- **Add `SUAutomaticallyUpdate: true`** — signed updates **download + install silently in the background** by default; Sparkle applies them on the agent's next relaunch. Users who turn off automatic updates in the updater prefs keep the prompt-first flow.
- Synced the code comments + README that documented the old 24h interval.

Verified end-to-end: `make install` built, signed, **notarized (Accepted)**, and installed; xcodegen regenerated `Info.plist` to match.

### README comparison
- Added **Token Pacer** (https://tokenpacer.app) as its own column — the closest namesake: a **paid, closed-source** native menu-bar tracker that also covers **Codex/opencode**.
- Added **Price** and **Beyond Claude Code** rows so the table is fair both ways (Token Pacer wins the multi-agent row).
- Its column is read from the **public site** (closed source), flagged in the footnote. ⚠️ The **"live limit % from the API"** cell is a best-effort guess (✦) — correct me if you know whether it reads the API or estimates from logs.

### Not in this PR
The analytics piece (Cloudflare Worker fronting the appcast, `SUFeedURL` repoint, optional system profiling / install ID) is deliberately deferred — separate follow-up once we settle the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)