### PR TITLE
perf(ui): fix dashboard scroll stutter (eager card stack + engine off-main)

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -411,7 +411,14 @@ final class AppBackgroundService {
         if !force, let last = lastEngineRecomputeAt,
            now.timeIntervalSince(last) < Self.engineRecomputeMinInterval { return }
         lastEngineRecomputeAt = now
-        await engine.recompute(now: now)
+        // Recompute OFF the main actor. `recomputeEngineIfDue` runs on
+        // `@MainActor`, so `await engine.recompute(...)` would resume the
+        // heavy forecast fit INLINE on the main thread (uncontended-actor
+        // optimization — confirmed on Main via sample(1) during a scroll).
+        // A detached task forces it onto the engine's executor.
+        await Task.detached(priority: .utility) { [engine] in
+            await engine.recompute(now: now)
+        }.value
         await exportEngineSnapshot()
         NotificationCenter.default.post(name: .pacerEngineDidRecompute, object: nil)
     }
@@ -420,7 +427,13 @@ final class AppBackgroundService {
     /// widget process can draw the same trajectory + outlook the dashboard
     /// shows.
     private func exportEngineSnapshot() async {
-        guard let json = await engine.snapshot().encodedJSON() else { return }
+        // `engine.snapshot()` fits the forecast models; run it off the main
+        // actor (same inline-on-main hazard as recomputeEngineIfDue) so it
+        // can't block the UI. The small SwiftData write stays on main.
+        let snapshotJSON = await Task.detached(priority: .utility) { [engine] in
+            await engine.snapshot().encodedJSON()
+        }.value
+        guard let json = snapshotJSON else { return }
         let context = ModelContext(container)
         let key = EngineSnapshot.metaKey
         let descriptor = FetchDescriptor<ClaudeCodeMeta>(

--- a/App/Views/DashboardView.swift
+++ b/App/Views/DashboardView.swift
@@ -21,6 +21,13 @@ struct DashboardView: View {
         PageScaffold(
             "Dashboard",
             subtitle: "Realtime view of your Claude Code usage.",
+            // Eager stack: the dashboard is a small, fixed set of cards the
+            // user scrolls through anyway, so realizing them all up front
+            // (rather than lazily as each crosses the viewport) removes the
+            // per-card render-on-appear that made scrolling past the chart
+            // cards stutter. The @Query fanout this re-incurs is mitigated
+            // by the cards' gated caches + the EquatableView work (#102/#105).
+            lazy: false,
             // Notice badges + the data-source freshness chip live in the
             // header's trailing slot — zero vertical pixels, and both
             // describe the page as a whole rather than any one card.

--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -34,7 +34,7 @@ struct PaceChartCard: View {
     @State private var outlooks: [String: UsageIntelligenceEngine.BurnOutlook] = [:]
     @State private var endEstimates: [String: Estimate] = [:]
 
-    struct WindowProjection: Equatable {
+    struct WindowProjection: Equatable, Sendable {
         var points: [PaceChartView.Data.Point]
         var crossesFullAt: Date?
     }
@@ -65,23 +65,34 @@ struct PaceChartCard: View {
     /// band, crossing, frequency facts).
     private func refreshProjections() async {
         guard let engine else { return }
-        var nextSelected: [String: WindowProjection] = [:]
-        var nextOutlooks: [String: UsageIntelligenceEngine.BurnOutlook] = [:]
-        var nextEnds: [String: Estimate] = [:]
-        for window in RateLimitWindowKind.allCases {
-            if let o = await engine.burnOutlook(window: window) { nextOutlooks[window.rawValue] = o }
-            nextEnds[window.rawValue] = await engine.ask(.rateLimitOutlook(window))
-            let list = await engine.rateLimitTrajectories(window: window)
-            guard !list.isEmpty else { continue }
-            if let chosen = list.first(where: { $0.isSelected }) ?? list.first {
-                nextSelected[window.rawValue] = WindowProjection(
-                    points: chosen.trajectory.points.map { .init(time: $0.at, value: $0.usedPercentage) },
-                    crossesFullAt: chosen.trajectory.crossesFullAt)
+        // Compute OFF the main actor. Awaiting the `@ModelActor` engine from
+        // `@MainActor` here resumes its heavy forecast-model fit INLINE on
+        // the main thread — the Swift "uncontended actor runs on the
+        // caller's executor" optimization. A `sample(1)` taken while
+        // scrolling caught `DiurnalBurnModel.fit` running on Main (~3k
+        // samples), the dominant scroll-stutter source. A detached task
+        // forces the fit onto the engine's own executor so it can never
+        // block the UI; only the cheap `@State` assignment lands on main.
+        let computed = await Task.detached(priority: .userInitiated) { [engine] in
+            var nextSelected: [String: WindowProjection] = [:]
+            var nextOutlooks: [String: UsageIntelligenceEngine.BurnOutlook] = [:]
+            var nextEnds: [String: Estimate] = [:]
+            for window in RateLimitWindowKind.allCases {
+                if let o = await engine.burnOutlook(window: window) { nextOutlooks[window.rawValue] = o }
+                nextEnds[window.rawValue] = await engine.ask(.rateLimitOutlook(window))
+                let list = await engine.rateLimitTrajectories(window: window)
+                guard !list.isEmpty else { continue }
+                if let chosen = list.first(where: { $0.isSelected }) ?? list.first {
+                    nextSelected[window.rawValue] = WindowProjection(
+                        points: chosen.trajectory.points.map { .init(time: $0.at, value: $0.usedPercentage) },
+                        crossesFullAt: chosen.trajectory.crossesFullAt)
+                }
             }
-        }
-        projections = nextSelected
-        outlooks = nextOutlooks
-        endEstimates = nextEnds
+            return (nextSelected, nextOutlooks, nextEnds)
+        }.value
+        projections = computed.0
+        outlooks = computed.1
+        endEstimates = computed.2
     }
 
     private struct Bucketed {

--- a/PacerCore/Sources/PacerUI/Design.swift
+++ b/PacerCore/Sources/PacerUI/Design.swift
@@ -356,17 +356,29 @@ public struct FreshnessPulse: View {
 public struct PageScaffold<Trailing: View, Content: View>: View {
     public let title: String
     public let subtitle: String?
+    /// Lazy (`LazyVStack`) defers each card's body + `@Query` until it
+    /// scrolls into view — lighter during active use, but the per-card
+    /// realize-on-appear cost lands *during* the scroll (visible jank when
+    /// scrolling past heavy chart cards). Eager (`VStack`) renders every
+    /// card once up front, so scrolling only translates already-rendered
+    /// content — buttery, at the cost of every card's `@Query` being live.
+    /// Pages with a small, fixed card set (the dashboard) prefer eager now
+    /// that the `@Query` fanout is mitigated; long/unbounded lists keep
+    /// lazy. See docs/perf-tuning.md.
+    public let lazy: Bool
     public let trailing: () -> Trailing
     public let content: () -> Content
 
     public init(
         _ title: String,
         subtitle: String? = nil,
+        lazy: Bool = true,
         @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() },
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.title = title
         self.subtitle = subtitle
+        self.lazy = lazy
         self.trailing = trailing
         self.content = content
     }
@@ -390,9 +402,22 @@ public struct PageScaffold<Trailing: View, Content: View>: View {
             // is minor and only happens on demand. The header stays
             // outside the lazy stack so the page title doesn't
             // disappear on scroll.
-            LazyVStack(alignment: .leading, spacing: PacerDesign.sectionSpacing) {
-                header
-                content()
+            Group {
+                if lazy {
+                    LazyVStack(alignment: .leading, spacing: PacerDesign.sectionSpacing) {
+                        header
+                        content()
+                    }
+                } else {
+                    // Eager: every card realized once on appear, so scrolling
+                    // never re-runs a card's body/render mid-flight (the
+                    // scroll-jank cause when heavy chart cards crossed the
+                    // viewport in the lazy stack).
+                    VStack(alignment: .leading, spacing: PacerDesign.sectionSpacing) {
+                        header
+                        content()
+                    }
+                }
             }
             .padding(.horizontal, 24)
             .padding(.top, 18)

--- a/PacerCore/Sources/PacerUI/PaceChartView.swift
+++ b/PacerCore/Sources/PacerUI/PaceChartView.swift
@@ -38,7 +38,7 @@ public struct PaceChartView: View {
         /// any — marked on the chart as the forecast limit-hit.
         public let projectionCrossesFullAt: Date?
 
-        public struct Point: Equatable, Identifiable {
+        public struct Point: Equatable, Identifiable, Sendable {
             public let time: Date
             public let value: Double
             public var id: TimeInterval { time.timeIntervalSince1970 }

--- a/docs/perf-tuning.md
+++ b/docs/perf-tuning.md
@@ -116,6 +116,33 @@ mechanisms are subtle enough that grep won't catch them in review.
    reliable enough that 5-min safety-net cadence is sufficient. The
    600 ms cost of a 900-file walk per minute, times 24/7, is exactly
    the kind of always-on CPU that puts a menu-bar app in the top-10.
+8. **`LazyVStack` of heavy chart cards in a `ScrollView` (2026-06-25).**
+   The lazy stack defers each card's body + `@Query` until it scrolls
+   on-screen — good for the notification budget, but it realizes the
+   card *mid-scroll*, so scrolling past a chart card builds its whole
+   Swift Charts body right then. A `sample(1)` taken WHILE scrolling
+   (the only way to catch this — an idle sample shows nothing) had the
+   main thread 74→99 % idle yet still dropped frames: the cost was
+   `ViewRendererHost`/`GraphHost` on the render thread, near-zero
+   `CA::Transaction::commit`, i.e. SwiftUI re-rendering cards as they
+   appeared, not compositing. Fix: eager `VStack` for pages with a
+   small fixed card set (a `lazy: Bool` flag on `PageScaffold`;
+   dashboard passes `lazy: false`). Re-incurs the `@Query` fanout, but
+   measured ~98 % main-thread idle during active use after the #102/#104/
+   #105 mitigations, so affordable. Lesson: **scroll jank with an idle
+   main thread is render/realize cost — profile WHILE scrolling.**
+9. **`await`ing an uncontended `@ModelActor` from `@MainActor` runs its
+   work INLINE on main (2026-06-25).** Swift skips the executor hop for
+   an idle actor and resumes the job on the caller's thread — so the
+   forecast engine's `DiurnalBurnModel.fit` ran on the main thread
+   (confirmed: no `swift_task_switch` frame between caller and fit; all
+   133 fit frames in the Main-Thread block). `@ModelActor` is not
+   enough; its default executor permits inline-on-main. Fix: wrap the
+   engine call sites (`PaceChartCard.refreshProjections`,
+   `AppBackgroundService.recomputeEngineIfDue`/`exportEngineSnapshot`)
+   in `Task.detached { [engine] in await engine.… }.value` so the await
+   genuinely hops off the main actor. (A dedicated `unownedExecutor` on
+   the engine would fix every call site at once — deferred.)
 
 ## Open work (deferred from the autonomous loop)
 


### PR DESCRIPTION
## What
Scrolling the dashboard dropped frames passing over the chart cards. A `sample(1)` **taken while scrolling** (an idle sample shows nothing) found the **main thread 99% idle yet still hitching** — the cost was on the render thread (`ViewRendererHost`/`GraphHost`), not main, with near-zero `CA::Transaction::commit`. Two compounding causes, both fixed.

### 1) Eager card stack — the scroll fix
`PageScaffold` wrapped every page in `ScrollView { LazyVStack }`. The lazy stack realizes each card's body + Swift Charts content **the moment it scrolls into view** → scrolling past a chart builds the whole chart mid-scroll. Added a `lazy: Bool = true` flag; the dashboard (small fixed card set) passes `lazy: false`, so cards render once up front and scrolling only translates them. Other pages keep lazy.
- Tradeoff (eager re-incurs `@Query` fanout) measured affordable: **~98% main-thread idle during active use** after the #102/#104/#105 mitigations.

### 2) Forecast engine fitting off the main thread
Found while profiling: `await`ing the uncontended `@ModelActor` engine from `@MainActor` resumes the heavy `DiurnalBurnModel.fit` **inline on the main thread** (Swift's idle-actor optimization — confirmed: no executor-hop frame; all 133 fit frames on Main). Wrapped the engine call sites in `Task.detached { [engine] in … }.value`. Re-profiled while scrolling: fit frames moved off main (74%→**99% idle**). Not the scroll bug, but a real UI-thread win. Adds `Sendable` to `PaceChartView.Data.Point` + `WindowProjection`.

## Verification
- **Owner confirmed the scroll is smooth** on the installed build.
- Objective: re-profile while scrolling shows engine fit off main + the eager stack removes the mid-scroll card realization.
- Both anti-patterns documented (`docs/perf-tuning.md` #8/#9).

## Note
This supersedes the chart-hover debounce (#106) as the actual scroll fix — #106 was a minor hover improvement, kept but not the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)