### PR TITLE
perf(ui): debounce chart hover-selection to fix scroll stutter

### DIFF
--- a/App/Views/DailyCostChartCard.swift
+++ b/App/Views/DailyCostChartCard.swift
@@ -46,7 +46,17 @@ struct DailyCostChartCard: View {
     @Query(ScanMetaFetchDescriptor.scanCompletedProbe)
     private var scanMeta: [ClaudeCodeMeta]
 
+    /// Debounced selection that the chart RuleMark + trailing slot read.
+    /// Updated from `rawSelection` only once the pointer settles, so a
+    /// scroll that sweeps the cursor across the bars doesn't re-lay-out
+    /// the whole chart on every pointer event — the scroll-stutter cause.
+    /// See docs/perf-tuning.md.
     @State private var selectedDate: String?
+    /// Raw `chartXSelection` binding — updates on every pointer move.
+    /// Nothing reads it for rendering; it feeds the debounce below and the
+    /// tap handler (which needs the immediate, un-debounced value).
+    @State private var rawSelection: String?
+    @State private var selectionDebounce: Task<Void, Never>?
     @State private var cachedDerived = Derived(dailyTotals: [], annotateDates: [], totalCost: 0)
 
     private struct Derived {
@@ -159,7 +169,20 @@ struct DailyCostChartCard: View {
                 }
             }
         }
-        .chartXSelection(value: $selectedDate)
+        .chartXSelection(value: $rawSelection)
+        // Coalesce the rapid hover stream a scroll produces into a single
+        // commit once the pointer settles, so the chart's marks re-lay-out
+        // at most once per hover instead of once per pointer event. 40ms is
+        // imperceptible on a deliberate hover but collapses a fast
+        // scroll-sweep across the bars to zero chart re-layouts.
+        .onChange(of: rawSelection) { _, newValue in
+            selectionDebounce?.cancel()
+            selectionDebounce = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(40))
+                guard !Task.isCancelled else { return }
+                selectedDate = newValue
+            }
+        }
         // Tap-to-drill pattern: chartXSelection already tracks the
         // hovered/clicked bar via the binding, so on tap we just
         // open that day. The whole chart surface becomes the hit
@@ -169,7 +192,9 @@ struct DailyCostChartCard: View {
         // link cursor per macOS HIG.
         .contentShape(Rectangle())
         .onTapGesture {
-            if let date = selectedDate, let onDayTap {
+            // Use the immediate selection, not the debounced one — on tap
+            // the 40ms debounce may not have committed `selectedDate` yet.
+            if let date = rawSelection, let onDayTap {
                 onDayTap(date)
             }
         }

--- a/App/Views/HistoryView.swift
+++ b/App/Views/HistoryView.swift
@@ -237,7 +237,14 @@ private struct MonthlyChartCard: View {
         )
     }
 
+    /// Debounced selection (chart RuleMark / annotations + trailing slot).
+    /// Updated from `rawSelectedMonth` only once the pointer settles, so a
+    /// scroll sweeping the bars doesn't re-lay-out the chart per pointer
+    /// event. See docs/perf-tuning.md.
     @State private var selectedMonth: String?
+    /// Raw `chartXSelection` binding (immediate); feeds the debounce.
+    @State private var rawSelectedMonth: String?
+    @State private var selectedMonthDebounce: Task<Void, Never>?
     @State private var cachedMonthly: [MonthBucket] = []
     @State private var cachedTotal: Double = 0
 
@@ -329,7 +336,15 @@ private struct MonthlyChartCard: View {
             }
         }
         .frame(height: 220)
-        .chartXSelection(value: $selectedMonth)
+        .chartXSelection(value: $rawSelectedMonth)
+        .onChange(of: rawSelectedMonth) { _, newValue in
+            selectedMonthDebounce?.cancel()
+            selectedMonthDebounce = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(40))
+                guard !Task.isCancelled else { return }
+                selectedMonth = newValue
+            }
+        }
         .chartYAxis {
             AxisMarks(position: .leading) { value in
                 AxisGridLine().foregroundStyle(.secondary.opacity(0.18))

--- a/App/Views/ModelsView.swift
+++ b/App/Views/ModelsView.swift
@@ -414,7 +414,14 @@ private struct ModelsContent: View {
         }
     }
 
+    /// Debounced hover (chart RuleMark + per-day breakdown reads). Updated
+    /// from `rawTrendHoverDate` only once the pointer settles, so a scroll
+    /// sweeping the bars doesn't re-lay-out the chart per pointer event.
+    /// See docs/perf-tuning.md.
     @State private var trendHoverDate: String?
+    /// Raw `chartXSelection` binding (immediate); feeds the debounce + tap.
+    @State private var rawTrendHoverDate: String?
+    @State private var trendHoverDebounce: Task<Void, Never>?
 
     /// Per-day, per-model totals for the hovered date. O(1) lookup
     /// into the pre-bucketed `trendBuckets` — the previous version
@@ -476,13 +483,22 @@ private struct ModelsContent: View {
                     }
                 }
                 .chartXAxis(.hidden)
-                .chartXSelection(value: $trendHoverDate)
+                .chartXSelection(value: $rawTrendHoverDate)
+                .onChange(of: rawTrendHoverDate) { _, newValue in
+                    trendHoverDebounce?.cancel()
+                    trendHoverDebounce = Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(40))
+                        guard !Task.isCancelled else { return }
+                        trendHoverDate = newValue
+                    }
+                }
                 // Tap-to-drill — uses the chartXSelection binding,
                 // same minimal pattern as DailyCostChartCard. Arrow
                 // cursor (default) per macOS HIG.
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    if let date = trendHoverDate {
+                    // Immediate selection, not the debounced one.
+                    if let date = rawTrendHoverDate {
                         onSelectDay(date)
                     }
                 }

--- a/App/Views/ProjectDetailView.swift
+++ b/App/Views/ProjectDetailView.swift
@@ -674,7 +674,14 @@ struct ProjectDetailView: View {
         .padding(.horizontal, 4)
     }
 
+    /// Debounced hover (chart RuleMark + reads). Updated from
+    /// `rawHoveredDate` only once the pointer settles, so a scroll sweeping
+    /// the bars doesn't re-lay-out the chart per pointer event. See
+    /// docs/perf-tuning.md.
     @State private var hoveredDate: String?
+    /// Raw `chartXSelection` binding (immediate); feeds the debounce + tap.
+    @State private var rawHoveredDate: String?
+    @State private var hoveredDateDebounce: Task<Void, Never>?
 
     private var dailyChartCard: some View {
         PacerCard("Daily activity", trailing: {
@@ -736,12 +743,22 @@ struct ProjectDetailView: View {
                     }
                 }
             }
-            .chartXSelection(value: $hoveredDate)
+            .chartXSelection(value: $rawHoveredDate)
+            .onChange(of: rawHoveredDate) { _, newValue in
+                hoveredDateDebounce?.cancel()
+                hoveredDateDebounce = Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(40))
+                    guard !Task.isCancelled else { return }
+                    hoveredDate = newValue
+                }
+            }
             // Arrow cursor (default) per macOS HIG — clickable charts
             // don't warrant the link cursor.
             .contentShape(Rectangle())
             .onTapGesture {
-                if let d = hoveredDate {
+                // Immediate selection, not the debounced one — the 40ms
+                // debounce may not have committed `hoveredDate` yet on tap.
+                if let d = rawHoveredDate {
                     push(.day(date: d))
                 }
             }

--- a/App/Views/TodayTimelineCard.swift
+++ b/App/Views/TodayTimelineCard.swift
@@ -82,7 +82,16 @@ struct TodayTimelineCard: View {
         )
     }
 
+    /// Debounced hover that the chart RuleMark + trailing slot read.
+    /// Updated from `rawHoveredHour` only once the pointer settles, so a
+    /// scroll that sweeps the cursor across the bars doesn't re-lay-out the
+    /// whole chart on every pointer event — the scroll-stutter cause. See
+    /// docs/perf-tuning.md.
     @State private var hoveredHour: Int?
+    /// Raw `chartXSelection` binding — updates on every pointer move; only
+    /// feeds the debounce below.
+    @State private var rawHoveredHour: Int?
+    @State private var hoverDebounce: Task<Void, Never>?
 
     var body: some View {
         PacerCard("Today by hour", trailing: {
@@ -153,7 +162,20 @@ struct TodayTimelineCard: View {
             }
         }
         .frame(height: 130)
-        .chartXSelection(value: $hoveredHour)
+        .chartXSelection(value: $rawHoveredHour)
+        // Coalesce the rapid hover stream a scroll produces into a single
+        // commit once the pointer settles, so the chart's marks re-lay-out
+        // at most once per hover instead of once per pointer event. 40ms is
+        // imperceptible on a deliberate hover but collapses a fast
+        // scroll-sweep across the bars to zero chart re-layouts.
+        .onChange(of: rawHoveredHour) { _, newValue in
+            hoverDebounce?.cancel()
+            hoverDebounce = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(40))
+                guard !Task.isCancelled else { return }
+                hoveredHour = newValue
+            }
+        }
         .chartYAxis(.hidden)
         .chartXAxis {
             // Locale-aware ticks. 24h: 0/6/12/18/23. 12h: 12a/6a/12p/6p/11p.


### PR DESCRIPTION
## What
Scrolling stuttered when the pointer passed over charts. **Cause:** every chart with `.chartXSelection` writes its selection `@State` on *every pointer-move*, and that selection feeds a RuleMark / annotation / trailing slot read inside the `Chart{}` body — so each pointer event re-evaluates the chart body and re-lays-out all marks. During a scroll the cursor sweeps across the charts, firing a flood of full re-layouts that fight the scroll for the main thread.

**Fix:** split the binding. `chartXSelection` writes a `raw*` `@State` that nothing renders from; a **40ms debounce** projects it into the displayed selection the marks read. A fast scroll-sweep never lets the raw value settle → zero chart re-layouts mid-scroll; a deliberate hover commits after an imperceptible 40ms. Tap-to-drill handlers read the raw (immediate) value so a click still resolves the bar under the cursor.

## Scope
Applied to every `chartXSelection` chart:
- Dashboard bar charts: `DailyCostChartCard`, `TodayTimelineCard`
- `HistoryView`, `ModelsView`, `ProjectDetailView`

The pace charts (`PaceChartView`) were already clean (no selection, downsampled in `dc66879`) — untouched.

## Confidence / verification
Root cause identified by a focused profiling investigation (static + idle `sample(1)` of the live app). Final confirmation is a scroll-test on the installed build — the owner will verify smoothness directly.

## Risk
Low — the hover feature is unchanged functionally (40ms-delayed commit), taps unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)