### PR TITLE
Prediction feedback loop v2: gated bands, snapshot trail, versioned params, shadow models, replay harness

### DIFF
--- a/App/Background/PacerHTTPServer.swift
+++ b/App/Background/PacerHTTPServer.swift
@@ -265,6 +265,15 @@ final class PacerHTTPServer: @unchecked Sendable {
                 return respond(client, status: 503, contentType: "text/plain", body: Data("No data yet\n".utf8))
             }
             respond(client, status: 200, contentType: "application/json; charset=utf-8", body: Data(json.utf8))
+        case "/v1/predictions/history":
+            guard authorized(headers) else { return unauthorized(client) }
+            let days = query["days"].flatMap { Int($0) } ?? 7
+            let surface = query["surface"]
+            guard let history = try? PacerPredictionHistoryBuilder.history(days: days, surface: surface),
+                  let json = try? history.encodedJSON() else {
+                return respond(client, status: 503, contentType: "text/plain", body: Data("No data yet\n".utf8))
+            }
+            respond(client, status: 200, contentType: "application/json; charset=utf-8", body: Data(json.utf8))
         case "/metrics":
             guard authorized(headers) else { return unauthorized(client) }
             guard let payload = currentPayload() else {
@@ -420,7 +429,7 @@ final class PacerHTTPServer: @unchecked Sendable {
             "version": appVersion,
             "build": appBuild,
             "schemaVersion": 1,
-            "endpoints": ["/v1/snapshot", "/v1/usage/daily", "/v1/usage/models", "/v1/stream", "/metrics", "/healthz"],
+            "endpoints": ["/v1/snapshot", "/v1/usage/daily", "/v1/usage/models", "/v1/predictions/history", "/v1/stream", "/metrics", "/healthz"],
         ]
         return (try? JSONSerialization.data(withJSONObject: info, options: [.prettyPrinted, .sortedKeys]))
             ?? Data("{}".utf8)

--- a/App/Notifications/NotificationCoordinator.swift
+++ b/App/Notifications/NotificationCoordinator.swift
@@ -345,13 +345,12 @@ public final class NotificationCoordinator {
         await requestAuthorizationIfNeeded()
         let content = UNMutableNotificationContent()
         let label: String = window == "five_hour" ? "5-hour" : "7-day"
-        // Heads-up title leads with the calibrated hit-time range ("in 3–8
-        // hr") — a single point time over-promises precision the models
-        // don't have. Imminent keeps the point: by then the range has
-        // collapsed and "in 45 minutes" is the actionable fact.
+        // Title carries the point ETA (points not ranges — Eric, 2026-07-06);
+        // the calibrated earliest–latest range lives in the body's "likely
+        // between…" line where there's room for it.
         content.title = tier == .imminent
             ? "\(label) limit imminent — projected \(Self.formatRelative(projectedFullAt))"
-            : "On pace to hit the \(label) limit \(IntelligenceFormatting.relativeCrossingPhrase(at: projectedFullAt, earliest: hitRangeEarliest, latest: hitRangeLatest) ?? Self.formatRelative(projectedFullAt))"
+            : "On pace to hit the \(label) limit \(IntelligenceFormatting.relativeCrossingPhrase(at: projectedFullAt) ?? Self.formatRelative(projectedFullAt))"
 
         // Body: the hit (with its plausible range when meaningfully tight),
         // the reset it beats, the current level, and the pace multiple.

--- a/App/Views/IntelligenceFormatting.swift
+++ b/App/Views/IntelligenceFormatting.swift
@@ -170,24 +170,20 @@ enum IntelligenceFormatting {
         return "→ limit \(point)"
     }
 
-    /// "in 45 min" / "in 3–8 hr" / "in 2–4 days" — the relative form of the
+    /// "in 45 min" / "in 7 hr" / "in 3 days" — the relative form of the
     /// crossing for the hero-tile chip, the menu bar, and notification
-    /// titles. Same honesty rule as `crossingPhrase`: lead with the
-    /// calibrated range, collapsing to a point only when both ends round to
-    /// the same words.
+    /// titles. A POINT, deliberately (points not ranges — Eric, 2026-07-06):
+    /// the chip surfaces are glanceable and a "5 min–32 hr" range there reads
+    /// broken, while the coarse units already say "approximately". The
+    /// calibrated earliest–latest range still speaks where there's room to
+    /// explain it — `crossingPhrase` in the hover tooltip and the
+    /// notification body's "likely between…" line.
     static func relativeCrossingPhrase(_ o: UsageIntelligenceEngine.BurnOutlook) -> String? {
-        relativeCrossingPhrase(at: o.projectedFullAt, earliest: o.projectedFullAtEarliest,
-                               latest: o.projectedFullAtLatest)
+        relativeCrossingPhrase(at: o.projectedFullAt)
     }
 
-    static func relativeCrossingPhrase(at hit: Date?, earliest: Date?, latest: Date?) -> String? {
+    static func relativeCrossingPhrase(at hit: Date?) -> String? {
         guard let hit else { return nil }
-        if let earliest, let latest, latest > earliest {
-            let a = coarseEta(earliest), b = coarseEta(latest)
-            if a.text == b.text { return "in \(a.text)" }
-            if a.unit == b.unit { return "in \(a.amount)–\(b.amount) \(b.unit)" }
-            return "in \(a.text)–\(b.text)"
-        }
         return "in \(coarseEta(hit).text)"
     }
 

--- a/App/Views/ProjectionDetailView.swift
+++ b/App/Views/ProjectionDetailView.swift
@@ -132,6 +132,7 @@ struct ProjectionDetailView: View {
         "recency-weighted": .green,
         "damped-acceleration": .purple,
         "saturating": .orange,
+        "kalman-trend": .pink,
         "diurnal-rate": .teal,
     ]
     private func color(_ id: String) -> Color { Self.palette[id] ?? .gray }

--- a/PacerCore/Sources/PacerCore/API/PacerPredictionHistory.swift
+++ b/PacerCore/Sources/PacerCore/API/PacerPredictionHistory.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SwiftData
+
+/// The prediction trail — every snapshot the engine recorded of what it was
+/// telling the user, with the evidence behind each answer. This is the
+/// debugging/replay export: join rows to realized truths on
+/// (`surface`, `periodKey`) via the self-eval outcomes (or the raw samples)
+/// to see which past predictions held up.
+public struct PacerPredictionHistory: Codable, Sendable {
+    public let schemaVersion: Int
+    public let generatedAt: Date
+    /// Version tag of the engine constants at export time (rows carry their own).
+    public let currentParamsVersion: String
+    public let rows: [Row]
+
+    public struct Row: Codable, Sendable {
+        public let recordedAt: Date
+        public let surface: String
+        public let method: String
+        public let paramsVersion: String
+        public let engineVersion: String
+        public let periodKey: String
+        public let periodEnd: Date?
+        public let value: Double?
+        public let lo80: Double?
+        public let hi80: Double?
+        public let lo50: Double?
+        public let hi50: Double?
+        public let confidence: String
+        public let support: Int
+        public let note: String?
+        public let crossingAt: Date?
+        public let crossingEarliest: Date?
+        public let crossingLatest: Date?
+        public let usedPct: Double?
+        public let anchorShift: Double?
+        public let slopePercentPerHour: Double?
+        public let bandStratum: String?
+        public let residualCount: Int?
+        public let spendSoFar: Double?
+    }
+
+    public func encodedJSON() throws -> String { try pacerAPIEncodedJSON(self) }
+}
+
+public enum PacerPredictionHistoryBuilder {
+
+    /// Snapshot rows from the last `days` days (clamped to 1…365), oldest
+    /// first, optionally filtered to one surface (`"rl-five_hour"`,
+    /// `"rl-seven_day"`, `"eod"`, `"month"`). Own short-lived `ModelContext`
+    /// (like `PacerUsageBuilder`) so the HTTP server reads it off its
+    /// background queue.
+    public nonisolated static func history(days: Int, surface: String? = nil, now: Date = Date()) throws -> PacerPredictionHistory {
+        let span = min(max(days, 1), 365)
+        let container = try PacerStore.sharedModelContainer()
+        let context = ModelContext(container)
+        let cutoff = now.addingTimeInterval(-Double(span) * 86400)
+        let descriptor: FetchDescriptor<PredictionSnapshot>
+        if let surface {
+            descriptor = FetchDescriptor<PredictionSnapshot>(
+                predicate: #Predicate { $0.recordedAt >= cutoff && $0.surface == surface },
+                sortBy: [SortDescriptor(\.recordedAt, order: .forward)])
+        } else {
+            descriptor = FetchDescriptor<PredictionSnapshot>(
+                predicate: #Predicate { $0.recordedAt >= cutoff },
+                sortBy: [SortDescriptor(\.recordedAt, order: .forward)])
+        }
+        let all = (try? context.fetch(descriptor)) ?? []
+        let rows = all.map { s in
+            PacerPredictionHistory.Row(
+                recordedAt: s.recordedAt, surface: s.surface, method: s.method,
+                paramsVersion: s.paramsVersion, engineVersion: s.engineVersion,
+                periodKey: s.periodKey, periodEnd: s.periodEnd,
+                value: s.value, lo80: s.lo80, hi80: s.hi80, lo50: s.lo50, hi50: s.hi50,
+                confidence: s.confidence, support: s.support, note: s.note,
+                crossingAt: s.crossingAt, crossingEarliest: s.crossingEarliest,
+                crossingLatest: s.crossingLatest, usedPct: s.usedPct,
+                anchorShift: s.anchorShift, slopePercentPerHour: s.slopePercentPerHour,
+                bandStratum: s.bandStratum, residualCount: s.residualCount,
+                spendSoFar: s.spendSoFar)
+        }
+        return PacerPredictionHistory(
+            schemaVersion: 1, generatedAt: now,
+            currentParamsVersion: EngineParams.version, rows: rows)
+    }
+}

--- a/PacerCore/Sources/PacerCore/API/PacerPredictionHistory.swift
+++ b/PacerCore/Sources/PacerCore/API/PacerPredictionHistory.swift
@@ -11,6 +11,9 @@ public struct PacerPredictionHistory: Codable, Sendable {
     public let generatedAt: Date
     /// Version tag of the engine constants at export time (rows carry their own).
     public let currentParamsVersion: String
+    /// The full current knob values — so the replay harness reproduces the
+    /// shipping configuration without reading Swift source.
+    public let currentParams: EngineParams
     public let rows: [Row]
 
     public struct Row: Codable, Sendable {
@@ -81,6 +84,7 @@ public enum PacerPredictionHistoryBuilder {
         }
         return PacerPredictionHistory(
             schemaVersion: 1, generatedAt: now,
-            currentParamsVersion: EngineParams.version, rows: rows)
+            currentParamsVersion: EngineParams.version,
+            currentParams: EngineParams.current, rows: rows)
     }
 }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/ConformalCalibrator.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/ConformalCalibrator.swift
@@ -81,6 +81,17 @@ public struct ConformalCalibrator: Sendable, Equatable {
         return lower...upper
     }
 
+    /// `quantile(_:)` gated the same way `interval(around:level:)` is: `nil`
+    /// until at least `minResiduals` residuals exist. A tail read off a
+    /// handful of cases is just the most extreme thing that ever happened —
+    /// one bad week then stretches every band to "5 min to 32 hours" — so
+    /// callers that shift a curve by a raw quantile must use this form and
+    /// fall back to the unshifted point when it declines.
+    public func gatedQuantile(_ p: Double, minResiduals: Int = 8) -> Double? {
+        guard residuals.count >= minResiduals else { return nil }
+        return quantile(p)
+    }
+
     /// Empirical quantile of the residuals with the conformal `(n+1)` rank
     /// adjustment. `p` in [0,1]; saturates to the extreme residual past the range
     /// (the honest "can't be more precise than what we've seen").

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Version tag for the engine's tuning constants — recorded into every
+/// `PredictionSnapshot` so a historical prediction stays interpretable after
+/// the knobs move ("this row was produced under v1 parameters").
+///
+/// Today the constants themselves still live where they're used
+/// (`EngineSelfEval`, `BurnTrajectoryModels`, `ConformalCalibrator`, …); this
+/// tag versions that whole implicit set. Pulling the knobs into an explicit
+/// parameter struct (so the replay harness can sweep them and winners ship as
+/// a new version here) is the planned follow-up.
+public enum EngineParams {
+    /// Bump on ANY change to a forecasting constant or model roster — the
+    /// snapshot trail's meaning depends on it.
+    public static let version = "v1-2026.07-baseline"
+}

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
@@ -46,6 +46,14 @@ public struct EngineParams: Sendable, Equatable, Codable {
     /// fraction of the cycle duration.
     public var recencyHalfLifeFraction: Double = 0.15
 
+    // MARK: Shadow-candidate promotion
+
+    /// Completed periods a SHADOW candidate's record needs before
+    /// `EngineSelfEval.bestMethod` may select it for display (it still must
+    /// win on realized error once there). Shadows score from day one; this
+    /// only stops a lucky thin record from reaching the screen.
+    public var shadowPromotionMinPeriods: Int = 15
+
     public init() {}
 
     /// The values the shipping engine runs with.
@@ -69,6 +77,7 @@ public struct EngineParams: Sendable, Equatable, Codable {
             "poolRecencyWindow=\(poolRecencyWindow)",
             "linearRecentLookbackFraction=\(g(linearRecentLookbackFraction))",
             "recencyHalfLifeFraction=\(g(recencyHalfLifeFraction))",
+            "shadowPromotionMinPeriods=\(shadowPromotionMinPeriods)",
         ].joined(separator: ";")
     }
 

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
@@ -1,16 +1,85 @@
 import Foundation
 
-/// Version tag for the engine's tuning constants — recorded into every
-/// `PredictionSnapshot` so a historical prediction stays interpretable after
-/// the knobs move ("this row was produced under v1 parameters").
+/// The engine's tunable constants, pulled into one explicit, versioned set —
+/// the single source of truth the estimators read and the replay harness
+/// sweeps.
 ///
-/// Today the constants themselves still live where they're used
-/// (`EngineSelfEval`, `BurnTrajectoryModels`, `ConformalCalibrator`, …); this
-/// tag versions that whole implicit set. Pulling the knobs into an explicit
-/// parameter struct (so the replay harness can sweep them and winners ship as
-/// a new version here) is the planned follow-up.
-public enum EngineParams {
-    /// Bump on ANY change to a forecasting constant or model roster — the
-    /// snapshot trail's meaning depends on it.
-    public static let version = "v1-2026.07-baseline"
+/// Every `PredictionSnapshot` row records `versionTag`, which is derived from
+/// the VALUES (not hand-bumped): change any knob and every subsequent row
+/// carries a new tag automatically, so historical predictions stay
+/// interpretable across tunings.
+///
+/// **Adoption protocol (hysteresis lives in the harness, not the app):** the
+/// Python replay harness (`research/harness`) sweeps these knobs walk-forward
+/// over the real store and recommends a change only when the winner is robust
+/// — better on the primary score in (almost) every fold, not just on average,
+/// and never worse on interval coverage. Winners land here as a reviewed code
+/// change; the app never mutates its own parameters at runtime, so selection
+/// noise can't thrash live behavior.
+public struct EngineParams: Sendable, Equatable, Codable {
+
+    // MARK: Conformal bands (rate-limit crossing/outlook uncertainty)
+
+    /// Minimum residuals before `ConformalCalibrator` will state a band or a
+    /// quantile shift; below this the surfaces show the point alone.
+    public var conformalMinResiduals: Int = 8
+    /// Minimum scores for a conformal stratum (early/late × weekday/weekend)
+    /// to stand alone; thinner strata fall back to the pooled calibrator.
+    public var rlStratumMinScores: Int = 10
+
+    // MARK: End-of-day pool selection (EngineSelfEval)
+
+    /// A method joins a cut's pool when its per-cut median APE is within this
+    /// relative factor of the best method's.
+    public var poolTolerance: Double = 1.25
+    /// Scored days a method needs at a cut before it can join that pool.
+    public var poolMinPeriods: Int = 10
+    /// Selection sees only the most recent N scored days per cut (drift
+    /// insurance); the all-time record still powers the accuracy display.
+    public var poolRecencyWindow: Int = 30
+
+    // MARK: Burn-trajectory candidates
+
+    /// `LinearRecent`: recent window as a fraction of the cycle duration.
+    public var linearRecentLookbackFraction: Double = 0.3
+    /// `RecencyWeighted` / `DampedAcceleration`: recency half-life as a
+    /// fraction of the cycle duration.
+    public var recencyHalfLifeFraction: Double = 0.15
+
+    public init() {}
+
+    /// The values the shipping engine runs with.
+    public static let current = EngineParams()
+
+    /// Tag recorded into every prediction snapshot — a semantic prefix plus a
+    /// hash of the values, e.g. `"v1-a41bcd12"`.
+    public static var version: String { current.versionTag }
+
+    public var versionTag: String { "v1-" + String(format: "%08x", UInt32(truncatingIfNeeded: fnv1a(canonical))) }
+
+    /// Canonical `key=value` string over every knob, fixed order — the hash
+    /// input. Extend when adding a knob (order matters; append, don't sort).
+    var canonical: String {
+        func g(_ v: Double) -> String { String(format: "%g", v) }
+        return [
+            "conformalMinResiduals=\(conformalMinResiduals)",
+            "rlStratumMinScores=\(rlStratumMinScores)",
+            "poolTolerance=\(g(poolTolerance))",
+            "poolMinPeriods=\(poolMinPeriods)",
+            "poolRecencyWindow=\(poolRecencyWindow)",
+            "linearRecentLookbackFraction=\(g(linearRecentLookbackFraction))",
+            "recencyHalfLifeFraction=\(g(recencyHalfLifeFraction))",
+        ].joined(separator: ";")
+    }
+
+    /// FNV-1a 64-bit — tiny, dependency-free, stable across runs/platforms
+    /// (unlike `Hasher`, which is seeded per process).
+    private func fnv1a(_ s: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in s.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3
+        }
+        return hash
+    }
 }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
@@ -232,14 +232,23 @@ public enum EngineSelfEval {
     /// displays (`medianAbsError`) — the two can never contradict each other.
     /// Returns `nil` until at least `minPeriods` completed periods back a
     /// method — the engine then falls back to its cold on-the-fly backtest.
+    ///
+    /// `provisionalMinPeriods` is the SHADOW promotion gate: methods listed
+    /// there need their own (much higher) floor of scored periods before they
+    /// can be selected at all. They accumulate record from day one like
+    /// everyone else — the gate only bounds what a thin early record can put
+    /// on screen, so a new candidate earns display instead of getting it on a
+    /// lucky week.
     public static func bestMethod(
         from records: [Record],
         minPeriods: Int = 2,
-        complexity: [String: Int] = [:]
+        complexity: [String: Int] = [:],
+        provisionalMinPeriods: [String: Int] = [:]
     ) -> String? {
         let byMethod = Dictionary(grouping: records, by: { $0.method })
         let scored = byMethod.compactMap { id, rows -> (id: String, err: Double, cx: Int)? in
-            guard Set(rows.map { $0.periodKey }).count >= minPeriods else { return nil }
+            let floor = provisionalMinPeriods[id] ?? minPeriods
+            guard Set(rows.map { $0.periodKey }).count >= floor else { return nil }
             return (id, median(rows.map { abs($0.predicted - $0.truth) }), complexity[id] ?? 3)
         }
         guard let best = scored.min(by: { $0.err < $1.err }) else { return nil }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineSelfEval.swift
@@ -31,16 +31,17 @@ public enum EngineSelfEval {
     /// Pool-trimming bar — applied to each user's *own* accumulated record.
     /// A method joins a cut's pool when its per-cut median APE is within
     /// `poolTolerance` (relative) of the best method's, with at least
-    /// `poolMinPeriods` scored days behind it.
-    static let poolTolerance = 1.25
-    static let poolMinPeriods = 10
+    /// `poolMinPeriods` scored days behind it. Values live in `EngineParams`
+    /// (the versioned, harness-sweepable set).
+    static var poolTolerance: Double { EngineParams.current.poolTolerance }
+    static var poolMinPeriods: Int { EngineParams.current.poolMinPeriods }
     /// Selection looks at only the most recent scored days per cut — drift
     /// insurance. Validated on the real store: with the all-time record the
     /// hour-of-day shape (strong in the first weeks, weak in the current
     /// month's regime) re-entered the morning pools and dragged the median;
     /// a trailing window keeps selection tracking the regime the user is IN,
     /// while the all-time record still powers the accuracy display.
-    static let poolRecencyWindow = 30
+    static var poolRecencyWindow: Int { EngineParams.current.poolRecencyWindow }
 
     // MARK: - Decoupled value types (SwiftData-free)
 

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -377,10 +377,11 @@ public actor UsageIntelligenceEngine {
         public let projectedFullAt: Date?
         public let etaSeconds: TimeInterval?
         /// Earliest-plausible crossing (the upper conformal band's crossing —
-        /// "could hit as early as") and latest-plausible (lower band's). Both
-        /// nil when the respective shifted curve never crosses before reset.
-        /// The pair is the honest "on pace to hit between X and Y" range; a
-        /// very wide pair means the ETA shouldn't be shown as a point at all.
+        /// "could hit as early as") and latest-plausible (lower band's). Nil
+        /// when the shifted curve never crosses before reset, and BOTH nil
+        /// when the calibrator lacks the residuals for an honest band
+        /// (`gatedQuantile` declined) — detail surfaces then show the point
+        /// alone instead of a saturated worst-case range.
         public let projectedFullAtEarliest: Date?
         public let projectedFullAtLatest: Date?
         public let usedPct: Double
@@ -443,15 +444,20 @@ public actor UsageIntelligenceEngine {
         if current.usedNow < 100 {
             let cutFraction = current.durationHours > 0 ? current.nowHours / current.durationHours : 1
             let calibrator = Self.rlCalibrator(rf, cutFraction: cutFraction, cycleStart: current.cycleStart, calendar: f.calendar)
-            let hiShift = calibrator?.quantile(0.9) ?? 0   // upper band → earliest plausible
-            let loShift = calibrator?.quantile(0.1) ?? 0   // lower band → latest plausible
+            // Band shifts are GATED on residual count (mirrors `interval()`):
+            // a 7-day calibrator built from ~5 completed cycles saturates to
+            // its most extreme residual and the "range" degenerates to
+            // "5 min – 32 hr". No honest band ⇒ earliest/latest stay nil and
+            // the surfaces show the point crossing alone.
+            let hiShift = calibrator?.gatedQuantile(0.9)   // upper band → earliest plausible
+            let loShift = calibrator?.gatedQuantile(0.1)   // lower band → latest plausible
             var t = f.now.addingTimeInterval(5 * 60)
             while t <= current.resetsAt {
                 let p = projection(t) + anchor
-                if earliest == nil, p + max(hiShift, 0) >= 100 { earliest = t }
+                if let hiShift, earliest == nil, p + max(hiShift, 0) >= 100 { earliest = t }
                 if crossing == nil, p >= 100 { crossing = t }
-                if latest == nil, p + min(loShift, 0) >= 100 { latest = t }
-                if earliest != nil, crossing != nil, latest != nil { break }
+                if let loShift, latest == nil, p + min(loShift, 0) >= 100 { latest = t }
+                if earliest != nil || hiShift == nil, crossing != nil, latest != nil || loShift == nil { break }
                 t = t.addingTimeInterval(5 * 60)
             }
         }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -353,8 +353,9 @@ public actor UsageIntelligenceEngine {
         // late × weekday/weekend), pooled fallback when the stratum was thin.
         let cutFraction = current.durationHours > 0 ? current.nowHours / current.durationHours : 1
         let calibrator = Self.rlCalibrator(rf, cutFraction: cutFraction, cycleStart: current.cycleStart, calendar: f.calendar)
-        let band80 = calibrator?.interval(around: raw, level: 0.8).map { clampPct($0) }
-        let band50 = calibrator?.interval(around: raw, level: 0.5).map { clampPct($0) }
+        let minResiduals = EngineParams.current.conformalMinResiduals
+        let band80 = calibrator?.interval(around: raw, level: 0.8, minResiduals: minResiduals).map { clampPct($0) }
+        let band50 = calibrator?.interval(around: raw, level: 0.5, minResiduals: minResiduals).map { clampPct($0) }
 
         let confidence: Estimate.Confidence
         if rf.historyCount < 3 { confidence = .low }
@@ -466,8 +467,9 @@ public actor UsageIntelligenceEngine {
             // its most extreme residual and the "range" degenerates to
             // "5 min – 32 hr". No honest band ⇒ earliest/latest stay nil and
             // the surfaces show the point crossing alone.
-            let hiShift = calibrator?.gatedQuantile(0.9)   // upper band → earliest plausible
-            let loShift = calibrator?.gatedQuantile(0.1)   // lower band → latest plausible
+            let minResiduals = EngineParams.current.conformalMinResiduals
+            let hiShift = calibrator?.gatedQuantile(0.9, minResiduals: minResiduals)   // upper band → earliest plausible
+            let loShift = calibrator?.gatedQuantile(0.1, minResiduals: minResiduals)   // lower band → latest plausible
             var t = f.now.addingTimeInterval(5 * 60)
             while t <= current.resetsAt {
                 let p = projection(t) + anchor
@@ -894,7 +896,8 @@ public actor UsageIntelligenceEngine {
         return "\(phase)|\(regime.rawValue)"
     }
     /// A stratum needs this many scores to stand alone; thinner ones pool.
-    static let rlStratumMinScores = 10
+    /// Lives in `EngineParams` (the versioned, harness-sweepable set).
+    static var rlStratumMinScores: Int { EngineParams.current.rlStratumMinScores }
 
     /// Stratified additive conformal calibrators for a rate-limit model:
     /// walk-forward over completed cycles, residual = truth − projection

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -192,7 +192,8 @@ public actor UsageIntelligenceEngine {
             let surface = EngineSelfEval.rlSurface(window.rawValue)
             let recs = records(surface)
             accuracyBySurface[surface] = EngineSelfEval.accuracy(surface: surface, from: recs)
-            if let pick = EngineSelfEval.bestMethod(from: recs, complexity: Self.rlComplexities(window)) {
+            if let pick = EngineSelfEval.bestMethod(from: recs, complexity: Self.rlComplexities(window),
+                                                    provisionalMinPeriods: Self.rlShadowFloors(window)) {
                 rlSelection[window.rawValue] = pick
             }
         }
@@ -243,8 +244,21 @@ public actor UsageIntelligenceEngine {
     /// pick can break near-ties toward the simpler model.
     static func rlComplexities(_ window: RateLimitWindowKind) -> [String: Int] {
         var c = Dictionary(uniqueKeysWithValues: BurnTrajectory.defaultModels.map { ($0.id, $0.complexity) })
-        if window == .sevenDay { c["diurnal-rate"] = 3 }
+        c["diurnal-rate"] = 3
         return c
+    }
+
+    /// The SHADOW candidates for a window and the promotion floor each must
+    /// clear (completed periods in its scored record) before `bestMethod` may
+    /// select it for display. Kalman is new everywhere; the diurnal model is
+    /// established on 7d but a shadow on 5h — the 2026-06 backtest measured a
+    /// null there (5h cycles rarely straddle a day/night boundary), and the
+    /// shadow record re-tests that assumption instead of trusting it forever.
+    static func rlShadowFloors(_ window: RateLimitWindowKind) -> [String: Int] {
+        let floor = EngineParams.current.shadowPromotionMinPeriods
+        var floors = ["kalman-trend": floor]
+        if window == .fiveHour { floors["diurnal-rate"] = floor }
+        return floors
     }
 
     // MARK: - Ask (the typed question → Estimate contract)
@@ -714,14 +728,13 @@ public actor UsageIntelligenceEngine {
                   let duration = PaceMath.windowDuration(for: window.rawValue) else { continue }
             let (_, history) = BurnTrajectory.segment(samples: samples, duration: duration, now: f.now)
 
-            // The 7-day window is where the diurnal idle structure lives; a 5h
-            // window rarely straddles a day/night boundary (a measured null),
-            // so it competes only the simple baselines there.
+            // The diurnal model competes on both windows now: established on
+            // 7d (where the idle structure lives), a promotion-gated SHADOW
+            // on 5h — the 2026-06 "measured null" there gets re-tested by the
+            // accumulating record instead of trusted forever.
             var roster = BurnTrajectory.defaultModels
-            if window == .sevenDay {
-                let table = DiurnalBurnModel.rateTable(cycles: history, calendar: f.calendar, prior: f.activityGrid)
-                roster.append(DiurnalBurnModel(rate: table, calendar: f.calendar))
-            }
+            let table = DiurnalBurnModel.rateTable(cycles: history, calendar: f.calendar, prior: f.activityGrid)
+            roster.append(DiurnalBurnModel(rate: table, calendar: f.calendar))
 
             // Prefer the accumulated per-user track record (`rlSelection`);
             // fall back to a cold on-the-fly backtest, then a hardcoded default
@@ -735,7 +748,12 @@ public actor UsageIntelligenceEngine {
             if let learned = rlSelection[window.rawValue] {
                 selectedId = learned
             } else {
-                let scores = BurnTrajectory.score(models: roster, cycles: history)
+                // Cold start never displays a shadow candidate — the whole
+                // point of the promotion floor is that new models earn
+                // display from the persisted record, not a cold backtest.
+                let shadowIds = Set(Self.rlShadowFloors(window).keys)
+                let scores = BurnTrajectory.score(models: roster.filter { !shadowIds.contains($0.id) },
+                                                  cycles: history)
                 selectedId = ForecastSelector.select(
                     scores: scores, policy: .init(minScoredCases: 6, minCoverage: 0.5)).id
                     ?? (window == .sevenDay ? "diurnal-rate" : "recency-weighted")
@@ -1153,7 +1171,7 @@ public actor UsageIntelligenceEngine {
             out += EngineSelfEval.newOutcomesRL(
                 window: window.rawValue, cycles: completed, activityGrid: f.activityGrid, calendar: calendar,
                 existingKeys: existingKeys,
-                includeDiurnal: window == .sevenDay)
+                includeDiurnal: true)
         }
         return out
     }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -76,6 +76,13 @@ public actor UsageIntelligenceEngine {
     /// Per-surface method track records (end-of-day, rate-limit windows),
     /// refreshed each recompute.
     private var accuracyBySurface: [String: EngineSelfEval.Accuracy] = [:]
+    /// Last prediction-snapshot written per surface (signature + when) — the
+    /// change/heartbeat policy that keeps the trail from growing per tick.
+    /// In-memory only: a relaunch writes one fresh row per surface, which
+    /// doubles as a restart marker in the trail.
+    private var lastSnapshotSig: [String: (at: Date, sig: String)] = [:]
+    /// Local-day key of the last retention prune (prune once per day).
+    private var lastSnapshotPruneDay: String?
 
     /// Per-user fitted state cached between scans. Holds the shapes that are
     /// expensive to derive (calibrators, the diurnal rate table); the cheap,
@@ -191,6 +198,11 @@ public actor UsageIntelligenceEngine {
         }
 
         self.fit = Self.makeFit(f, eodPools: pools, rlSelection: rlSelection)
+
+        // Prediction trail: record what this refit would tell the user —
+        // the live answers with their bands, residual evidence, and version
+        // tags — behind the change/heartbeat policy.
+        recordPredictionSnapshots(f, now: now)
     }
 
     /// Number of historical days the fit was trained on — for a future
@@ -386,6 +398,10 @@ public actor UsageIntelligenceEngine {
         public let projectedFullAtLatest: Date?
         public let usedPct: Double
         public let resetsAt: Date
+        /// Upward shift that pinned the model curve to the live reading —
+        /// recorded into prediction snapshots so a replay can separate model
+        /// error from anchoring.
+        public let anchorShift: Double
         /// Stable id of the model that produced the crossing (for affordances).
         public let method: String
         /// Natural-frequency facts over completed cycles, for honest risk
@@ -423,7 +439,8 @@ public actor UsageIntelligenceEngine {
         guard let model, let projection = model.fit(current) else {
             return BurnOutlook(slopePercentPerHour: slope, projectedFullAt: nil, etaSeconds: nil,
                                projectedFullAtEarliest: nil, projectedFullAtLatest: nil,
-                               usedPct: current.usedNow, resetsAt: current.resetsAt, method: "none",
+                               usedPct: current.usedNow, resetsAt: current.resetsAt,
+                               anchorShift: 0, method: "none",
                                cyclesObserved: rf.cyclesObserved,
                                cyclesPeakOver90: rf.cyclesPeakOver90, cyclesHit100: rf.cyclesHit100)
         }
@@ -469,6 +486,7 @@ public actor UsageIntelligenceEngine {
             projectedFullAtLatest: latest,
             usedPct: current.usedNow,
             resetsAt: current.resetsAt,
+            anchorShift: anchor,
             method: model.id,
             cyclesObserved: rf.cyclesObserved,
             cyclesPeakOver90: rf.cyclesPeakOver90,
@@ -917,6 +935,153 @@ public actor UsageIntelligenceEngine {
         let lo = min(100, max(0, r.lowerBound))
         let hi = min(100, max(0, r.upperBound))
         return lo...max(lo, hi)
+    }
+
+    // MARK: - Prediction snapshot trail
+
+    /// A not-yet-persisted `PredictionSnapshot` — pure output of
+    /// `snapshotDrafts`, so the whole surface tests without a container.
+    struct SnapshotDraft {
+        let surface: String
+        let method: String
+        let periodKey: String
+        let periodEnd: Date?
+        let value: Double?
+        let lo80: Double?, hi80: Double?
+        let lo50: Double?, hi50: Double?
+        let confidence: String
+        let support: Int
+        let note: String?
+        var crossingAt: Date?
+        var crossingEarliest: Date?
+        var crossingLatest: Date?
+        var usedPct: Double?
+        var anchorShift: Double?
+        var slopePercentPerHour: Double?
+        var bandStratum: String?
+        var residualCount: Int?
+        var spendSoFar: Double?
+
+        /// The row's identity at DISPLAY precision: a new row is worth writing
+        /// exactly when the user-visible facts would change (utilisation to
+        /// the whole point, dollars to 2 significant figures, crossings to
+        /// the 15-minute bucket). Everything else re-records on the heartbeat.
+        var signature: String {
+            func pp(_ v: Double?) -> String { v.map { String(Int($0.rounded())) } ?? "-" }
+            func sig2(_ v: Double?) -> String {
+                guard let v, v.isFinite else { return "-" }
+                guard v > 0 else { return String(v) }
+                let mag = pow(10, floor(log10(v)) - 1)
+                return String(Int((v / mag).rounded() * mag))
+            }
+            func t(_ d: Date?) -> String { d.map { String(Int($0.timeIntervalSince1970 / 900)) } ?? "-" }
+            let isCost = surface == EngineSelfEval.surfaceEOD || surface == "month"
+            let v = isCost ? sig2 : pp
+            return [surface, method, confidence, periodKey,
+                    v(value), v(lo80), v(hi80),
+                    t(crossingAt), t(crossingEarliest), t(crossingLatest)].joined(separator: "|")
+        }
+    }
+
+    /// Even an unchanged prediction re-records this often, so the trail shows
+    /// "still saying X" rather than a gap.
+    static let snapshotHeartbeat: TimeInterval = 30 * 60
+
+    /// One draft per live surface — the same answers the views ask for, with
+    /// the band-evidence facts (stratum, residual count) the views don't show.
+    static func snapshotDrafts(_ f: EngineFeatures, _ fit: Fit) -> [SnapshotDraft] {
+        var out: [SnapshotDraft] = []
+        for window in RateLimitWindowKind.allCases {
+            guard let o = burnOutlook(f, fit, window: window) else { continue }
+            let key = window.rawValue
+            let est = rateLimitOutlook(f, fit, window: window)
+            var stratum: String?
+            var residuals: Int?
+            if let samples = f.rateLimit[key], let rf = fit.rl[key],
+               case let (currentOpt, _) = BurnTrajectory.segment(samples: samples, duration: rf.duration, now: f.now),
+               let current = currentOpt {
+                let cutFraction = current.durationHours > 0 ? current.nowHours / current.durationHours : 1
+                let stratumKey = rlStratum(cutFraction: cutFraction, cycleStart: current.cycleStart, calendar: f.calendar)
+                if let cal = rf.calibrators[stratumKey] { stratum = stratumKey; residuals = cal.count }
+                else if let pooled = rf.calibrators["pooled"] { stratum = "pooled"; residuals = pooled.count }
+            }
+            out.append(SnapshotDraft(
+                surface: EngineSelfEval.rlSurface(key), method: o.method,
+                periodKey: EngineSelfEval.periodKeyRL(o.resetsAt), periodEnd: o.resetsAt,
+                value: est.isInsufficient ? nil : est.value,
+                lo80: est.interval80?.lowerBound, hi80: est.interval80?.upperBound,
+                lo50: est.interval50?.lowerBound, hi50: est.interval50?.upperBound,
+                confidence: est.confidence.rawValue, support: est.support, note: est.note,
+                crossingAt: o.projectedFullAt,
+                crossingEarliest: o.projectedFullAtEarliest,
+                crossingLatest: o.projectedFullAtLatest,
+                usedPct: o.usedPct, anchorShift: o.anchorShift,
+                slopePercentPerHour: o.slopePercentPerHour,
+                bandStratum: stratum, residualCount: residuals))
+        }
+
+        let todayKey = TokenSample.formatDate(f.now, timeZone: f.calendar.timeZone)
+        let eod = projectedCostToday(f, fit)
+        out.append(SnapshotDraft(
+            surface: EngineSelfEval.surfaceEOD, method: eod.method,
+            periodKey: todayKey, periodEnd: f.todayStart.addingTimeInterval(86400),
+            value: eod.isInsufficient ? nil : eod.value,
+            lo80: eod.interval80?.lowerBound, hi80: eod.interval80?.upperBound,
+            lo50: eod.interval50?.lowerBound, hi50: eod.interval50?.upperBound,
+            confidence: eod.confidence.rawValue, support: eod.support, note: eod.note,
+            spendSoFar: f.todayElapsed.last?.cumulative ?? 0))
+
+        let month = MonthlyProjector.project(dailyCosts: f.dailyCosts, now: f.now, calendar: f.calendar)
+        out.append(SnapshotDraft(
+            surface: "month", method: month.method,
+            periodKey: String(todayKey.prefix(7)),
+            periodEnd: f.calendar.dateInterval(of: .month, for: f.now)?.end,
+            value: month.isInsufficient ? nil : month.value,
+            lo80: month.interval80?.lowerBound, hi80: month.interval80?.upperBound,
+            lo50: month.interval50?.lowerBound, hi50: month.interval50?.upperBound,
+            confidence: month.confidence.rawValue, support: month.support, note: month.note))
+        return out
+    }
+
+    /// Change/heartbeat write policy — pure, so the policy tests directly.
+    static func shouldRecordSnapshot(prev: (at: Date, sig: String)?, now: Date, signature: String) -> Bool {
+        guard let prev else { return true }
+        return prev.sig != signature || now.timeIntervalSince(prev.at) >= snapshotHeartbeat
+    }
+
+    private func recordPredictionSnapshots(_ f: EngineFeatures, now: Date) {
+        let engineVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
+        var dirty = false
+        for d in Self.snapshotDrafts(f, fit) {
+            let sig = d.signature
+            guard Self.shouldRecordSnapshot(prev: lastSnapshotSig[d.surface], now: now, signature: sig) else { continue }
+            modelContext.insert(PredictionSnapshot(
+                recordedAt: now, surface: d.surface, method: d.method,
+                paramsVersion: EngineParams.version, engineVersion: engineVersion,
+                periodKey: d.periodKey, periodEnd: d.periodEnd,
+                value: d.value, lo80: d.lo80, hi80: d.hi80, lo50: d.lo50, hi50: d.hi50,
+                confidence: d.confidence, support: d.support, note: d.note,
+                crossingAt: d.crossingAt, crossingEarliest: d.crossingEarliest,
+                crossingLatest: d.crossingLatest, usedPct: d.usedPct,
+                anchorShift: d.anchorShift, slopePercentPerHour: d.slopePercentPerHour,
+                bandStratum: d.bandStratum, residualCount: d.residualCount,
+                spendSoFar: d.spendSoFar))
+            lastSnapshotSig[d.surface] = (now, sig)
+            dirty = true
+        }
+
+        // Retention: once per local day, drop rows past the horizon. The
+        // eval table keeps the accuracy record forever; this is the
+        // high-resolution trail and 180 days of it is plenty for replay.
+        let dayKey = TokenSample.formatDate(now, timeZone: f.calendar.timeZone)
+        if lastSnapshotPruneDay != dayKey {
+            lastSnapshotPruneDay = dayKey
+            let cutoff = now.addingTimeInterval(-Double(PredictionSnapshot.retentionDays) * 86400)
+            try? modelContext.delete(model: PredictionSnapshot.self,
+                                     where: #Predicate { $0.recordedAt < cutoff })
+            dirty = true
+        }
+        if dirty { try? modelContext.save() }
     }
 
     // MARK: - Store reads

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectory.swift
@@ -76,12 +76,16 @@ public enum BurnTrajectory {
 
     /// Default roster. Quadratic is deliberately excluded — it reliably
     /// explodes on real cycles and was the worst fit in every backtest.
+    /// `KalmanTrend` rides along as a shadow candidate: it accumulates a
+    /// scored record like the others but can't be displayed until it clears
+    /// the promotion floor (`EngineParams.shadowPromotionMinPeriods`).
     public static var defaultModels: [any Model] {
         [
             LinearRecent(),
             RecencyWeighted(),
             DampedAcceleration(),
             Saturating(),
+            KalmanTrend(),
         ]
     }
 
@@ -222,6 +226,7 @@ public enum BurnTrajectory {
         case "recency-weighted": return "Recency-weighted"
         case "damped-acceleration": return "Damped acceleration"
         case "saturating": return "Saturating"
+        case "kalman-trend": return "Smoothed trend"
         case "diurnal-rate": return "Your daily rhythm"
         default: return modelId
         }

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectoryModels.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectoryModels.swift
@@ -11,9 +11,12 @@ extension BurnTrajectory {
     public struct LinearRecent: Model {
         public let id = "linear-recent"
         public let complexity = 1
-        /// Recent window as a fraction of the cycle duration.
+        /// Recent window as a fraction of the cycle duration (from
+        /// `EngineParams`, the versioned, harness-sweepable set).
         public let lookbackFraction: Double
-        public init(lookbackFraction: Double = 0.3) { self.lookbackFraction = lookbackFraction }
+        public init(lookbackFraction: Double = EngineParams.current.linearRecentLookbackFraction) {
+            self.lookbackFraction = lookbackFraction
+        }
 
         public func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)? {
             let cutoff = cycle.nowHours - cycle.durationHours * lookbackFraction
@@ -48,7 +51,7 @@ extension BurnTrajectory {
                 parameters: .init(
                     now: cycle.now, minSamples: 3,
                     minSpanSeconds: max(300, cycle.durationHours * 3600 * 0.05),
-                    recencyHalfLifeSeconds: cycle.durationHours * 3600 * 0.15,
+                    recencyHalfLifeSeconds: cycle.durationHours * 3600 * EngineParams.current.recencyHalfLifeFraction,
                     dampingTauSeconds: 3600, maxAccelSlopeFraction: 0))
             else { return nil }
             let now = cycle.now
@@ -70,7 +73,7 @@ extension BurnTrajectory {
                 parameters: .init(
                     now: cycle.now, minSamples: 4,
                     minSpanSeconds: max(300, cycle.durationHours * 3600 * 0.05),
-                    recencyHalfLifeSeconds: cycle.durationHours * 3600 * 0.15,
+                    recencyHalfLifeSeconds: cycle.durationHours * 3600 * EngineParams.current.recencyHalfLifeFraction,
                     dampingTauSeconds: remaining, maxAccelSlopeFraction: 1))
             else { return nil }
             let now = cycle.now

--- a/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectoryModels.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Ensemble/BurnTrajectoryModels.swift
@@ -81,6 +81,64 @@ extension BurnTrajectory {
         }
     }
 
+    /// Local-level + trend Kalman filter — a SHADOW candidate: scored into
+    /// the per-user record from day one like every roster member, but
+    /// display-promotion requires the shadow floor
+    /// (`EngineParams.shadowPromotionMinPeriods`) — see
+    /// `EngineSelfEval.bestMethod`. Tests whether optimal recursive smoothing
+    /// beats the recency-weighted regression at tracking the live burn slope;
+    /// projection is the filtered level carried forward at the filtered slope.
+    public struct KalmanTrend: Model {
+        public let id = "kalman-trend"
+        public let complexity = 5
+        /// Slope random-walk intensity (pp/hr per √hr) and measurement noise
+        /// (pp std). Fixed pending replay-harness sweeps.
+        static let processNoise = 0.5
+        static let measurementNoise = 0.5
+        public init() {}
+
+        public func fit(_ cycle: PartialCycle) -> (@Sendable (Date) -> Double)? {
+            let samples = cycle.samples
+            guard samples.count >= 3 else { return nil }
+            // State [level (pp), slope (pp/hr)]; constant-velocity transition
+            // with continuous white-noise-acceleration process covariance.
+            var level = samples[0].usedPercentage
+            var slope = 0.0
+            var p00 = 25.0, p01 = 0.0, p11 = 25.0
+            let q = Self.processNoise * Self.processNoise
+            let r = Self.measurementNoise * Self.measurementNoise
+            var lastT = cycle.hours(samples[0].at)
+            for s in samples.dropFirst() {
+                let t = cycle.hours(s.at)
+                let dt = max(1e-3, t - lastT)
+                lastT = t
+                // Predict.
+                level += slope * dt
+                let np00 = p00 + 2 * dt * p01 + dt * dt * p11 + q * dt * dt * dt / 3
+                let np01 = p01 + dt * p11 + q * dt * dt / 2
+                let np11 = p11 + q * dt
+                // Update.
+                let innov = s.usedPercentage - level
+                let denom = np00 + r
+                guard denom > 1e-12 else { return nil }
+                let k0 = np00 / denom, k1 = np01 / denom
+                level += k0 * innov
+                slope += k1 * innov
+                p00 = (1 - k0) * np00
+                p01 = (1 - k0) * np01
+                p11 = np11 - k1 * np01
+            }
+            guard level.isFinite, slope.isFinite else { return nil }
+            let filteredLevel = level, filteredSlope = slope
+            let anchorHours = lastT
+            let cycleStart = cycle.cycleStart
+            return { date in
+                let t = date.timeIntervalSince(cycleStart) / 3600
+                return filteredLevel + filteredSlope * (t - anchorHours)
+            }
+        }
+    }
+
     /// Saturating exponential `L·(1 − e^(−k·s))` — captures usage that
     /// decelerates as a window fills or rolls old usage off. Fit by a grid over
     /// the ceiling `L` with a closed-form `k` per `L` (linear through the

--- a/PacerCore/Sources/PacerCore/Models/PredictionSnapshot.swift
+++ b/PacerCore/Sources/PacerCore/Models/PredictionSnapshot.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SwiftData
+
+/// One displayed-prediction snapshot — what the engine was telling the user at
+/// a moment in time, together with everything needed to reconstruct *why*:
+/// the chosen method, the band and the residual evidence behind it, the state
+/// of the window, and the parameter/engine versions that produced it.
+///
+/// `EngineEvalOutcome` records how candidates did on *completed* periods; this
+/// table records the live answers as they were shown. The pair closes the
+/// debugging loop the eval table can't: "at 14:03 the badge said limit in
+/// 5 min–32 hr — which inputs did that, and what actually happened?" Rows are
+/// written by the engine on recompute behind a change/heartbeat policy (not
+/// per tick), and pruned after `PredictionSnapshot.retentionDays`.
+///
+/// `periodKey` matches the eval table's key for the same period (`yyyy-MM-dd`
+/// for cost surfaces, the rounded reset ISO-stamp for rate-limit cycles), so
+/// snapshot → realized-truth joins are a plain equality — the replay harness
+/// leans on this.
+@Model
+public final class PredictionSnapshot {
+    #Index<PredictionSnapshot>([\.surface], [\.surface, \.recordedAt], [\.recordedAt])
+
+    public var recordedAt: Date
+    /// `"rl-five_hour"` / `"rl-seven_day"` / `"eod"` / `"month"` — same ids the
+    /// self-eval scoreboard uses, so the two tables join on (surface, periodKey).
+    public var surface: String
+    /// Stable id of the method behind the point (`"diurnal-rate"`, `"eod-pool"`).
+    public var method: String
+    /// Version tag of the engine's tuning constants (see `EngineParams`).
+    public var paramsVersion: String
+    /// App marketing version that wrote the row (code changes move predictions
+    /// too, not just parameter changes).
+    public var engineVersion: String
+    /// The period this prediction is *about* — joins to `EngineEvalOutcome`.
+    public var periodKey: String
+    /// When the period resolves (window reset / local midnight / month end).
+    public var periodEnd: Date?
+
+    /// Point estimate — end-of-period utilisation (pp) for rate-limit
+    /// surfaces, dollars for cost surfaces. Nil = the engine answered
+    /// "insufficient" (that refusal is itself worth recording).
+    public var value: Double?
+    public var lo80: Double?
+    public var hi80: Double?
+    public var lo50: Double?
+    public var hi50: Double?
+    /// `Estimate.Confidence` raw value.
+    public var confidence: String
+    /// Historical cases backing the estimate (days / cycles).
+    public var support: Int
+    public var note: String?
+
+    // Rate-limit specifics (nil on cost surfaces).
+    /// The point crossing ("limit in 2 hr") and the calibrated band's
+    /// earliest/latest crossings — the exact facts the chips render.
+    public var crossingAt: Date?
+    public var crossingEarliest: Date?
+    public var crossingLatest: Date?
+    /// Live utilisation at prediction time.
+    public var usedPct: Double?
+    /// Upward shift applied to pin the model curve to the live reading.
+    public var anchorShift: Double?
+    /// Descriptive recent slope (pp/hour) at prediction time.
+    public var slopePercentPerHour: Double?
+    /// Which conformal stratum served the band (`"late|weekday"`, `"pooled"`)
+    /// and how many residuals it held — the "was this band honest" evidence.
+    public var bandStratum: String?
+    public var residualCount: Int?
+
+    // Cost specifics (nil on rate-limit surfaces).
+    /// Spend already realized within the period at prediction time.
+    public var spendSoFar: Double?
+
+    /// Snapshots older than this are pruned (the eval table keeps the
+    /// predicted-vs-truth accuracy record forever; this table is the
+    /// high-resolution debugging trail).
+    public static let retentionDays = 180
+
+    public init(
+        recordedAt: Date,
+        surface: String,
+        method: String,
+        paramsVersion: String,
+        engineVersion: String,
+        periodKey: String,
+        periodEnd: Date?,
+        value: Double?,
+        lo80: Double? = nil,
+        hi80: Double? = nil,
+        lo50: Double? = nil,
+        hi50: Double? = nil,
+        confidence: String,
+        support: Int,
+        note: String? = nil,
+        crossingAt: Date? = nil,
+        crossingEarliest: Date? = nil,
+        crossingLatest: Date? = nil,
+        usedPct: Double? = nil,
+        anchorShift: Double? = nil,
+        slopePercentPerHour: Double? = nil,
+        bandStratum: String? = nil,
+        residualCount: Int? = nil,
+        spendSoFar: Double? = nil
+    ) {
+        self.recordedAt = recordedAt
+        self.surface = surface
+        self.method = method
+        self.paramsVersion = paramsVersion
+        self.engineVersion = engineVersion
+        self.periodKey = periodKey
+        self.periodEnd = periodEnd
+        self.value = value
+        self.lo80 = lo80
+        self.hi80 = hi80
+        self.lo50 = lo50
+        self.hi50 = hi50
+        self.confidence = confidence
+        self.support = support
+        self.note = note
+        self.crossingAt = crossingAt
+        self.crossingEarliest = crossingEarliest
+        self.crossingLatest = crossingLatest
+        self.usedPct = usedPct
+        self.anchorShift = anchorShift
+        self.slopePercentPerHour = slopePercentPerHour
+        self.bandStratum = bandStratum
+        self.residualCount = residualCount
+        self.spendSoFar = spendSoFar
+    }
+}

--- a/PacerCore/Sources/PacerCore/PacerStore.swift
+++ b/PacerCore/Sources/PacerCore/PacerStore.swift
@@ -117,6 +117,7 @@ public enum PacerStore {
         AlertRule.self,
         ForecastModelOutcome.self,
         EngineEvalOutcome.self,
+        PredictionSnapshot.self,
     ]
 
     public static func makeModelContainer() throws -> ModelContainer {

--- a/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
@@ -34,6 +34,7 @@ struct EngineParamsTests {
         #expect(p.poolRecencyWindow == 30)
         #expect(p.linearRecentLookbackFraction == 0.3)
         #expect(p.recencyHalfLifeFraction == 0.15)
+        #expect(p.shadowPromotionMinPeriods == 15)
     }
 
     @Test func paramsRoundTripThroughJSON() throws {

--- a/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+/// The versioned parameter set: the tag must be a pure, stable function of
+/// the values, and the defaults must stay pinned to the validated constants
+/// (a drive-by change here silently re-tunes the whole engine).
+@Suite("Engine params")
+struct EngineParamsTests {
+
+    @Test func versionTagIsStableAcrossInstances() {
+        #expect(EngineParams().versionTag == EngineParams().versionTag)
+        #expect(EngineParams.version == EngineParams.current.versionTag)
+    }
+
+    @Test func versionTagChangesWhenAnyKnobChanges() {
+        let base = EngineParams()
+        var tweaked = EngineParams()
+        tweaked.conformalMinResiduals = 12
+        #expect(base.versionTag != tweaked.versionTag)
+
+        var tweaked2 = EngineParams()
+        tweaked2.recencyHalfLifeFraction = 0.2
+        #expect(base.versionTag != tweaked2.versionTag)
+        #expect(tweaked.versionTag != tweaked2.versionTag)
+    }
+
+    @Test func defaultsMatchTheValidatedConstants() {
+        let p = EngineParams.current
+        #expect(p.conformalMinResiduals == 8)
+        #expect(p.rlStratumMinScores == 10)
+        #expect(p.poolTolerance == 1.25)
+        #expect(p.poolMinPeriods == 10)
+        #expect(p.poolRecencyWindow == 30)
+        #expect(p.linearRecentLookbackFraction == 0.3)
+        #expect(p.recencyHalfLifeFraction == 0.15)
+    }
+
+    @Test func paramsRoundTripThroughJSON() throws {
+        let data = try JSONEncoder().encode(EngineParams.current)
+        let back = try JSONDecoder().decode(EngineParams.self, from: data)
+        #expect(back == EngineParams.current)
+        #expect(back.versionTag == EngineParams.current.versionTag)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
@@ -37,6 +37,13 @@ struct EngineParamsTests {
         #expect(p.shadowPromotionMinPeriods == 15)
     }
 
+    @Test func versionTagMatchesPythonHarness() {
+        // research/harness/pacer_replay.py `Params().version_tag()` computes
+        // the same FNV-1a over the same canonical string; this pin catches
+        // either side drifting. Update BOTH when a knob is added/changed.
+        #expect(EngineParams.current.versionTag == "v1-36d9fd53")
+    }
+
     @Test func paramsRoundTripThroughJSON() throws {
         let data = try JSONEncoder().encode(EngineParams.current)
         let back = try JSONDecoder().decode(EngineParams.self, from: data)

--- a/PacerCore/Tests/PacerCoreTests/PredictionSnapshotTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PredictionSnapshotTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+import SwiftData
+@testable import PacerCore
+
+/// The prediction trail: the change/heartbeat write policy, display-precision
+/// signatures, the per-surface drafts, and the actor's end-to-end write path.
+@Suite("Prediction snapshot trail")
+struct PredictionSnapshotTests {
+
+    static var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+    static let now = utc.date(from: DateComponents(year: 2026, month: 7, day: 6, hour: 14, minute: 0))!
+
+    // MARK: - Write policy
+
+    @Test func firstSnapshotAlwaysRecords() {
+        #expect(UsageIntelligenceEngine.shouldRecordSnapshot(prev: nil, now: Self.now, signature: "x"))
+    }
+
+    @Test func unchangedSignatureWithinHeartbeatIsSkipped() {
+        let prev = (at: Self.now.addingTimeInterval(-60), sig: "x")
+        #expect(!UsageIntelligenceEngine.shouldRecordSnapshot(prev: prev, now: Self.now, signature: "x"))
+    }
+
+    @Test func changedSignatureRecordsImmediately() {
+        let prev = (at: Self.now.addingTimeInterval(-60), sig: "x")
+        #expect(UsageIntelligenceEngine.shouldRecordSnapshot(prev: prev, now: Self.now, signature: "y"))
+    }
+
+    @Test func heartbeatForcesRecordEvenWhenUnchanged() {
+        let prev = (at: Self.now.addingTimeInterval(-UsageIntelligenceEngine.snapshotHeartbeat), sig: "x")
+        #expect(UsageIntelligenceEngine.shouldRecordSnapshot(prev: prev, now: Self.now, signature: "x"))
+    }
+
+    // MARK: - Display-precision signatures
+
+    private func rlDraft(value: Double?, crossingAt: Date? = nil) -> UsageIntelligenceEngine.SnapshotDraft {
+        .init(surface: "rl-five_hour", method: "m", periodKey: "p", periodEnd: nil,
+              value: value, lo80: nil, hi80: nil, lo50: nil, hi50: nil,
+              confidence: "medium", support: 10, note: nil, crossingAt: crossingAt)
+    }
+
+    private func costDraft(value: Double?) -> UsageIntelligenceEngine.SnapshotDraft {
+        .init(surface: "eod", method: "m", periodKey: "p", periodEnd: nil,
+              value: value, lo80: nil, hi80: nil, lo50: nil, hi50: nil,
+              confidence: "medium", support: 10, note: nil)
+    }
+
+    @Test func utilisationSignatureIsStableWithinTheDisplayedPoint() {
+        // 71.2% and 71.4% both display as 71% — same signature; 72.6% differs.
+        #expect(rlDraft(value: 71.2).signature == rlDraft(value: 71.4).signature)
+        #expect(rlDraft(value: 71.2).signature != rlDraft(value: 72.6).signature)
+    }
+
+    @Test func costSignatureIsStableWithinTwoSignificantFigures() {
+        // $123 and $124 both display as $120 (2sf); $130 differs.
+        #expect(costDraft(value: 123).signature == costDraft(value: 124).signature)
+        #expect(costDraft(value: 123).signature != costDraft(value: 131).signature)
+    }
+
+    @Test func crossingSignatureBucketsAtFifteenMinutes() {
+        let base = Self.now
+        #expect(rlDraft(value: 50, crossingAt: base).signature
+                == rlDraft(value: 50, crossingAt: base.addingTimeInterval(5 * 60)).signature)
+        #expect(rlDraft(value: 50, crossingAt: base).signature
+                != rlDraft(value: 50, crossingAt: base.addingTimeInterval(20 * 60)).signature)
+    }
+
+    @Test func insufficientValueIsItsOwnSignature() {
+        #expect(costDraft(value: nil).signature != costDraft(value: 100).signature)
+    }
+
+    // MARK: - Drafts from features
+
+    @Test func draftsCoverCostSurfacesEvenWhenInsufficient() {
+        let f = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: [],
+                                     hourly: [], rate: [], lastArrivalAt: nil)
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        let drafts = UsageIntelligenceEngine.snapshotDrafts(f, fit)
+        let surfaces = Set(drafts.map { $0.surface })
+        // No rate-limit history ⇒ no rl drafts; the cost surfaces still record
+        // their honest "insufficient" answers.
+        #expect(surfaces == ["eod", "month"])
+        #expect(drafts.allSatisfy { $0.value == nil })
+        #expect(drafts.first { $0.surface == "eod" }?.periodKey == "2026-07-06")
+        #expect(drafts.first { $0.surface == "month" }?.periodKey == "2026-07")
+    }
+
+    @Test func liveRateLimitCycleProducesADraftJoinableToTheEvalTable() {
+        // A live 5h cycle: 40% → 60% over the last 90 minutes.
+        var rate: [EngineFeatures.RateRow] = []
+        let resetsAt = Self.now.addingTimeInterval(2 * 3600)
+        for i in 0..<10 {
+            let at = Self.now.addingTimeInterval(Double(i - 9) * 10 * 60)
+            rate.append(.init(window: "five_hour", at: at,
+                              usedPercentage: 40 + Double(i) * 2.2, resetsAt: resetsAt))
+        }
+        let f = EngineFeatures.build(now: Self.now, calendar: Self.utc, daily: [],
+                                     hourly: [], rate: rate, lastArrivalAt: nil)
+        let fit = UsageIntelligenceEngine.makeFit(f)
+        let drafts = UsageIntelligenceEngine.snapshotDrafts(f, fit)
+        let rl = drafts.first { $0.surface == "rl-five_hour" }
+        #expect(rl != nil)
+        // periodKey must match the self-eval table's cycle key so the replay
+        // harness joins prediction → realized truth on equality.
+        #expect(rl?.periodKey == EngineSelfEval.periodKeyRL(resetsAt))
+        #expect(rl?.usedPct != nil)
+        #expect(rl?.method.isEmpty == false)
+    }
+
+    // MARK: - Actor end-to-end (write, dedupe, heartbeat)
+
+    @Test func actorWritesOncePerSignatureAndAgainOnHeartbeat() async throws {
+        let container = try PacerStore.makeInMemoryContainer()
+        let engine = UsageIntelligenceEngine(modelContainer: container)
+
+        await engine.recompute(now: Self.now, calendar: Self.utc)
+        let context = ModelContext(container)
+        let afterFirst = (try? context.fetch(FetchDescriptor<PredictionSnapshot>()))?.count ?? 0
+        #expect(afterFirst == 2)   // eod + month (no rate-limit history)
+
+        // Unchanged answers a minute later: no new rows.
+        await engine.recompute(now: Self.now.addingTimeInterval(60), calendar: Self.utc)
+        let afterSecond = (try? context.fetch(FetchDescriptor<PredictionSnapshot>()))?.count ?? 0
+        #expect(afterSecond == afterFirst)
+
+        // Past the heartbeat: each surface re-records "still saying this".
+        await engine.recompute(now: Self.now.addingTimeInterval(UsageIntelligenceEngine.snapshotHeartbeat + 61),
+                               calendar: Self.utc)
+        let afterHeartbeat = (try? context.fetch(FetchDescriptor<PredictionSnapshot>()))?.count ?? 0
+        #expect(afterHeartbeat == afterFirst * 2)
+
+        // Rows carry the version tags the replay harness keys on.
+        let rows = (try? context.fetch(FetchDescriptor<PredictionSnapshot>())) ?? []
+        #expect(rows.allSatisfy { $0.paramsVersion == EngineParams.version })
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/ShadowModelTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ShadowModelTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+/// Shadow candidates: they score into the record from day one, but the
+/// promotion floor keeps a thin (lucky) record off the screen.
+@Suite("Shadow model candidates")
+struct ShadowModelTests {
+
+    static var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+    static let now = utc.date(from: DateComponents(year: 2026, month: 7, day: 6, hour: 14))!
+
+    /// `periods` distinct scored periods where `method` beats `rival` (1pp vs 5pp error).
+    private func records(method: String, rival: String, periods: Int) -> [EngineSelfEval.Record] {
+        (0..<periods).flatMap { i -> [EngineSelfEval.Record] in
+            let key = "2026-06-\(String(format: "%02d", i + 1))"
+            return [
+                .init(method: method, bucket: "cut=0.50", periodKey: key, predicted: 51, truth: 50),
+                .init(method: rival, bucket: "cut=0.50", periodKey: key, predicted: 55, truth: 50),
+            ]
+        }
+    }
+
+    @Test func shadowCannotBePromotedBelowItsFloor() {
+        // Kalman wins every period, but with only 10 < 15 scored periods the
+        // gate holds and the established rival is selected.
+        let recs = records(method: "kalman-trend", rival: "recency-weighted", periods: 10)
+        let pick = EngineSelfEval.bestMethod(
+            from: recs, provisionalMinPeriods: ["kalman-trend": 15])
+        #expect(pick == "recency-weighted")
+    }
+
+    @Test func shadowPromotesOnceFloorIsMetAndItWins() {
+        let recs = records(method: "kalman-trend", rival: "recency-weighted", periods: 15)
+        let pick = EngineSelfEval.bestMethod(
+            from: recs, provisionalMinPeriods: ["kalman-trend": 15])
+        #expect(pick == "kalman-trend")
+    }
+
+    @Test func shadowFloorsCoverKalmanEverywhereAndDiurnalOnFiveHourOnly() {
+        let fiveH = UsageIntelligenceEngine.rlShadowFloors(.fiveHour)
+        let sevenD = UsageIntelligenceEngine.rlShadowFloors(.sevenDay)
+        #expect(fiveH["kalman-trend"] == EngineParams.current.shadowPromotionMinPeriods)
+        #expect(fiveH["diurnal-rate"] == EngineParams.current.shadowPromotionMinPeriods)
+        #expect(sevenD["kalman-trend"] == EngineParams.current.shadowPromotionMinPeriods)
+        #expect(sevenD["diurnal-rate"] == nil)   // established on 7d, not a shadow
+    }
+
+    @Test func kalmanIsInTheDefaultRosterSoItAccumulatesRecord() {
+        #expect(BurnTrajectory.defaultModels.contains { $0.id == "kalman-trend" })
+    }
+
+    // MARK: - KalmanTrend fit sanity
+
+    private func cycle(slopePerHour: Double, hours: Double, noise: [Double] = []) -> BurnTrajectory.PartialCycle {
+        let start = Self.now.addingTimeInterval(-hours * 3600)
+        var samples: [BurnTrajectory.Sample] = []
+        var i = 0
+        var t = 0.0
+        while t <= hours {
+            let jitter = noise.isEmpty ? 0 : noise[i % noise.count]
+            samples.append(.init(at: start.addingTimeInterval(t * 3600),
+                                 usedPercentage: 10 + slopePerHour * t + jitter))
+            t += 0.25
+            i += 1
+        }
+        return .init(samples: samples, now: Self.now, cycleStart: start,
+                     resetsAt: Self.now.addingTimeInterval(2 * 3600))
+    }
+
+    @Test func kalmanRecoversACleanLinearSlope() throws {
+        let c = cycle(slopePerHour: 8, hours: 3)
+        let projection = try #require(BurnTrajectory.KalmanTrend().fit(c))
+        // One hour ahead of the last sample the projection should climb ≈8pp.
+        let atNow = projection(Self.now)
+        let inOneHour = projection(Self.now.addingTimeInterval(3600))
+        #expect(abs((inOneHour - atNow) - 8) < 1.0)
+    }
+
+    @Test func kalmanSmoothsZeroMeanNoiseInsteadOfChasingIt() throws {
+        let c = cycle(slopePerHour: 4, hours: 3, noise: [0.6, -0.6, 0.3, -0.3])
+        let projection = try #require(BurnTrajectory.KalmanTrend().fit(c))
+        let atNow = projection(Self.now)
+        let inOneHour = projection(Self.now.addingTimeInterval(3600))
+        #expect(abs((inOneHour - atNow) - 4) < 1.5)
+    }
+
+    @Test func kalmanDeclinesTinyCycles() {
+        var c = cycle(slopePerHour: 5, hours: 3)
+        c = .init(samples: Array(c.samples.prefix(2)), now: c.now,
+                  cycleStart: c.cycleStart, resetsAt: c.resetsAt)
+        #expect(BurnTrajectory.KalmanTrend().fit(c) == nil)
+    }
+}

--- a/docs/intelligence-engine.md
+++ b/docs/intelligence-engine.md
@@ -132,6 +132,34 @@ Selection — EOD pools, RL picks — reads the accumulated record, so the engin
 regime shifts. Nothing trained on any other user ships; the only shared
 numbers are generic statistical bars (pool tolerance, minimum support).
 
+Three layers close the loop end-to-end (2026-07):
+
+- **Prediction trail** (`PredictionSnapshot`): every displayed answer is
+  recorded with its band, conformal stratum + residual count, anchor shift,
+  live state, and version tags — change-at-display-precision writes with a
+  30-min heartbeat, 180-day retention, exported at
+  `GET /v1/predictions/history`. The eval table says how methods did; the
+  trail says what the user was actually shown, and why.
+- **Versioned knobs** (`EngineParams`): all tuning constants live in one
+  struct whose `versionTag` is derived from the values (FNV over a canonical
+  string, bit-identical to the Python harness). The app never mutates its own
+  parameters; changes arrive as reviewed code and re-tag the trail
+  automatically.
+- **Shadow candidates**: new models (`kalman-trend` everywhere, the diurnal
+  model on 5h) score into the record from day one but can't be displayed
+  until they clear `shadowPromotionMinPeriods` completed periods AND win on
+  realized error — display is earned, never granted to a lucky thin record.
+  Cold-start selection skips shadows entirely.
+
+The tuning loop itself lives out-of-app in `research/harness` (Python/uv):
+a walk-forward replay of this whole pipeline over the real store (~1s for
+all history) scoring point error, **80%-band coverage**, pinball, and Brier,
+plus a deterministic grid sweep whose adoption rule is the hysteresis — a
+knob change is recommended only when fold-robust (≥3 of 4 time folds, ≥5%
+median improvement, coverage within [0.70, 0.92]). First run (2026-07-06):
+5h bands are honest (coverage 0.785 on 1032 cases); 7d bands under-cover
+(0.589 on 70 cases) — a cycle-count problem, not a knob problem.
+
 ## Presentation rules (the research, distilled)
 
 Uncertainty communication follows the weather/fintech evidence: a
@@ -155,7 +183,8 @@ evening accuracy from its own record.
   online coverage tracker (P-control on alpha) is the safety net to add with it.
 - CreateML tabular candidate joins the EOD roster via the scoreboard at ~6
   months of data.
-- 5-hour window: diurnal structure is a measured null (too short to straddle
-  day/night); cap-hit early-warning there has an information wall (44→100% in
-  12 minutes once observed). Don't rebuild these; they're not broken, they're
-  impossible.
+- 5-hour window: diurnal structure was a measured null in 2026-06 (too short
+  to straddle day/night) — now re-tested continuously as a promotion-gated
+  shadow candidate instead of trusted forever. Cap-hit early-warning there
+  has an information wall (44→100% in 12 minutes once observed); that one IS
+  impossible, don't rebuild it.

--- a/research/harness/.gitignore
+++ b/research/harness/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+uv.lock

--- a/research/harness/README.md
+++ b/research/harness/README.md
@@ -1,0 +1,55 @@
+# Pacer prediction replay harness
+
+Python (uv) port of the rate-limit prediction pipeline, replayed **walk-forward**
+over the real store: every prediction is made with only the data that existed
+at prediction time, then scored against what actually happened. This is where
+model/parameter changes earn their way into the app — research in Python,
+ship in Swift.
+
+```
+uv run pacer_replay.py            # score the shipping configuration
+uv run sweep.py                   # grid-sweep the EngineParams knobs
+uv run sweep.py --full --json     # bigger grid, machine-readable
+```
+
+The store (`pacer.sqlite` in the app group) is copied to a temp dir and opened
+read-only — the live app is never touched. A full-history replay takes ~1s,
+which is why the sweep is a plain deterministic grid: no need for random
+search, and every run is reproducible.
+
+## Scores
+
+| metric | meaning | healthy |
+|---|---|---|
+| `medianAbsErrorPP` | end-at-reset point error (pp) | lower |
+| `coverage80` | how often truth landed inside the stated 80% band | ≈ 0.80 |
+| `meanPinball` | q10/q90 quantile quality | lower |
+| `brier` | "hits the limit before reset" probability quality | lower |
+| `bandStatedShare` | how often the residual gate allowed a band at all | context |
+
+`coverage80` is the one to watch: > 0.9 means the bands are wastefully wide
+(the old "5 min–32 hr" failure mode), < 0.7 means they're overconfident.
+
+## Adoption protocol (the hysteresis)
+
+`sweep.py` recommends a parameter change **only** when the candidate beats the
+shipping baseline in ≥ 3 of 4 contiguous time folds, improves the overall
+median by ≥ 5%, and keeps coverage inside [0.70, 0.92]. A "no recommendation"
+result is the hysteresis working — noise doesn't move parameters.
+
+Winners land in Swift (`PacerCore/.../Forecast/Engine/EngineParams.swift`) as
+a reviewed code change. The `Params` dataclass here mirrors `EngineParams`
+exactly, including the canonical string and FNV version tag, so the tag the
+sweep prints is the tag the app will record into its prediction snapshots
+(`PredictionSnapshot.paramsVersion`, exported at `/v1/predictions/history`).
+`EngineParamsTests.versionTagMatchesPythonHarness` pins the cross-language
+parity — if either side drifts, CI fails.
+
+## What it does / doesn't replay
+
+Replayed: cycle segmentation, all six burn-trajectory models (including the
+shadow Kalman + diurnal), record-driven selection with shadow promotion
+floors, live-value anchoring, stratified additive conformal bands with the
+gated quantiles. Not replayed (yet): the EOD/month cost surfaces and their
+pool selection — extend `Params` + `replay_window` when those knobs need
+sweeping.

--- a/research/harness/pacer_replay.py
+++ b/research/harness/pacer_replay.py
@@ -1,0 +1,666 @@
+"""Replay Pacer's rate-limit prediction pipeline over the real store, walk-forward.
+
+Faithful Python ports of the Swift engine's pieces (BurnTrajectory models,
+DiurnalBurnModel, stratified additive conformal, method selection with shadow
+floors), driven by the same raw RateLimitSample rows the app reads. Every
+prediction is made using only data that existed at prediction time, then
+scored against the realized cycle:
+
+- absolute error of the end-at-reset point (percentage points)
+- 80% interval coverage (should be ~0.80 if the bands are honest)
+- pinball loss at q10/q90 (the band's quantile quality)
+- Brier score for "hits the limit before reset"
+
+Usage:
+    uv run pacer_replay.py                 # replay both windows, current params
+    uv run pacer_replay.py --window seven_day
+    uv run pacer_replay.py --store /path/to/pacer.sqlite
+
+The store is copied to a temp dir first and opened read-only — the live app
+is never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+CORE_DATA_EPOCH = 978307200.0  # 2001-01-01 → unix offset
+GROUP_DIR = Path.home() / "Library/Group Containers/YZXWMJ5VBY.com.ericandrechek.pacer"
+
+WINDOW_SECONDS = {"five_hour": 5 * 3600.0, "seven_day": 7 * 24 * 3600.0}
+
+# Segmentation thresholds (BurnTrajectory.resetDropPoints / resetLowMax).
+RESET_DROP_POINTS = 15.0
+RESET_LOW_MAX = 5.0
+
+# Scoring cuts (EngineSelfEval.rlCutFractions).
+RL_CUT_FRACTIONS = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+
+
+# ---------------------------------------------------------------------------
+# Parameters (mirror EngineParams — canonical string must match Swift)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Params:
+    conformal_min_residuals: int = 8
+    rl_stratum_min_scores: int = 10
+    pool_tolerance: float = 1.25
+    pool_min_periods: int = 10
+    pool_recency_window: int = 30
+    linear_recent_lookback_fraction: float = 0.3
+    recency_half_life_fraction: float = 0.15
+    shadow_promotion_min_periods: int = 15
+
+    def canonical(self) -> str:
+        def g(v: float) -> str:
+            return f"{v:g}"
+
+        return ";".join([
+            f"conformalMinResiduals={self.conformal_min_residuals}",
+            f"rlStratumMinScores={self.rl_stratum_min_scores}",
+            f"poolTolerance={g(self.pool_tolerance)}",
+            f"poolMinPeriods={self.pool_min_periods}",
+            f"poolRecencyWindow={self.pool_recency_window}",
+            f"linearRecentLookbackFraction={g(self.linear_recent_lookback_fraction)}",
+            f"recencyHalfLifeFraction={g(self.recency_half_life_fraction)}",
+            f"shadowPromotionMinPeriods={self.shadow_promotion_min_periods}",
+        ])
+
+    def version_tag(self) -> str:
+        h = 0xCBF29CE484222325
+        for b in self.canonical().encode():
+            h ^= b
+            h = (h * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+        return "v1-" + format(h & 0xFFFFFFFF, "08x")
+
+
+# ---------------------------------------------------------------------------
+# Store access (read-only copy)
+# ---------------------------------------------------------------------------
+
+def locate_store(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser()
+    hits = sorted(GROUP_DIR.rglob("pacer.sqlite"))
+    if not hits:
+        raise SystemExit(f"no pacer.sqlite under {GROUP_DIR} — pass --store")
+    return hits[0]
+
+
+def open_copy(store: Path) -> sqlite3.Connection:
+    tmp = Path(tempfile.mkdtemp(prefix="pacer-harness-"))
+    for suffix in ("", "-wal", "-shm"):
+        src = Path(str(store) + suffix)
+        if src.exists():
+            shutil.copy2(src, tmp / src.name)
+    conn = sqlite3.connect(f"file:{tmp / store.name}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _cols(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def load_rate_samples(conn: sqlite3.Connection, window: str) -> list[tuple[float, float, float]]:
+    """(at_unix, used_pct, resets_unix) sorted by time, resets non-null only."""
+    cols = _cols(conn, "ZRATELIMITSAMPLE")
+    need = {"ZSAMPLEDAT", "ZUSEDPERCENTAGE", "ZWINDOW", "ZRESETSAT"}
+    if not need <= cols:
+        raise SystemExit(f"ZRATELIMITSAMPLE columns {sorted(cols)} missing {sorted(need - cols)}")
+    rows = conn.execute(
+        "SELECT ZSAMPLEDAT, ZUSEDPERCENTAGE, ZRESETSAT FROM ZRATELIMITSAMPLE "
+        "WHERE ZWINDOW = ? AND ZRESETSAT IS NOT NULL ORDER BY ZSAMPLEDAT",
+        (window,),
+    ).fetchall()
+    return [(r[0] + CORE_DATA_EPOCH, float(r[1]), r[2] + CORE_DATA_EPOCH) for r in rows]
+
+
+def load_activity_grid(conn: sqlite3.Connection) -> list[list[float]]:
+    """P(active)[weekday 0=Sun..6=Sat][hour] from hourly aggregates — the
+    diurnal prior. Idle days count in the denominator (gaps are real zeros).
+    A missing/renamed table degrades to a uniform (absent) prior."""
+    try:
+        rows = conn.execute(
+            "SELECT ZDATE, ZHOUR, SUM(ZTOTALCOSTUSD) FROM ZHOURLYAGGREGATE GROUP BY ZDATE, ZHOUR"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return [[0.0] * 24 for _ in range(7)]
+    active: dict[str, set[int]] = {}
+    for date_key, hour, cost in rows:
+        if cost and cost > 0:
+            active.setdefault(date_key, set()).add(int(hour))
+    if not active:
+        return [[0.0] * 24 for _ in range(7)]
+    days = sorted(active)
+    first = datetime.strptime(days[0], "%Y-%m-%d").date()
+    last = datetime.strptime(days[-1], "%Y-%m-%d").date()
+    num = [[0.0] * 24 for _ in range(7)]
+    den = [0.0] * 7
+    day = first
+    from datetime import timedelta
+    while day <= last:
+        wd = (day.weekday() + 1) % 7  # python Mon=0 → gregorian Sun=0
+        den[wd] += 1
+        for h in active.get(day.strftime("%Y-%m-%d"), ()):
+            num[wd][h] += 1
+        day += timedelta(days=1)
+    return [[(num[wd][h] / den[wd]) if den[wd] > 0 else 0.0 for h in range(24)] for wd in range(7)]
+
+
+# ---------------------------------------------------------------------------
+# Cycle segmentation (port of BurnTrajectory.segment)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Cycle:
+    samples: list[tuple[float, float]]  # (at_unix, used_pct)
+    cycle_start: float
+    resets_at: float
+
+    @property
+    def final(self) -> float:
+        return max(p for _, p in self.samples)
+
+    @property
+    def duration(self) -> float:
+        return self.resets_at - self.cycle_start
+
+
+def _post_reset_start(rows: list[tuple[float, float, float]]) -> int:
+    split = 0
+    for i in range(1, len(rows)):
+        if rows[i - 1][1] - rows[i][1] >= RESET_DROP_POINTS and rows[i][1] <= RESET_LOW_MAX:
+            split = i
+    return split
+
+
+def segment(samples: list[tuple[float, float, float]], duration: float) -> list[Cycle]:
+    """All cycles (completed = all but the one with the max reset key)."""
+    groups: dict[float, list[tuple[float, float, float]]] = {}
+    for s in samples:
+        key = round(s[2] / 60.0) * 60.0
+        groups.setdefault(key, []).append(s)
+    cycles: list[Cycle] = []
+    for key, rows in groups.items():
+        rows = sorted(rows)
+        split = _post_reset_start(rows)
+        kept = rows[split:]
+        if not kept:
+            continue
+        reset = max(r[2] for r in kept)
+        start = rows[split - 1][0] if split > 0 else reset - duration
+        cycles.append(Cycle([(r[0], r[1]) for r in kept], start, reset))
+    return sorted(cycles, key=lambda c: c.cycle_start)
+
+
+# ---------------------------------------------------------------------------
+# Model ports (BurnTrajectoryModels + DiurnalBurnModel)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Partial:
+    samples: list[tuple[float, float]]
+    now: float
+    cycle_start: float
+    resets_at: float
+
+    def hours(self, at: float) -> float:
+        return (at - self.cycle_start) / 3600.0
+
+    @property
+    def duration_hours(self) -> float:
+        return (self.resets_at - self.cycle_start) / 3600.0
+
+    @property
+    def used_now(self) -> float:
+        return self.samples[-1][1] if self.samples else 0.0
+
+
+def _ls_line(pts: list[tuple[float, float]]):
+    n = float(len(pts))
+    sx = sum(p[0] for p in pts)
+    sy = sum(p[1] for p in pts)
+    sxx = sum(p[0] * p[0] for p in pts)
+    sxy = sum(p[0] * p[1] for p in pts)
+    det = n * sxx - sx * sx
+    if abs(det) <= 1e-9:
+        return None
+    return (n * sxy - sx * sy) / det, (sy * sxx - sx * sxy) / det
+
+
+def linear_recent(c: Partial, params: Params):
+    cutoff = c.hours(c.now) - c.duration_hours * params.linear_recent_lookback_fraction
+    pts = [(c.hours(a), p) for a, p in c.samples if c.hours(a) >= cutoff]
+    used = pts if len(pts) >= 2 else [(c.hours(a), p) for a, p in c.samples]
+    if len(used) < 2:
+        return None
+    line = _ls_line(used)
+    if line is None:
+        return None
+    slope, intercept = line
+    return lambda t: slope * ((t - c.cycle_start) / 3600.0) + intercept
+
+
+def _trend_fit(c: Partial, params: Params, *, min_samples: int, damping_tau_s: float,
+               max_accel_frac: float):
+    """TrendEstimator.fit port (weighted LS in half-life units)."""
+    half_life_h = c.duration_hours * params.recency_half_life_fraction
+    if half_life_h <= 0:
+        return None
+    min_span = max(300.0, c.duration_hours * 3600.0 * 0.05)
+    recent = sorted((a, v) for a, v in c.samples if a <= c.now)
+    if len(recent) < min_samples or recent[-1][0] - recent[0][0] < min_span:
+        return None
+    rows = []
+    for a, v in recent:
+        u = ((a - c.now) / 3600.0) / half_life_h
+        rows.append((u, v, 2.0 ** u))
+    s0 = s1 = s2 = s3 = s4 = t0 = t1 = t2 = 0.0
+    for u, v, w in rows:
+        u2 = u * u
+        s0 += w; s1 += w * u; s2 += w * u2; s3 += w * u2 * u; s4 += w * u2 * u2
+        t0 += w * v; t1 += w * v * u; t2 += w * v * u2
+    det = s0 * s2 - s1 * s1
+    if abs(det) <= 1e-12:
+        return None
+    a_lin = (t0 * s2 - t1 * s1) / det
+    b_lin = (s0 * t1 - s1 * t0) / det
+    level, slope_ph = a_lin, b_lin / half_life_h
+    accel = 0.0
+    if len({u for u, _, _ in rows}) >= 3:
+        # Cramer's rule for the quadratic normal equations; c is the third
+        # unknown, so its numerator replaces the third column with t.
+        d = (s0 * (s2 * s4 - s3 * s3) - s1 * (s1 * s4 - s3 * s2) + s2 * (s1 * s3 - s2 * s2))
+        if abs(d) > 1e-12:
+            cq = (s0 * (s2 * t2 - t1 * s3) - s1 * (s1 * t2 - t1 * s2) + t0 * (s1 * s3 - s2 * s2))
+            accel = 2 * (cq / d) / (half_life_h * half_life_h)
+    tau_h = damping_tau_s / 3600.0
+    max_boost = max_accel_frac * abs(slope_ph)
+    if tau_h > 0 and math.isfinite(max_boost):
+        cap = max_boost / tau_h
+        accel_e = max(-cap, min(cap, accel))
+    else:
+        accel_e = 0.0 if tau_h <= 0 else accel
+    now = c.now
+
+    def project(t: float) -> float:
+        h = (t - now) / 3600.0
+        linear = level + slope_ph * h
+        if tau_h <= 0 or accel_e == 0:
+            return linear
+        return linear + accel_e * tau_h * (h - tau_h * (1 - math.exp(-h / tau_h)))
+
+    return project
+
+
+def recency_weighted(c: Partial, params: Params):
+    return _trend_fit(c, params, min_samples=3, damping_tau_s=3600.0, max_accel_frac=0.0)
+
+
+def damped_acceleration(c: Partial, params: Params):
+    remaining = max(3600.0, c.resets_at - c.now)
+    return _trend_fit(c, params, min_samples=4, damping_tau_s=remaining, max_accel_frac=1.0)
+
+
+def saturating(c: Partial, params: Params):
+    s = [c.hours(a) for a, _ in c.samples]
+    y = [p for _, p in c.samples]
+    if len(s) < 3 or max(y) <= 0:
+        return None
+    y_max = max(y)
+    best = None
+    ceiling = 1.05
+    while ceiling <= 2.5:
+        big_l = max(y_max * ceiling, y_max + 1)
+        sk = ss = 0.0
+        for si, yi in zip(s, y):
+            if 0 < yi < big_l * 0.999:
+                z = -math.log(1 - yi / big_l)
+                sk += si * z
+                ss += si * si
+        if ss > 1e-9:
+            k = sk / ss
+            if k > 0:
+                sse = sum((big_l * (1 - math.exp(-k * si)) - yi) ** 2 for si, yi in zip(s, y))
+                if best is None or sse < best[0]:
+                    best = (sse, big_l, k)
+        ceiling += 0.05
+    if best is None:
+        return None
+    _, big_l, k = best
+    start = c.cycle_start
+    return lambda t: big_l * (1 - math.exp(-k * ((t - start) / 3600.0)))
+
+
+def kalman_trend(c: Partial, params: Params):
+    samples = c.samples
+    if len(samples) < 3:
+        return None
+    q, r = 0.5 ** 2, 0.5 ** 2
+    level, slope = samples[0][1], 0.0
+    p00, p01, p11 = 25.0, 0.0, 25.0
+    last_t = c.hours(samples[0][0])
+    for a, v in samples[1:]:
+        t = c.hours(a)
+        dt = max(1e-3, t - last_t)
+        last_t = t
+        level += slope * dt
+        np00 = p00 + 2 * dt * p01 + dt * dt * p11 + q * dt ** 3 / 3
+        np01 = p01 + dt * p11 + q * dt * dt / 2
+        np11 = p11 + q * dt
+        innov = v - level
+        denom = np00 + r
+        if denom <= 1e-12:
+            return None
+        k0, k1 = np00 / denom, np01 / denom
+        level += k0 * innov
+        slope += k1 * innov
+        p00, p01, p11 = (1 - k0) * np00, (1 - k0) * np01, np11 - k1 * np01
+    if not (math.isfinite(level) and math.isfinite(slope)):
+        return None
+    anchor_h, start = last_t, c.cycle_start
+    return lambda t: level + slope * ((t - start) / 3600.0 - anchor_h)
+
+
+def diurnal_rate_table(cycles: list[Cycle], prior: list[list[float]] | None,
+                       pseudocount: float = 6.0) -> list[list[float]]:
+    sums = [[0.0] * 24 for _ in range(7)]
+    cnt = [[0.0] * 24 for _ in range(7)]
+    for cyc in cycles:
+        s = sorted(cyc.samples)
+        for i in range(1, len(s)):
+            dt = s[i][0] - s[i - 1][0]
+            if dt <= 0:
+                continue
+            rate = max(0.0, s[i][1] - s[i - 1][1]) / dt
+            mid = datetime.fromtimestamp(s[i - 1][0] + dt / 2)
+            wd = (mid.weekday() + 1) % 7
+            sums[wd][mid.hour] += rate
+            cnt[wd][mid.hour] += 1
+    obs = [[0.0] * 24 for _ in range(7)]
+    populated = []
+    for wd in range(7):
+        for h in range(24):
+            if cnt[wd][h] > 0:
+                obs[wd][h] = sums[wd][h] / cnt[wd][h]
+                populated.append(obs[wd][h])
+    mean = sum(populated) / len(populated) if populated else 0.0
+    if mean > 0:
+        obs = [[v / mean for v in row] for row in obs]
+    if prior and len(prior) == 7 and all(len(r) == 24 for r in prior):
+        flat = [v for row in prior for v in row]
+        pm = sum(flat) / len(flat)
+        pri = [[v / pm for v in row] for row in prior] if pm > 0 else [[1.0] * 24 for _ in range(7)]
+    else:
+        pri = [[1.0] * 24 for _ in range(7)]
+    table = [[0.0] * 24 for _ in range(7)]
+    for wd in range(7):
+        for h in range(24):
+            n = cnt[wd][h]
+            w = n / (n + pseudocount)
+            table[wd][h] = w * (obs[wd][h] if n > 0 else 0.0) + (1 - w) * pri[wd][h]
+    return table
+
+
+def diurnal_integrate(table: list[list[float]], a: float, b: float, step: float = 600.0) -> float:
+    if b <= a or step <= 0:
+        return 0.0
+    total, t = 0.0, a
+    while t < b:
+        dt = min(step, b - t)
+        mid = datetime.fromtimestamp(t + dt / 2)
+        wd = (mid.weekday() + 1) % 7
+        total += table[wd][mid.hour] * dt
+        t += step
+    return total
+
+
+def diurnal_fit(table: list[list[float]]):
+    def fit(c: Partial, params: Params):
+        used = c.used_now
+        if used <= 0:
+            return None
+        observed = diurnal_integrate(table, c.cycle_start, c.now)
+        if observed <= 0:
+            return None
+        level = used / observed
+        origin, base = c.now, used
+        return lambda t: base + (level * diurnal_integrate(table, origin, t) if t > origin else 0.0)
+    return fit
+
+
+MODEL_COMPLEXITY = {
+    "linear-recent": 1, "recency-weighted": 2, "saturating": 3,
+    "damped-acceleration": 4, "kalman-trend": 5, "diurnal-rate": 3,
+}
+SHADOW_IDS = {"five_hour": {"kalman-trend", "diurnal-rate"}, "seven_day": {"kalman-trend"}}
+
+
+def model_roster(diurnal_table):
+    return {
+        "linear-recent": linear_recent,
+        "recency-weighted": recency_weighted,
+        "damped-acceleration": damped_acceleration,
+        "saturating": saturating,
+        "kalman-trend": kalman_trend,
+        "diurnal-rate": diurnal_fit(diurnal_table),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Conformal (stratified additive) + selection
+# ---------------------------------------------------------------------------
+
+def stratum_key(cut_fraction: float, cycle_start: float) -> str:
+    phase = "early" if cut_fraction < 0.5 else "late"
+    wd = datetime.fromtimestamp(cycle_start).weekday()  # Mon=0
+    regime = "weekend" if wd >= 5 else "weekday"
+    return f"{phase}|{regime}"
+
+
+def gated_quantile(residuals: list[float], p: float, min_residuals: int) -> float | None:
+    n = len(residuals)
+    if n < min_residuals:
+        return None
+    rank = math.ceil((n + 1) * p)
+    return sorted(residuals)[min(max(rank, 1), n) - 1]
+
+
+def collect_residuals(model_fit, params: Params, history: list[Cycle]) -> dict[str, list[float]]:
+    """Walk-forward residuals (truth_final − projection at reset), stratified,
+    with the pooled fallback — port of stratifiedRLCalibrators."""
+    by: dict[str, list[float]] = {"pooled": []}
+    for cyc in history:
+        true_final = cyc.final
+        if true_final <= 0:
+            continue
+        for cf in RL_CUT_FRACTIONS:
+            cut_now = cyc.cycle_start + cyc.duration * cf
+            seen = [s for s in cyc.samples if s[0] <= cut_now]
+            if len(seen) < 3:
+                continue
+            partial = Partial(seen, cut_now, cyc.cycle_start, cyc.resets_at)
+            proj = model_fit(partial, params)
+            if proj is None:
+                continue
+            residual = true_final - proj(cyc.resets_at)
+            by["pooled"].append(residual)
+            by.setdefault(stratum_key(cf, cyc.cycle_start), []).append(residual)
+    return {k: v for k, v in by.items() if k == "pooled" or len(v) >= params.rl_stratum_min_scores}
+
+
+def best_method(record: dict[str, dict[str, list[float]]], window: str, params: Params) -> str | None:
+    """Port of EngineSelfEval.bestMethod: lowest median |err|, ties within
+    1.5pp to the simpler model, shadow floors applied."""
+    scored = []
+    for mid, per_period in record.items():
+        floor = params.shadow_promotion_min_periods if mid in SHADOW_IDS[window] else 2
+        if len(per_period) < floor:
+            continue
+        errs = [e for es in per_period.values() for e in es]
+        errs.sort()
+        n = len(errs)
+        med = errs[n // 2] if n % 2 else (errs[n // 2 - 1] + errs[n // 2]) / 2
+        scored.append((mid, med, MODEL_COMPLEXITY.get(mid, 3)))
+    if not scored:
+        return None
+    best = min(scored, key=lambda x: x[1])
+    near = [x for x in scored if x[1] <= best[1] + 1.5]
+    return min(near, key=lambda x: (x[2], x[1]))[0]
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def pinball(truth: float, pred: float, q: float) -> float:
+    d = truth - pred
+    return q * d if d >= 0 else (q - 1) * d
+
+
+@dataclass
+class CaseScore:
+    cycle_index: int
+    cut: float
+    method: str
+    abs_error: float
+    covered80: bool | None       # None when no band was stated
+    pinball_q10: float | None
+    pinball_q90: float | None
+    brier: float
+    truth_hit: bool
+    band_stated: bool
+
+
+def replay_window(window: str, samples, activity_grid, params: Params) -> list[CaseScore]:
+    duration = WINDOW_SECONDS[window]
+    cycles = segment(samples, duration)
+    completed = cycles[:-1] if cycles else []   # last group = current/live
+    scores: list[CaseScore] = []
+    # record[m][period_key] = [abs errors] — accumulated walk-forward.
+    record: dict[str, dict[str, list[float]]] = {}
+
+    for i, cyc in enumerate(completed):
+        history = completed[:i]
+        table = diurnal_rate_table(history, activity_grid)
+        roster = model_roster(table)
+        truth = cyc.final
+        if truth <= 0:
+            continue
+        truth_hit = truth >= 99.5
+
+        # Selection and the calibrator depend only on the record/history, not
+        # the cut — resolve once per cycle (the walk over cuts is the hot loop).
+        chosen = best_method(record, window, params) or (
+            "diurnal-rate" if window == "seven_day" else "recency-weighted")
+        residuals = collect_residuals(roster[chosen], params, history)
+
+        for cf in RL_CUT_FRACTIONS:
+            cut_now = cyc.cycle_start + cyc.duration * cf
+            seen = [s for s in cyc.samples if s[0] <= cut_now]
+            if len(seen) < 3:
+                continue
+            partial = Partial(seen, cut_now, cyc.cycle_start, cyc.resets_at)
+            proj = roster[chosen](partial, params)
+            if proj is None:
+                continue
+            anchor = max(0.0, partial.used_now - proj(cut_now))
+            raw = proj(cyc.resets_at) + anchor
+            point = min(100.0, max(partial.used_now, raw))
+
+            strat = residuals.get(stratum_key(cf, cyc.cycle_start), residuals.get("pooled", []))
+            lo = gated_quantile(strat, 0.1, params.conformal_min_residuals)
+            hi = gated_quantile(strat, 0.9, params.conformal_min_residuals)
+            band_stated = lo is not None and hi is not None
+            covered = (min(raw + lo, raw + hi) <= truth <= max(raw + lo, raw + hi)) if band_stated else None
+            pb10 = pinball(truth, raw + lo, 0.1) if band_stated else None
+            pb90 = pinball(truth, raw + hi, 0.9) if band_stated else None
+            # Hit probability: empirical share of residual-shifted outcomes ≥100
+            # (conformal predictive), falling back to the deterministic call.
+            if len(strat) >= params.conformal_min_residuals:
+                p_hit = sum(1 for r in strat if raw + r >= 100.0) / len(strat)
+            else:
+                p_hit = 1.0 if point >= 100.0 else 0.0
+            scores.append(CaseScore(i, cf, chosen, abs(point - truth), covered,
+                                    pb10, pb90, (p_hit - (1.0 if truth_hit else 0.0)) ** 2,
+                                    truth_hit, band_stated))
+
+        # After the cycle completes, extend every model's record (walk-forward).
+        period_key = str(round(cyc.resets_at / 60) * 60)
+        for mid, fit in roster.items():
+            for cf in RL_CUT_FRACTIONS:
+                cut_now = cyc.cycle_start + cyc.duration * cf
+                seen = [s for s in cyc.samples if s[0] <= cut_now]
+                if len(seen) < 3:
+                    continue
+                proj = fit(Partial(seen, cut_now, cyc.cycle_start, cyc.resets_at), params)
+                if proj is None:
+                    continue
+                record.setdefault(mid, {}).setdefault(period_key, []).append(
+                    abs(proj(cyc.resets_at) - truth))
+    return scores
+
+
+def summarize(scores: list[CaseScore]) -> dict:
+    if not scores:
+        return {"cases": 0}
+    errs = sorted(s.abs_error for s in scores)
+    n = len(errs)
+    banded = [s for s in scores if s.covered80 is not None]
+    out = {
+        "cases": n,
+        "medianAbsErrorPP": round(errs[n // 2] if n % 2 else (errs[n // 2 - 1] + errs[n // 2]) / 2, 2),
+        "meanAbsErrorPP": round(sum(errs) / n, 2),
+        "coverage80": round(sum(1 for s in banded if s.covered80) / len(banded), 3) if banded else None,
+        "bandStatedShare": round(len(banded) / n, 3),
+        "meanPinball": round(sum((s.pinball_q10 + s.pinball_q90) / 2 for s in banded) / len(banded), 3) if banded else None,
+        "brier": round(sum(s.brier for s in scores) / n, 4),
+        "capHitBaseRate": round(sum(1 for s in scores if s.truth_hit) / n, 3),
+        "methodShare": {},
+    }
+    for s in scores:
+        out["methodShare"][s.method] = out["methodShare"].get(s.method, 0) + 1
+    out["methodShare"] = {k: round(v / n, 3) for k, v in
+                          sorted(out["methodShare"].items(), key=lambda kv: -kv[1])}
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--store", help="path to pacer.sqlite (default: app group)")
+    ap.add_argument("--window", choices=["five_hour", "seven_day"], help="one window only")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    conn = open_copy(locate_store(args.store))
+    grid = load_activity_grid(conn)
+    params = Params()
+    report = {"paramsVersion": params.version_tag(), "params": params.canonical(), "windows": {}}
+    for window in ([args.window] if args.window else ["five_hour", "seven_day"]):
+        samples = load_rate_samples(conn, window)
+        scores = replay_window(window, samples, grid, params)
+        report["windows"][window] = summarize(scores)
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+    print(f"params {report['paramsVersion']}  ({report['params']})\n")
+    for window, s in report["windows"].items():
+        print(f"[{window}]  cases={s.get('cases', 0)}")
+        for k, v in s.items():
+            if k != "cases":
+                print(f"  {k:>20}: {v}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/research/harness/pyproject.toml
+++ b/research/harness/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "pacer-harness"
+version = "0.1.0"
+description = "Replay/backtest harness for Pacer's rate-limit prediction engine — walk-forward scoring and deterministic parameter sweeps over the real store."
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.uv]
+package = false

--- a/research/harness/sweep.py
+++ b/research/harness/sweep.py
@@ -1,0 +1,145 @@
+"""Deterministic parameter sweep over the replay harness — the tuning loop.
+
+Grid-sweeps the EngineParams knobs, replaying the WHOLE store walk-forward for
+each configuration (~1s per config), and recommends a change only when the
+winner is FOLD-ROBUST — this is the adoption hysteresis, kept out of the app
+by design:
+
+  a candidate is recommendable only if, versus the shipping baseline, it
+  1. improves the median |end-at-reset error| in ≥ 3 of 4 contiguous
+     time folds (not just on average),
+  2. improves the overall median by ≥ 5%, and
+  3. keeps 80%-band coverage inside [0.70, 0.92].
+
+Winners land in Swift's EngineParams as a reviewed code change; the printed
+canonical string / version tag matches what the app will then record into
+its prediction snapshots.
+
+Usage:
+    uv run sweep.py                       # default grid, both windows
+    uv run sweep.py --window seven_day --full
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+from dataclasses import replace
+
+from pacer_replay import (
+    CaseScore, Params, load_activity_grid, load_rate_samples, locate_store,
+    open_copy, replay_window, summarize,
+)
+
+FOLDS = 4
+
+DEFAULT_GRID = {
+    "linear_recent_lookback_fraction": [0.2, 0.3, 0.45],
+    "recency_half_life_fraction": [0.10, 0.15, 0.25],
+    "conformal_min_residuals": [5, 8, 12],
+}
+FULL_GRID = {
+    "linear_recent_lookback_fraction": [0.15, 0.2, 0.3, 0.4, 0.5],
+    "recency_half_life_fraction": [0.08, 0.10, 0.15, 0.20, 0.25, 0.35],
+    "conformal_min_residuals": [5, 8, 12, 20],
+    "rl_stratum_min_scores": [6, 10, 16],
+}
+
+
+def fold_medians(scores: list[CaseScore]) -> list[float | None]:
+    """Median |error| per contiguous time fold (by cycle index)."""
+    if not scores:
+        return [None] * FOLDS
+    max_idx = max(s.cycle_index for s in scores) + 1
+    out: list[float | None] = []
+    for f in range(FOLDS):
+        lo, hi = max_idx * f / FOLDS, max_idx * (f + 1) / FOLDS
+        errs = sorted(s.abs_error for s in scores if lo <= s.cycle_index < hi)
+        n = len(errs)
+        out.append(None if n == 0 else (errs[n // 2] if n % 2 else (errs[n // 2 - 1] + errs[n // 2]) / 2))
+    return out
+
+
+def robust_improvement(base_folds, cand_folds, base_med, cand_med, cand_cov) -> bool:
+    paired = [(b, c) for b, c in zip(base_folds, cand_folds) if b is not None and c is not None]
+    if len(paired) < 3:
+        return False
+    wins = sum(1 for b, c in paired if c < b)
+    if wins < max(3, len(paired) - 1):
+        return False
+    if base_med is None or cand_med is None or cand_med > base_med * 0.95:
+        return False
+    return cand_cov is not None and 0.70 <= cand_cov <= 0.92
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--store")
+    ap.add_argument("--window", choices=["five_hour", "seven_day"])
+    ap.add_argument("--full", action="store_true", help="the larger grid (~360 configs)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    conn = open_copy(locate_store(args.store))
+    grid_prior = load_activity_grid(conn)
+    windows = [args.window] if args.window else ["five_hour", "seven_day"]
+    samples = {w: load_rate_samples(conn, w) for w in windows}
+
+    grid = FULL_GRID if args.full else DEFAULT_GRID
+    keys = sorted(grid)
+    configs = [Params(), *(
+        replace(Params(), **dict(zip(keys, values)))
+        for values in itertools.product(*(grid[k] for k in keys))
+    )]
+    # De-dup (the baseline usually appears in the grid too).
+    seen, unique = set(), []
+    for p in configs:
+        if p.canonical() not in seen:
+            seen.add(p.canonical())
+            unique.append(p)
+
+    report: dict = {"baseline": Params().version_tag(), "windows": {}}
+    for window in windows:
+        rows = []
+        for i, p in enumerate(unique):
+            scores = replay_window(window, samples[window], grid_prior, p)
+            s = summarize(scores)
+            rows.append({
+                "tag": p.version_tag(), "canonical": p.canonical(),
+                "median": s.get("medianAbsErrorPP"), "coverage80": s.get("coverage80"),
+                "brier": s.get("brier"), "folds": fold_medians(scores),
+                "isBaseline": i == 0,
+            })
+            print(f"\r[{window}] {i + 1}/{len(unique)}", end="", flush=True)
+        print()
+        base = rows[0]
+        recommendable = [r for r in rows[1:] if robust_improvement(
+            base["folds"], r["folds"], base["median"], r["median"], r["coverage80"])]
+        recommendable.sort(key=lambda r: r["median"])
+        report["windows"][window] = {
+            "baseline": {k: base[k] for k in ("tag", "median", "coverage80", "brier")},
+            "recommend": recommendable[0] if recommendable else None,
+            "top5": sorted(rows, key=lambda r: (r["median"] is None, r["median"]))[:5],
+        }
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+    for window, r in report["windows"].items():
+        b = r["baseline"]
+        print(f"\n[{window}] baseline {b['tag']}: median {b['median']}pp, coverage {b['coverage80']}, brier {b['brier']}")
+        if r["recommend"]:
+            c = r["recommend"]
+            print(f"  RECOMMEND {c['tag']}: median {c['median']}pp, coverage {c['coverage80']} (fold-robust)")
+            print(f"    {c['canonical']}")
+        else:
+            print("  no fold-robust improvement — keep the baseline (this is the hysteresis working)")
+        print("  top 5 by median error:")
+        for row in r["top5"]:
+            mark = "*" if row["isBaseline"] else " "
+            print(f"   {mark} {row['tag']}  median={row['median']}  cov={row['coverage80']}  brier={row['brier']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes the prediction feedback loop end-to-end, and fixes the "limit in 5 min–32 hr" badge.

## What's here (5 commits)

- **fix(forecast): gated conformal bands + point-first chips** — `burnOutlook` shifted its curve by raw conformal quantiles with no minimum-sample gate; with only a handful of completed 7-day cycles the band saturated to the most extreme residual ever seen, producing degenerate "5 min–32 hr" ranges. Band shifts now gate on residual count (mirroring `interval()`), and the glanceable chip surfaces (menu bar, pace card, notification titles) show a point ETA — the calibrated range still speaks in the hover tooltip and notification body.
- **feat: prediction snapshot trail** — new `PredictionSnapshot` @Model records every displayed prediction with its evidence (bands, conformal stratum + residual count, anchor shift, live state, params/engine version tags). Change-at-display-precision writes with a 30-min heartbeat; 180-day retention; exported at `GET /v1/predictions/history` on the opt-in local API. `periodKey` joins to `EngineEvalOutcome` by equality for prediction→truth replay.
- **feat: EngineParams** — all estimator knobs in one versioned struct; the version tag is derived from the values (FNV over a canonical string) so any change re-tags the trail automatically. Bit-identical tag computed by the Python harness; a test pins cross-language parity (`v1-36d9fd53`).
- **feat: shadow model candidates** — `kalman-trend` (both windows) and the diurnal model (5h) score into the self-eval record from day one but can't be displayed until they clear 15 completed periods AND win on realized error. Cold-start selection never picks shadows. The 2026-06 "5h diurnal is a null" finding gets re-tested by data instead of trusted forever.
- **feat: research/harness** — Python/uv walk-forward replay of the whole rate-limit pipeline over the real store (~1s for all history), scoring point error, 80%-band coverage, pinball, and Brier, plus a deterministic grid sweep whose adoption rule is the hysteresis (fold-robust only).

## First real-store results

5h bands are honest (coverage **0.785** on 1032 walk-forward cases, median error 4.6pp); 7d bands under-cover (**0.589** on 70 cases) — a cycle-count problem, not a knob problem. The sweep recommends **no parameter change**: current values are fold-robust.

## Testing

538 PacerCore tests green (27 new: snapshot policy/drafts/actor round-trip, params parity, shadow gates, Kalman fit). Installed locally and verified live: snapshots recording, `/v1/predictions/history` serving rows with the matching params tag, and the real 5h window showing a coherent point ETA + tight calibrated band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrjwqXhsrvSuG9GaA9rE4j