### PR TITLE
tooling: bin/ship.sh + /ship skill for the release workflow

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ship
+description: >-
+  Ship a Pacer release using the install-first, single-gate flow. Use when the
+  maintainer asks to release / ship / cut / publish a version, or — after a
+  local install they've reviewed — to land and release the current work. Covers
+  the version-bump + release-notes gate, landing the PR, and the backgrounded
+  tag → watch → verify. Do NOT start a release mid-work: it only begins once the
+  work is done AND approved (either up front — "…and release it" — or at the
+  post-install gate). The mechanical half is `bin/ship.sh`; the human process +
+  one-time secret setup is `docs/releasing.md`.
+---
+
+# Ship a Pacer release
+
+This skill is the **orchestration and the gate**. The deterministic plumbing —
+computing the next version, tagging, watching the Release workflow, verifying
+the published artifact — is in `bin/ship.sh`. Read `docs/releasing.md` for the
+pipeline and one-time setup.
+
+**There is exactly ONE human gate: a single approval right after a local
+install.** Everything after it is autonomous and backgrounded. The whole point
+is that a release costs almost no attention (and almost no expensive model
+tokens): the waiting and verifying happen in a backgrounded script, and the
+draft/review chores go to a cheap model.
+
+## 0 · Before a release (during the work)
+
+- Branches and PRs are your judgement — stack/rename branches freely as scope
+  grows, push for backup whenever. **Do not open the PR yet**, and never
+  tag/merge here.
+- When the work is done, `make install` so the maintainer can see it live.
+  Stop there.
+
+## 1 · The gate — right after `make install` is live
+
+1. `bin/ship.sh preflight` → prints the suggested bump (patch, or **minor** if a
+   `@Model`/schema change is detected — you confirm; minor = a SwiftData reset)
+   and the next version.
+2. `bin/ship.sh notes <version>` → previews the **exact** notes CI will publish
+   (`--generate-notes`), so what you show matches what ships.
+3. Surface **bump + notes**:
+   - **Not pre-authorized** → ask **once** with `AskUserQuestion` (it push-
+     notifies the maintainer and blocks). Offer: ship it · hold · change the
+     bump. This is the *only* AskUserQuestion in the flow.
+   - **Pre-authorized** — the kickoff request already said to ship ("…and
+     release it", "ship it autonomously", "merge and release") → send a
+     `PushNotification` FYI with the bump + notes, then proceed.
+
+The only other permitted interruption anywhere is a genuine implementation/
+direction fork you shouldn't guess on.
+
+## 2 · Prep — into the PR, before merge
+
+Do the release housekeeping and commit it to the branch **before** merging (so
+the shipped PR is self-contained):
+
+- If any UI changed: `make screenshots`, eyeball them, commit the PNGs.
+- Update README / docs / `docs/releasing.md` / any stale internal `.md` for what
+  changed. Update your durable memory if a real lesson came out of the work.
+- **PII scan** the screenshots + new docs. Delegate to a **Haiku subagent**
+  (vision): "flag any real names, emails, absolute home paths, tokens; public
+  examples must be fictional (Acme/Globex)." Fix anything it finds.
+
+Commit it all, then open the PR.
+
+## 3 · Land — autonomous, background the waits
+
+- Push, open the PR.
+- `bin/ship.sh wait-ci <branch>` — **background it**. On failure: pull the logs
+  (a Haiku subagent can summarize), **fix recursively yourself**, re-push,
+  re-wait. No gating.
+- Squash-merge to main; `git checkout main && git pull`.
+- Converge any other session branches the same way; if a merge changes rendered
+  output, regenerate screenshots/docs onto main.
+- `bin/ship.sh wait-ci main` (backgrounded) — main must be green before tagging.
+
+## 4 · Release — autonomous, backgrounded
+
+- `bin/ship.sh release <version>` — **run it with `run_in_background: true`**. It
+  tags, watches the Release run, then verifies (asset present · appcast
+  advertises the version · enclosure length matches the asset · EdDSA signature
+  validates against the app's embedded `SUPublicEDKey`). One notification when
+  it's done.
+- If it exits non-zero: fix the cause and cut an autonomous **patch** bump with a
+  short note (e.g. "fix release pipeline"), no gating — these are needed to make
+  the *already-approved* release actually work. Repeat until
+  `bin/ship.sh verify <version>` is green.
+- **Never** try to drive the maintainer's GUI to confirm the Sparkle download/
+  relaunch — screen control is not allowed. The headless signature check already
+  proves the update path works.
+
+## 5 · Recap
+
+Relay a short what-shipped summary — version, release + PR links, and the
+`verify` checklist. A Haiku subagent can draft it.
+
+## Token discipline (why this exists)
+
+- **Background** `wait-ci` and `release` — never poll them turn-by-turn; each
+  poll re-reads the whole context on an expensive model.
+- **Delegate** the draftable + visual chores (notes/recap wording, CI-failure
+  summaries, the PII/screenshot review) to **Haiku subagents**
+  (`Agent` with `model: haiku` — Haiku has vision).
+- Keep the expensive model for the three things that actually need it: the gate
+  judgement, the patch-vs-minor call, and non-trivial CI fixes.

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,7 @@ updates/
 .idea/
 *.swp
 
-# Loop runtime state — local only
-.claude/
+# Claude Code local state — ignored, EXCEPT shared project skills (checked in
+# so every contributor/agent gets them, e.g. .claude/skills/ship).
+.claude/*
+!.claude/skills/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,5 +96,13 @@ but its widgets won't show data.
 4. Comments explain *why*, not *what* — especially where Pacer deliberately
    deviates from `ccusage` or upstream defaults.
 
+## Releasing
+
+Releases are tag-driven and mostly automated. Maintainers: see
+[`docs/releasing.md`](docs/releasing.md) and the `bin/ship.sh` helper
+(`preflight` → `release` → `verify`). If you use Claude Code, the committed
+[`/ship`](.claude/skills/ship/SKILL.md) skill encodes the full protocol
+(install-first, single approval gate, then autonomous land + release + verify).
+
 By contributing you agree your contributions are licensed under the repository's
 [MIT License](LICENSE).

--- a/bin/ship.sh
+++ b/bin/ship.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# ship.sh — the deterministic tail of a Pacer release.
+#
+# This is the mechanical half of the flow documented in docs/releasing.md
+# (and orchestrated by the `/ship` agent skill in .claude/skills/ship/). It
+# does the parts that are pure plumbing — the parts you should never pay a
+# human's (or an LLM's) attention to babysit: computing the next version,
+# tagging, watching the Release workflow, and verifying the published
+# artifact end to end.
+#
+# It deliberately does NOT decide *whether* to release, write the human-facing
+# recap, or fix a red CI run — those need judgement and live one level up. Each
+# subcommand is safe to run on its own and exits non-zero the moment something
+# is off, so a caller (person or agent) can react.
+#
+# Usage:
+#   bin/ship.sh preflight [patch|minor|major]   # are we ready? what version?
+#   bin/ship.sh notes [<version>]               # preview the auto-generated notes
+#   bin/ship.sh wait-ci [<ref>]                 # block until CI on <ref> is green
+#   bin/ship.sh release <version>               # tag → watch Release run → verify
+#   bin/ship.sh verify <version>                # health-check a published release
+#
+# `release` and `wait-ci` are the long-running ones — run them backgrounded
+# (they print a structured summary at the end) so nothing has to poll them.
+
+set -euo pipefail
+
+APPCAST_URL="https://ericandrechek.github.io/Pacer/appcast.xml"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---- pretty output -------------------------------------------------------
+if [ -t 1 ]; then B=$'\033[1m'; G=$'\033[32m'; Y=$'\033[33m'; R=$'\033[31m'; D=$'\033[2m'; X=$'\033[0m'
+else B=; G=; Y=; R=; D=; X=; fi
+info() { printf '%s==>%s %s\n' "$B" "$X" "$*"; }
+ok()   { printf '%s  ✓%s %s\n' "$G" "$X" "$*"; }
+warn() { printf '%s  !%s %s\n' "$Y" "$X" "$*"; }
+bad()  { printf '%s  ✗%s %s\n' "$R" "$X" "$*"; }
+die()  { printf '%s  ✗ %s%s\n' "$R" "$*" "$X" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
+
+need git; need gh
+
+# ---- version helpers -----------------------------------------------------
+latest_tag() { git tag -l 'v*' --sort=-v:refname | head -1; }
+
+# next_version <current vX.Y.Z> <patch|minor|major>
+next_version() {
+  local cur="${1#v}" bump="${2:-patch}" M m p
+  IFS=. read -r M m p <<<"$cur"
+  case "$bump" in
+    major) M=$((M+1)); m=0; p=0 ;;
+    minor) m=$((m+1)); p=0 ;;
+    patch|*) p=$((p+1)) ;;
+  esac
+  printf 'v%s.%s.%s' "$M" "$m" "$p"
+}
+
+# Heuristic: did anything that forces a SwiftData reset change since the last
+# tag? A @Model / schema-version edit is the tell. Only a *hint* — the caller
+# confirms the patch-vs-minor call.
+schema_touched() {
+  local base="$1"
+  git diff --unified=0 "${base}..HEAD" -- '*.swift' 2>/dev/null \
+    | grep -qE '^\+.*(@Model|VersionedSchema|SchemaMigrationPlan|@Attribute\(\.unique)' \
+    && return 0 || return 1
+}
+
+assert_releasable() {
+  [ "$(git branch --show-current)" = "main" ] || die "not on main (on '$(git branch --show-current)')"
+  git diff --quiet && git diff --cached --quiet || die "working tree is dirty — commit or stash first"
+  git fetch --quiet origin main
+  [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || die "local main is not in sync with origin/main"
+}
+
+# ---- subcommands ---------------------------------------------------------
+cmd_preflight() {
+  local bump="${1:-}" cur next
+  cur="$(latest_tag)"; [ -n "$cur" ] || die "no existing vX.Y.Z tag to bump from"
+  info "Release preflight"
+  local branch dirty synced=yes
+  branch="$(git branch --show-current)"
+  { git diff --quiet && git diff --cached --quiet; } && dirty=no || dirty=yes
+  git fetch --quiet origin main || true
+  [ "$(git rev-parse HEAD 2>/dev/null)" = "$(git rev-parse origin/main 2>/dev/null)" ] || synced=no
+  [ "$branch" = main ] && ok "on main" || bad "on '$branch' (release runs from main)"
+  [ "$dirty" = no ] && ok "working tree clean" || bad "working tree dirty"
+  [ "$synced" = yes ] && ok "in sync with origin/main" || bad "behind/ahead of origin/main"
+
+  if [ -z "$bump" ]; then
+    if schema_touched "$cur"; then bump=minor; warn "schema-ish change since ${cur} → suggesting a MINOR bump (data reset)"
+    else bump=patch; ok "no schema change since ${cur} → suggesting a PATCH bump"; fi
+  fi
+  next="$(next_version "$cur" "$bump")"
+  echo
+  printf '  latest : %s\n  bump   : %s\n  %snext   : %s%s\n' "$cur" "$bump" "$B" "$next" "$X"
+  echo
+  printf '  %snext-version=%s%s\n' "$D" "$next" "$X"   # machine-readable
+  [ "$branch" = main ] && [ "$dirty" = no ] && [ "$synced" = yes ]
+}
+
+cmd_notes() {
+  local version="${1:-}" tag prev
+  prev="$(latest_tag)"
+  if [ -z "$version" ]; then version="$(next_version "$prev" patch)"; version="${version#v}"; fi
+  tag="v${version}"
+  info "Auto-generated release notes preview for ${tag} (what --generate-notes will publish)"
+  gh api "repos/{owner}/{repo}/releases/generate-notes" \
+    -f tag_name="$tag" -f target_commitish=main -f previous_tag_name="$prev" \
+    --jq '.body' 2>/dev/null || die "could not generate notes (is $prev the right previous tag?)"
+}
+
+cmd_wait_ci() {
+  local ref="${1:-$(git branch --show-current)}" sha id
+  sha="$(git rev-parse "$ref" 2>/dev/null || git rev-parse HEAD)"
+  info "Waiting for CI on ${ref} (${sha:0:7})"
+  for _ in $(seq 1 20); do
+    id="$(gh run list --workflow=CI --limit 20 \
+          --json databaseId,headSha --jq "[.[]|select(.headSha==\"$sha\")][0].databaseId" 2>/dev/null || true)"
+    [ -n "$id" ] && [ "$id" != null ] && break
+    sleep 6
+  done
+  [ -n "${id:-}" ] && [ "$id" != null ] || die "no CI run found for ${sha:0:7} yet"
+  gh run watch "$id" --exit-status >/dev/null && { ok "CI green"; return 0; } || {
+    bad "CI failed — $(gh run view "$id" --json url --jq .url)"; return 1; }
+}
+
+cmd_release() {
+  local version="${1:?usage: ship.sh release <version>}" tag
+  version="${version#v}"; tag="v${version}"
+  need gh
+  assert_releasable
+  git rev-parse "$tag" >/dev/null 2>&1 && die "tag ${tag} already exists"
+  info "Tagging ${tag} on $(git rev-parse --short HEAD) and pushing"
+  git tag -a "$tag" -m "Pacer ${version}"
+  git push origin "$tag" >/dev/null
+  ok "pushed ${tag} — Release workflow will pick it up"
+
+  info "Locating the Release run"
+  local run_id=
+  for _ in $(seq 1 25); do
+    run_id="$(gh run list --workflow=Release --limit 15 \
+      --json databaseId,headBranch,createdAt \
+      --jq "[.[]|select(.headBranch==\"$tag\")]|sort_by(.createdAt)|last|.databaseId" 2>/dev/null || true)"
+    [ -n "$run_id" ] && [ "$run_id" != null ] && break
+    sleep 6
+  done
+  [ -n "$run_id" ] && [ "$run_id" != null ] || die "Release run for ${tag} never appeared — check the Actions tab"
+  info "Watching Release run ${run_id} ($(gh run view "$run_id" --json url --jq .url))"
+  gh run watch "$run_id" --exit-status >/dev/null \
+    || die "Release run failed — $(gh run view "$run_id" --json url --jq .url)"
+  ok "Release workflow succeeded"
+  echo
+  cmd_verify "$version"
+}
+
+cmd_verify() {
+  local version="${1:?usage: ship.sh verify <version>}" tag rc=0
+  version="${version#v}"; tag="v${version}"
+  info "Verifying release ${tag} end to end"
+
+  # 1. GitHub Release has the DMG asset.
+  local asset_json name size
+  asset_json="$(gh release view "$tag" --json assets,isDraft \
+                --jq '{draft:.isDraft, dmg:(.assets[]|select(.name|endswith(".dmg")))}' 2>/dev/null || true)"
+  [ -n "$asset_json" ] || { bad "no GitHub Release ${tag} with a .dmg asset"; return 1; }
+  [ "$(printf '%s' "$asset_json" | python3 -c 'import sys,json;print(json.load(sys.stdin)["draft"])')" = False ] \
+    && ok "GitHub Release ${tag} published (not a draft)" || { bad "${tag} is still a draft"; rc=1; }
+  name="$(printf '%s' "$asset_json" | python3 -c 'import sys,json;print(json.load(sys.stdin)["dmg"]["name"])')"
+  size="$(printf '%s' "$asset_json" | python3 -c 'import sys,json;print(json.load(sys.stdin)["dmg"]["size"])')"
+  ok "asset ${name} (${size} bytes)"
+
+  # 2+3. Appcast advertises this version, and its <enclosure> is consistent
+  #      with the published asset (same DMG, same byte length). Also grab the
+  #      EdDSA signature + the app's embedded public key for the crypto check.
+  local pubkey; pubkey="$(grep -E 'SUPublicEDKey:' project.yml | head -1 | sed -E 's/.*SUPublicEDKey:[[:space:]]*//')"
+  APPCAST_URL="$APPCAST_URL" VERSION="$version" ASSET_SIZE="$size" python3 - <<'PY' || rc=1
+import os, sys, urllib.request, xml.etree.ElementTree as ET
+url, version, asset_size = os.environ["APPCAST_URL"], os.environ["VERSION"], int(os.environ["ASSET_SIZE"])
+_tty = sys.stdout.isatty()
+G, R, X = ("\033[32m", "\033[31m", "\033[0m") if _tty else ("", "", "")
+def ok(m): print(f"{G}  ✓{X} {m}")
+def bad(m): print(f"{R}  ✗{X} {m}"); globals().__setitem__("FAIL", True)
+FAIL = False
+try:
+    xml = urllib.request.urlopen(url, timeout=20).read()
+except Exception as e:
+    print(f"{R}  ✗{X} could not fetch appcast: {e}"); sys.exit(1)
+ns = {"s": "http://www.andymatuschak.org/xml-namespaces/sparkle"}
+root = ET.fromstring(xml)
+item = None
+for it in root.iter("item"):
+    sv = it.find("s:shortVersionString", ns)
+    if sv is not None and sv.text == version:
+        item = it; break
+if item is None:
+    bad(f"appcast does not advertise {version}"); sys.exit(1)
+ok(f"appcast advertises {version}")
+enc = item.find("enclosure")
+enc_url = enc.get("url", "")
+enc_len = int(enc.get("length", "0"))
+if enc_url.endswith(f"Pacer-{version}.dmg"): ok(f"enclosure → {enc_url.split('/')[-1]}")
+else: bad(f"enclosure URL unexpected: {enc_url}")
+if enc_len == asset_size: ok(f"enclosure length matches the published asset ({enc_len} bytes)")
+else: bad(f"enclosure length {enc_len} != asset size {asset_size}")
+sys.exit(1 if FAIL else 0)
+PY
+
+  # 4. Best-effort EdDSA verification of the DMG against the embedded pubkey.
+  #    Needs `uv` (for a throwaway pynacl); skipped with a note if absent so
+  #    the script stays runnable on a bare machine.
+  local sig encurl
+  sig="$(APPCAST_URL="$APPCAST_URL" python3 - "$version" <<'PY' 2>/dev/null || true
+import os,sys,urllib.request,xml.etree.ElementTree as ET
+v=sys.argv[1]; ns={"s":"http://www.andymatuschak.org/xml-namespaces/sparkle"}
+root=ET.fromstring(urllib.request.urlopen(os.environ["APPCAST_URL"],timeout=20).read())
+for it in root.iter("item"):
+    sv=it.find("s:shortVersionString",ns)
+    if sv is not None and sv.text==v:
+        enc=it.find("enclosure")
+        print(enc.get("{http://www.andymatuschak.org/xml-namespaces/sparkle}edSignature",""))
+        print(enc.get("url",""))
+PY
+)"
+  encurl="$(printf '%s\n' "$sig" | sed -n 2p)"; sig="$(printf '%s\n' "$sig" | sed -n 1p)"
+  if command -v uv >/dev/null 2>&1 && [ -n "$sig" ] && [ -n "$encurl" ] && [ -n "$pubkey" ]; then
+    info "EdDSA-verifying the DMG against the app's embedded SUPublicEDKey"
+    if PUBKEY="$pubkey" SIG="$sig" DMG="$encurl" uv run --quiet --with pynacl python - <<'PY'
+import os, base64, urllib.request, sys
+from nacl.signing import VerifyKey
+from nacl.exceptions import BadSignatureError
+dmg = urllib.request.urlopen(os.environ["DMG"], timeout=60).read()
+vk = VerifyKey(base64.b64decode(os.environ["PUBKEY"]))
+try:
+    vk.verify(dmg, base64.b64decode(os.environ["SIG"])); print("OK")
+except BadSignatureError:
+    print("BAD"); sys.exit(1)
+PY
+    then ok "EdDSA signature valid — installed clients will accept this update"
+    else bad "EdDSA signature did NOT verify against SUPublicEDKey"; rc=1; fi
+  else
+    warn "skipped EdDSA crypto-verify (need uv + a signature/pubkey); asset+length checks still cover integrity"
+  fi
+
+  echo
+  [ "$rc" = 0 ] && ok "${tag} verified: published, advertised, and signed correctly." \
+                || bad "${tag} verification FAILED — see above."
+  return "$rc"
+}
+
+# ---- dispatch ------------------------------------------------------------
+sub="${1:-}"; shift || true
+case "$sub" in
+  preflight) cmd_preflight "$@" ;;
+  notes)     cmd_notes "$@" ;;
+  wait-ci)   cmd_wait_ci "$@" ;;
+  release)   cmd_release "$@" ;;
+  verify)    cmd_verify "$@" ;;
+  ""|-h|--help|help)
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *) die "unknown subcommand: $sub (try: preflight | notes | wait-ci | release | verify)" ;;
+esac

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,7 +6,35 @@ The release pipeline lives in
 tag-driven, GitHub-Actions-hosted, no local steps once the secrets are
 in place.
 
-## Cutting a release (steady state)
+## The fast path: `bin/ship.sh`
+
+Most of a release is plumbing you shouldn't babysit. [`bin/ship.sh`](../bin/ship.sh)
+does the mechanical parts and exits non-zero the moment something's off:
+
+```sh
+bin/ship.sh preflight            # on main? clean? synced? → suggested next version
+bin/ship.sh notes <version>      # preview the exact notes CI will publish
+bin/ship.sh release <version>    # tag → watch the Release run → verify (backgroundable)
+bin/ship.sh verify <version>     # health-check a published release any time
+```
+
+`release` blocks until the workflow finishes and then runs `verify`, which
+checks the whole chain end to end: the GitHub Release has the DMG asset, the
+live appcast advertises the version, its `<enclosure>` length matches the
+published asset, and — if `uv` is available — the DMG's EdDSA signature
+validates against the app's embedded `SUPublicEDKey`. Run `release` / `wait-ci`
+backgrounded so nothing has to poll them.
+
+> **Agent note.** A Claude Code skill, [`/ship`](../.claude/skills/ship/SKILL.md),
+> wraps this with the project's release *protocol*: work on branches, install
+> locally first, then a **single** approval gate (version bump + notes) before
+> anything is pushed/merged/tagged; after approval it lands the PR, converges
+> branches, and runs `bin/ship.sh release` autonomously. It never drives your
+> GUI to confirm the Sparkle update — the headless signature check stands in.
+
+## Cutting a release (steady state, under the hood)
+
+The steps `bin/ship.sh` automates, spelled out:
 
 1. Land your changes on `main`. `CI` (PacerCore tests + verify build)
    should be green.


### PR DESCRIPTION
Codifies Pacer's release flow into the repo so every contributor (and agent) gets it — not just one person's setup — and so the token-expensive, attention-expensive parts never need babysitting.

## What's here

**`bin/ship.sh`** — the deterministic tail of a release:
- `preflight` — on main? clean? synced with origin? → suggested next version (patch, or minor if a `@Model`/schema change is detected)
- `notes <version>` — previews the **exact** `--generate-notes` body CI will publish, so what you approve matches what ships
- `wait-ci [ref]` — block until the CI run for a ref is green
- `release <version>` — annotated tag → locate + watch the Release run → `verify`
- `verify <version>` — release asset present · appcast advertises the version · `<enclosure>` length matches the published asset · the DMG's **EdDSA signature validates against the app's embedded `SUPublicEDKey`** (best-effort via `uv`+pynacl)

`release`/`wait-ci` are backgroundable and exit non-zero on any problem. Colors are tty-gated so backgrounded logs stay clean. Verified end-to-end against the live **v0.3.19** release.

**`.claude/skills/ship/SKILL.md`** — the committed Claude Code skill wrapping the script with the *protocol*:
- work on branches; **install locally first**; then a **single approval gate** (version bump + notes) before anything is pushed/merged/tagged
- after approval: land the PR with screenshots/docs/**PII scan inside the PR**, converge session branches, run `bin/ship.sh release` autonomously, recover from release-pipeline failures with autonomous patch bumps
- delegates drafting + the PII/screenshot review to **Haiku subagents**; never drives a GUI to confirm the Sparkle update (the headless signature check stands in)

`.gitignore` un-ignores `.claude/skills/` (local `settings.local.json` stays ignored).

**Docs** — `docs/releasing.md` gets a "fast path" section above the existing manual steps; `CONTRIBUTING.md` gets a Releasing pointer.

## Why

Two problems from the last release: (1) shipping mid-session locked the repo behind a ~10-min release before work could be redirected — now gated behind a single post-install approval; (2) the mechanical tail burned expensive-model tokens polling turn-by-turn — now a backgrounded script + cheap-model delegation.

No app code changed (shell + markdown only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)