### PR TITLE
chore(install): self-heal the local notarization keychain profile

### DIFF
--- a/bin/dev-install.sh
+++ b/bin/dev-install.sh
@@ -267,6 +267,33 @@ echo
 echo "==> Notarizing with Apple (profile: ${NOTARY_PROFILE})"
 
 if ! xcrun notarytool history --keychain-profile "${NOTARY_PROFILE}" >/dev/null 2>&1; then
+    # Self-heal. The notarization profile is a login-Keychain item, NOT a
+    # file in keys/ — so it goes missing on a fresh machine or after a
+    # Keychain reset even when keys/ already holds every credential (the
+    # exact "I thought I had everything in keys/" trap). If the raw creds
+    # are present locally, recreate the profile non-interactively instead
+    # of erroring out. keys/ is gitignored; nothing here is committed.
+    KEYS_DIR="${REPO_ROOT}/keys"
+    KEYS_P8="$(ls "${KEYS_DIR}"/AuthKey_*.p8 2>/dev/null | head -1)"
+    if [ -f "${KEYS_DIR}/.env" ] && [ -n "${KEYS_P8}" ]; then
+        echo "    profile '${NOTARY_PROFILE}' not in Keychain — recreating from keys/ …"
+        # Subshell so the sourced secrets (incl. CERTIFICATE_PASSWORD) stay
+        # out of this script's environment. KEY_ID/ISSUER_ID come from
+        # keys/.env, the same file refresh-secrets.sh reads.
+        (
+            # shellcheck disable=SC1091
+            . "${KEYS_DIR}/.env"
+            xcrun notarytool store-credentials "${NOTARY_PROFILE}" \
+                --key "${KEYS_P8}" \
+                --key-id "${KEY_ID:?KEY_ID missing in keys/.env}" \
+                --issuer "${ISSUER_ID:?ISSUER_ID missing in keys/.env}"
+        ) || echo "    auto-setup failed — see manual steps below"
+    fi
+fi
+
+# Re-check: covers both the just-healed case and a genuinely-absent
+# profile (keys/ not present, or auto-setup failed above).
+if ! xcrun notarytool history --keychain-profile "${NOTARY_PROFILE}" >/dev/null 2>&1; then
     echo "ERROR: notarytool credential profile '${NOTARY_PROFILE}' not found."
     echo "Set it up once with:"
     echo "  xcrun notarytool store-credentials ${NOTARY_PROFILE} \\"
@@ -274,6 +301,8 @@ if ! xcrun notarytool history --keychain-profile "${NOTARY_PROFILE}" >/dev/null 
     echo "      --key-id <KEY_ID> --issuer <ISSUER_UUID>"
     echo "Get the .p8 + Key ID + Issuer ID from App Store Connect →"
     echo "Users and Access → Integrations → Team Keys."
+    echo "(With keys/.env + keys/AuthKey_*.p8 present, this install"
+    echo " recreates the profile automatically — check those files.)"
     echo
     echo "For rapid local-only iteration without notarization:"
     echo "  PACER_DEV_SKIP_NOTARIZE=1 make install"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -62,6 +62,16 @@ You already have a Developer ID Application certificate (Team ID
 
 ### 2. App Store Connect API key (for notarization)
 
+> **Local `make install` note.** Notarizing locally needs a `notarytool`
+> keychain profile named `pacer-notarization` in your login Keychain —
+> a *different* thing from the CI secrets below, and not a file in
+> `keys/`. It goes missing on a fresh machine or after a Keychain reset
+> even when `keys/` is complete. `bin/dev-install.sh` self-heals it: when
+> the profile is absent but `keys/.env` + `keys/AuthKey_*.p8` are present,
+> it recreates it via `xcrun notarytool store-credentials` on the next
+> install. (Or skip notarization for fast iteration:
+> `PACER_DEV_SKIP_NOTARIZE=1 make install`.)
+
 The local `pacer-notarization` keychain profile won't work in CI.
 Use an API key instead:
 


### PR DESCRIPTION
## What

`make install` notarizes via a `notarytool` keychain profile named `pacer-notarization`. That profile lives in the **login Keychain**, not in `keys/` — so it goes missing on a fresh machine or after a Keychain reset even when `keys/` holds every credential, hard-failing with `credential profile 'pacer-notarization' not found` despite `keys/` looking complete.

`bin/dev-install.sh` now **self-heals**: when the profile is absent but `keys/.env` + `keys/AuthKey_*.p8` are present, it recreates it via `xcrun notarytool store-credentials` and re-checks, instead of erroring out. Falls through to the existing manual instructions only when the local creds genuinely aren't there.

## Notes
- The `store-credentials` call runs in a **subshell** so sourced secrets (incl. `CERTIFICATE_PASSWORD`) never enter the script's environment. `keys/` stays gitignored.
- Documents the local-profile-vs-CI-secrets distinction in `docs/releasing.md`.
- Dev-tooling only — does not touch the app binary.

## Verification
- `bash -n` clean.
- Self-heal wiring dry-run resolves the right creds from repo root (key `AuthKey_75ALXVV25X.p8`, key-id `75ALXVV25X`, issuer `…fe32`).
- The underlying `store-credentials` command was confirmed working end-to-end: a full notarized `make install` now passes (Apple `status: Accepted`, ticket stapled, `spctl` → `accepted / Notarized Developer ID`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)