### PR TITLE
perf(ui): columnar fetch for PaceChartCard's 8-day rate-limit @Query

### DIFF
--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -42,11 +42,22 @@ struct PaceChartCard: View {
     init(onCompare: ((String) -> Void)? = nil) {
         self.onCompare = onCompare
         let cutoff = Date().addingTimeInterval(-8 * 86400)
-        _samples = Query(
-            filter: #Predicate<RateLimitSample> { $0.sampledAt >= cutoff },
-            sort: \.sampledAt,
-            order: .reverse
+        var descriptor = FetchDescriptor<RateLimitSample>(
+            predicate: #Predicate<RateLimitSample> { $0.sampledAt >= cutoff },
+            sortBy: [SortDescriptor(\.sampledAt, order: .reverse)]
         )
+        // Columnar projection. SwiftData @Query invalidation is
+        // entity-agnostic, so this 8-day window (~2.8k rows) re-runs on
+        // EVERY store save — including the token-only saves that fire
+        // while the user types in Claude Code, even though no rate-limit
+        // row changed. The card only ever reads these four scalar
+        // attributes, so fetching just them avoids materializing ~2.8k
+        // full RateLimitSample objects per refresh (the dominant remaining
+        // open-window MainActor cost after the PR #102 toolbar fix; the
+        // rows are warm in the page cache, so the cost is CPU object
+        // instantiation, not disk). See docs/perf-tuning.md.
+        descriptor.propertiesToFetch = [\.window, \.sampledAt, \.resetsAt, \.usedPercentage]
+        _samples = Query(descriptor)
     }
 
     /// Re-ask the engine for both windows' answers. One pass powers the


### PR DESCRIPTION
## What
PaceChartCard holds an 8-day `@Query<RateLimitSample>` (~2,784 rows) to plot ~27 points. SwiftData `@Query` invalidation is entity-agnostic, so it re-runs on **every** store save — including token-only saves while the user types — even though no rate-limit row changed. In a profiler trace it was the **dominant remaining open-window main-thread cost** after PR #102 (`samples.getter` ~130× the next card's @Query getter). The cost is Core Data materializing 2,784 full objects per refresh (warm cache → CPU, not disk).

**Fix:** add `propertiesToFetch` for the four scalar attributes the card actually reads (`window`/`sampledAt`/`resetsAt`/`usedPercentage`), so each refresh materializes a columnar projection instead of full objects.

## Why this approach (not a gated manual fetch)
The author deliberately kept the reactive `@Query` so the chart renders synchronously on first paint — replacing it with an `.onAppear`-driven manual fetch would reintroduce the card-reflow the inline comment documents avoiding. Columnar projection keeps synchronous first-paint **and** cuts the per-save materialization, respecting the card's design constraint.

Independently validated by (a) the DuckDB feasibility spike (which concluded the cost is SwiftData object-faulting, not SQL, and `propertiesToFetch` is the fix) and (b) the in-tree `ProjectDetailView` precedent, which uses `propertiesToFetch` for the same class of heavy-`@Query` fix.

## Risk
Low — no behavior/visual change, no reactivity change. The card reads only the four projected columns, so nothing faults. Compiles clean.

## Measurement note
The cost only manifests under typing-rate saves (the entity-agnostic refetch), which can't be reproduced deterministically in a sample window, so there's no clean before/after number here — the justification is the profiled mechanism + the two converging analyses above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)