### PR TITLE
perf(engine): stop re-reading .git/config for origin-less repos forever

### DIFF
--- a/PacerCore/Sources/PacerCore/Models/ProjectPathProbe.swift
+++ b/PacerCore/Sources/PacerCore/Models/ProjectPathProbe.swift
@@ -58,17 +58,32 @@ public final class ProjectPathProbe {
     /// the column additively (existing rows get `false`).
     public var autoMergeRejected: Bool = false
 
+    /// We attempted the `.git/config` origin read for this probe at least
+    /// once. Set after the backfill pass tries a row — regardless of
+    /// result — so origin-less repos (local-only, no `remote.origin.url`)
+    /// stop getting their `.git/config` re-read on every cycle forever.
+    /// Without this, a probe with `gitRoot != nil && originURL == nil`
+    /// re-qualifies for backfill on every run and never converges. If a
+    /// remote is later added, "Reset auto-merge" (which clears the probe
+    /// table) re-probes it.
+    ///
+    /// Declared with a default so SwiftData's lightweight migration adds
+    /// the column additively (existing rows get `false`).
+    public var originBackfillAttempted: Bool = false
+
     public init(
         path: String,
         gitRoot: String?,
         originURL: String? = nil,
         probedAt: Date = Date(),
-        autoMergeRejected: Bool = false
+        autoMergeRejected: Bool = false,
+        originBackfillAttempted: Bool = false
     ) {
         self.path = path
         self.gitRoot = gitRoot
         self.originURL = originURL
         self.probedAt = probedAt
         self.autoMergeRejected = autoMergeRejected
+        self.originBackfillAttempted = originBackfillAttempted
     }
 }

--- a/PacerCore/Sources/PacerCore/Persistence/ProjectGitRootAutoAliaser.swift
+++ b/PacerCore/Sources/PacerCore/Persistence/ProjectGitRootAutoAliaser.swift
@@ -80,7 +80,7 @@ public final class ProjectGitRootAutoAliaser {
         // URL recorded. Plug them in here — single .git/config
         // read per row, capped to the rows that actually need it.
         let probesNeedingOriginBackfill = existingProbes.values.filter {
-            $0.gitRoot != nil && $0.originURL == nil
+            $0.gitRoot != nil && $0.originURL == nil && !$0.originBackfillAttempted
         }
         let home = FileManager.default.homeDirectoryForCurrentUser.path
 
@@ -131,6 +131,11 @@ public final class ProjectGitRootAutoAliaser {
             for r in backfillResults {
                 if let row = existingProbes[r.probePath] {
                     row.originURL = r.originURL
+                    // Mark attempted regardless of result so an origin-less
+                    // repo (local-only, no remote.origin.url) isn't re-read
+                    // on every future cycle forever — see
+                    // ProjectPathProbe.originBackfillAttempted.
+                    row.originBackfillAttempted = true
                 }
             }
         }
@@ -145,7 +150,11 @@ public final class ProjectGitRootAutoAliaser {
                 path: probe.path,
                 gitRoot: probe.gitRoot,
                 originURL: probe.originURL,
-                probedAt: now
+                probedAt: now,
+                // The walk already attempted the origin read when a git
+                // root was found, so record that — an origin-less new probe
+                // shouldn't re-qualify for backfill next cycle.
+                originBackfillAttempted: probe.gitRoot != nil
             ))
             guard let gitRoot = probe.gitRoot, gitRoot != probe.path else { continue }
             do {


### PR DESCRIPTION
## What
The auto-aliaser's origin backfill re-qualifies any probe with `gitRoot != nil && originURL == nil` on **every run**. For local-only repos with no `remote.origin.url`, `readGitOrigin` correctly returns nil every time, so those rows **never converge** — they get their `.git/config` re-read on every cycle forever (18 such rows on my machine). Pure wasted filesystem I/O.

**Fix:** add an additive `originBackfillAttempted` flag to `ProjectPathProbe` (default `false` → SwiftData lightweight migration, same pattern as `autoMergeRejected`, **no store reset**). The backfill filter skips already-attempted rows; the flag is set after an attempt regardless of result, and new probes are marked attempted when the walk found a git root. "Reset auto-merge" (clears the probe table) re-probes if a remote is later added.

## Scope
This is the **safe half** of the aliasing work. The larger fix — moving the git filesystem-walk off the `@ScanActor` scan pipeline so a slow/cold walk can't stall usage recording — is **deferred to a focused, well-tested follow-up** (it's a core-pipeline concurrency refactor).

## Verification
All 7 `ProjectGitRootAutoAliaser` tests pass; app builds clean. Migration is additive (patch-level, no SwiftData reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)