### PR TITLE
fix(ui): drop cross-cycle straggler that drew a red vertical line in pace charts

### DIFF
--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -237,6 +237,7 @@ private struct PaceChartColumn: View {
         let cycleStart = resets.addingTimeInterval(-duration)
         let now = Date()
         var points = windowSamples
+            .inCycle(resetting: resets, duration: duration)
             .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
             .sorted { $0.sampledAt < $1.sampledAt }
             .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }

--- a/App/Views/ProjectionDetailView.swift
+++ b/App/Views/ProjectionDetailView.swift
@@ -49,6 +49,7 @@ struct ProjectionCompareModal: View {
         let cycleStart = resets.addingTimeInterval(-duration)
         let now = Date()
         var points = samples
+            .inCycle(resetting: resets, duration: duration)
             .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
             .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }
         let tailTime = min(now, resets)

--- a/PacerCore/Sources/PacerCore/Models/RateLimitSample.swift
+++ b/PacerCore/Sources/PacerCore/Models/RateLimitSample.swift
@@ -64,3 +64,34 @@ public final class RateLimitSample {
         self.source = source
     }
 }
+
+public extension Sequence where Element == RateLimitSample {
+    /// Samples that belong to the cycle resetting at `resets` — i.e. with
+    /// the stragglers from neighboring cycles dropped.
+    ///
+    /// Each sample carries its own `resetsAt`, so cycle membership is a
+    /// direct property of the row, not an inference from its timestamp.
+    /// A sample is in-cycle when its `resetsAt` matches `resets` (within
+    /// half a window — consecutive resets are always ≥ one window apart,
+    /// while a single cycle's `resets_at` only jitters by ~1s across
+    /// polls), or when it's `nil` (the server returns `resets_at: null`
+    /// for the post-reset 0%-used readings, before the new window
+    /// re-anchors on your next message).
+    ///
+    /// The chart consumers used to scope a cycle purely by timestamp
+    /// (`sampledAt >= resets - duration`). Because the 7-day reset lands
+    /// almost exactly one window after the previous one, the prior cycle's
+    /// *final* high-usage sample — taken within milliseconds of the new
+    /// `cycleStart` — slipped past that `>=` and got plotted as the first
+    /// point, drawing a spurious near-vertical line (red, since at the
+    /// cycle's start any usage is far over the ~0% pace target) at the
+    /// chart's left edge. Filtering on the sample's own reset removes it
+    /// regardless of sub-second boundary jitter.
+    func inCycle(resetting resets: Date, duration: TimeInterval) -> [RateLimitSample] {
+        let tolerance = duration / 2
+        return filter { sample in
+            guard let sampleReset = sample.resetsAt else { return true }
+            return abs(sampleReset.timeIntervalSince(resets)) < tolerance
+        }
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/RateLimitSampleCycleTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/RateLimitSampleCycleTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+/// Cross-cycle straggler filtering for the pace charts. Reproduces the
+/// real boundary leak captured on 2026-06-29: the 7-day window reset at
+/// ~10:00:00 UTC while still reading 82% used, the new cycle anchored its
+/// reset exactly one window later, and the previous cycle's final 82%
+/// sample — taken 34ms *after* the new `cycleStart` — slipped past the
+/// pure `sampledAt >= cycleStart` filter and drew a near-vertical red line
+/// at the chart's left edge.
+@Suite struct RateLimitSampleCycleTests {
+
+    private static let sevenDays: TimeInterval = 7 * 86400
+
+    private func sample(_ sampledAt: Date, used: Double, resets: Date?) -> RateLimitSample {
+        RateLimitSample(
+            sampledAt: sampledAt, window: "seven_day",
+            usedPercentage: used, resetsAt: resets, source: "oauth"
+        )
+    }
+
+    /// The exact production geometry: previous reset == new `cycleStart`,
+    /// last old-cycle sample lands 34ms after it. `inCycle` must drop it.
+    @Test func dropsBoundaryStragglerFromPreviousCycle() {
+        let prevReset = Date(timeIntervalSince1970: 1_000_000)
+        let curReset = prevReset.addingTimeInterval(Self.sevenDays) // exactly one window later
+        // cycleStart of the current cycle is curReset - duration == prevReset.
+
+        let straggler = sample(prevReset.addingTimeInterval(0.034), used: 82, resets: prevReset)
+        let postResetIdle = sample(prevReset.addingTimeInterval(300), used: 0, resets: nil)
+        let fresh = sample(prevReset.addingTimeInterval(3600), used: 5, resets: curReset)
+
+        let kept = [straggler, postResetIdle, fresh]
+            .inCycle(resetting: curReset, duration: Self.sevenDays)
+
+        #expect(!kept.contains { $0.usedPercentage == 82 })   // straggler gone
+        #expect(kept.contains { $0.resetsAt == nil })          // post-reset 0% kept
+        #expect(kept.contains { $0.usedPercentage == 5 })      // current sample kept
+        #expect(kept.count == 2)
+    }
+
+    /// Sub-second `resets_at` jitter within the *same* cycle must never
+    /// drop a legitimately in-cycle sample.
+    @Test func keepsSameCycleDespiteJitter() {
+        let reset = Date(timeIntervalSince1970: 2_000_000)
+        let jittered = sample(reset.addingTimeInterval(-3600), used: 40, resets: reset.addingTimeInterval(-0.8))
+        let exact = sample(reset.addingTimeInterval(-1800), used: 45, resets: reset)
+
+        let kept = [jittered, exact].inCycle(resetting: reset, duration: Self.sevenDays)
+        #expect(kept.count == 2)
+    }
+
+    /// A neighbouring cycle that reset more than one window earlier (an
+    /// idle gap) is excluded just the same.
+    @Test func dropsDistantNeighbourCycle() {
+        let curReset = Date(timeIntervalSince1970: 3_000_000)
+        let old = sample(curReset.addingTimeInterval(-9 * 86400), used: 90,
+                         resets: curReset.addingTimeInterval(-8 * 86400))
+        let cur = sample(curReset.addingTimeInterval(-3600), used: 30, resets: curReset)
+
+        let kept = [old, cur].inCycle(resetting: curReset, duration: Self.sevenDays)
+        #expect(kept.count == 1)
+        #expect(kept.first?.usedPercentage == 30)
+    }
+}

--- a/Widgets/PaceChartWidget.swift
+++ b/Widgets/PaceChartWidget.swift
@@ -156,6 +156,7 @@ struct PaceChartProvider: AppIntentTimelineProvider {
         let cycleStart = resetsAt.addingTimeInterval(-duration)
         let now = Date()
         var points = windowRows
+            .inCycle(resetting: resetsAt, duration: duration)
             .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
             .sorted { $0.sampledAt < $1.sampledAt }
             .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }


### PR DESCRIPTION
## What

The 7-day (and 5-hour) pace charts occasionally drew a **red vertical line at the chart's left edge**, right after a reset. It self-healed within a poll or two, which made it look like a ghost. It's a real, recurring boundary bug.

## Why

The charts scoped "this cycle's samples" purely by timestamp:

```swift
.filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }   // cycleStart = resetsAt - duration
```

The 7-day reset lands almost exactly one window after the previous one, so `cycleStart` ≈ the **previous** reset. The prior cycle's *final* high-usage sample — taken within milliseconds of that instant — satisfies `>=` and gets plotted as the first point, immediately followed by the new cycle's reset-to-0 readings → a near-vertical segment at the extreme left. At the cycle's start the linear pace target is ~0%, so that point lands in the **red/danger** `PaceBand` → red line.

### Proven against the live store (2026-06-29)

| | value |
|---|---|
| previous cycle, last reading | **82% used**, reset `2026-06-29 09:59:59 UTC` |
| new cycle anchored | reset `2026-07-06 09:59:59 UTC` → `cycleStart` = `2026-06-29 09:59:59.237` |
| 82% straggler sampledAt | `2026-06-29 09:59:59.271` |
| **delta** | **+0.034 s → leaks in (`>= cycleStart`)** |

It self-heals because `resets_at` jitters ~1s across polls; once the latest sample's reset rounds to the other side, `cycleStart` shifts past the straggler and it drops out.

## Fix

Each `RateLimitSample` already stores its own `resetsAt`, so cycle membership is a property of the row — not an inference from its timestamp. New `inCycle(resetting:duration:)` keeps a sample only when its reset matches the current cycle (within half a window — consecutive resets are always ≥ one window apart; a single cycle only jitters ~1s) or is `nil` (the post-reset `resets_at: null` 0%-used readings). Boundary jitter no longer matters.

Applied to all three consumers that shared the leaky filter:
- `PaceChartCard` (dashboard)
- `PaceChartWidget` (widget)
- `ProjectionDetailView` (compare-models modal)

## Tests

`RateLimitSampleCycleTests` reproduces the exact 34 ms straggler geometry and asserts it's dropped while the legit post-reset and current samples are kept; plus same-cycle jitter and distant-neighbour cases. `make install` green (full app + widget notarized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)