### PR TITLE
7d band-coverage fix (per-cycle block conformal) + shadow-progress UI + weekly watchdog

### DIFF
--- a/App/Views/ProjectionDetailView.swift
+++ b/App/Views/ProjectionDetailView.swift
@@ -17,6 +17,7 @@ struct ProjectionCompareModal: View {
     @Environment(\.usageEngine) private var engine
     @Query private var samples: [RateLimitSample]
     @State private var trajectories: [BurnTrajectory.ScoredTrajectory] = []
+    @State private var accuracy: EngineSelfEval.Accuracy?
     @State private var loaded = false
 
     init(windowKey: String) {
@@ -91,7 +92,9 @@ struct ProjectionCompareModal: View {
                     resetsAt: data.resetsAt,
                     durationSeconds: duration,
                     actual: data.points,
-                    trajectories: overlays
+                    trajectories: overlays,
+                    accuracy: accuracy,
+                    shadowFloors: UsageIntelligenceEngine.rlShadowFloors(kind)
                 )
             } else if loaded {
                 Text("Not enough data to compare models yet.")
@@ -111,6 +114,7 @@ struct ProjectionCompareModal: View {
     private func refresh() async {
         guard let engine else { loaded = true; return }
         trajectories = await engine.rateLimitTrajectories(window: kind)
+        accuracy = await engine.selfEvalAccuracy(surface: EngineSelfEval.rlSurface(windowKey))
         loaded = true
     }
 }
@@ -125,6 +129,13 @@ struct ProjectionDetailView: View {
     let durationSeconds: TimeInterval
     let actual: [PaceChartView.Data.Point]
     let trajectories: [BurnTrajectory.ScoredTrajectory]
+    /// Per-method scored record for this window (completed cycles + median
+    /// miss) — powers the shadow-progress captions and the selected model's
+    /// earned-record footer. Nil until the engine has scored a cycle.
+    let accuracy: EngineSelfEval.Accuracy?
+    /// Shadow candidates for this window → the completed-cycle floor each
+    /// must clear before the engine may pick it for display.
+    let shadowFloors: [String: Int]
 
     /// Stable per-model colors for the lines and the legend swatches.
     private static let palette: [String: Color] = [
@@ -468,6 +479,37 @@ struct ProjectionDetailView: View {
 
     // MARK: - Accuracy table
 
+    /// Completed scored cycles for one method, from the persisted record.
+    private func scoredPeriods(_ modelId: String) -> Int {
+        accuracy?.methods.first(where: { $0.method == modelId })?.periods ?? 0
+    }
+
+    /// Shadow candidates are promotion-gated: they accumulate a scored record
+    /// like everyone else but can't drive the dashboard until they've banked
+    /// enough completed cycles AND win on realized error. Say so quietly, so
+    /// a new model visibly earns its place instead of appearing from nowhere.
+    /// Past the floor the caption collapses to "eligible" (and disappears on
+    /// a selected row — "on the dashboard" already says it graduated).
+    private func shadowCaption(_ st: BurnTrajectory.ScoredTrajectory) -> String? {
+        guard let floor = shadowFloors[st.modelId] else { return nil }
+        let periods = scoredPeriods(st.modelId)
+        guard periods < floor else { return st.isSelected ? nil : "eligible" }
+        return "earning trust — \(periods) of \(floor) cycles"
+    }
+
+    /// The selected model's earned record — how many completed cycles back
+    /// it. The miss itself already sits in the row's "within ±N%" column
+    /// (no number twice); the footer adds the depth of evidence behind the
+    /// pick. Only claim a record once it's meaningfully sized (≥ 5 cycles).
+    private var selectedRecordText: String? {
+        guard let selected = trajectories.first(where: { $0.isSelected }),
+              let stat = accuracy?.methods.first(where: { $0.method == selected.modelId }),
+              stat.periods >= 5
+        else { return nil }
+        return "Selected: \(BurnTrajectory.displayName(selected.modelId)) — "
+            + "earned on \(stat.periods) of your completed cycles."
+    }
+
     private var accuracyTable: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Column headers make the right-hand number self-explanatory —
@@ -490,8 +532,15 @@ struct ProjectionDetailView: View {
                     RoundedRectangle(cornerRadius: 2)
                         .fill(color(st.modelId))
                         .frame(width: 14, height: 4)
-                    Text(BurnTrajectory.displayName(st.modelId))
-                        .font(.system(size: 13, weight: st.isSelected ? .semibold : .regular))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(BurnTrajectory.displayName(st.modelId))
+                            .font(.system(size: 13, weight: st.isSelected ? .semibold : .regular))
+                        if let caption = shadowCaption(st) {
+                            Text("\(Image(systemName: "flask")) \(caption)")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
                     if st.isSelected {
                         Text("on the dashboard").font(.system(size: 10, weight: .semibold))
                             .padding(.horizontal, 6).padding(.vertical, 2)
@@ -520,6 +569,14 @@ struct ProjectionDetailView: View {
                 if idx != ranked.indices.last {
                     Divider().opacity(0.25).padding(.leading, 34)
                 }
+            }
+
+            if let record = selectedRecordText {
+                Text(record)
+                    .font(.system(size: 11).monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 8)
             }
         }
     }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/EngineParams.swift
@@ -54,6 +54,19 @@ public struct EngineParams: Sendable, Equatable, Codable {
     /// only stops a lucky thin record from reaching the screen.
     public var shadowPromotionMinPeriods: Int = 15
 
+    // MARK: Conformal residual grouping
+
+    /// Below this many completed cycles, the rate-limit calibrator collapses
+    /// each cycle's cut-residuals to ONE per (cycle, stratum) — per-cycle
+    /// blocks. Residuals from one cycle are strongly correlated (a heavy week
+    /// blows all 8 cuts at once), so counting them separately overstates the
+    /// effective sample and yields confidently-too-narrow bands: measured
+    /// 0.12 coverage on an 80% band in the 7d window's first fold. With
+    /// plentiful cycles the within-cycle spread is real tail information
+    /// (5h holds 0.785 with per-cut residuals), so past the threshold the
+    /// grouping switches back. Validated in research/harness (2026-07-06).
+    public var conformalBlockMinCycles: Int = 40
+
     public init() {}
 
     /// The values the shipping engine runs with.
@@ -78,6 +91,7 @@ public struct EngineParams: Sendable, Equatable, Codable {
             "linearRecentLookbackFraction=\(g(linearRecentLookbackFraction))",
             "recencyHalfLifeFraction=\(g(recencyHalfLifeFraction))",
             "shadowPromotionMinPeriods=\(shadowPromotionMinPeriods)",
+            "conformalBlockMinCycles=\(conformalBlockMinCycles)",
         ].joined(separator: ";")
     }
 

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -254,7 +254,7 @@ public actor UsageIntelligenceEngine {
     /// established on 7d but a shadow on 5h — the 2026-06 backtest measured a
     /// null there (5h cycles rarely straddle a day/night boundary), and the
     /// shadow record re-tests that assumption instead of trusting it forever.
-    static func rlShadowFloors(_ window: RateLimitWindowKind) -> [String: Int] {
+    public static func rlShadowFloors(_ window: RateLimitWindowKind) -> [String: Int] {
         let floor = EngineParams.current.shadowPromotionMinPeriods
         var floors = ["kalman-trend": floor]
         if window == .fiveHour { floors["diurnal-rate"] = floor }

--- a/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
+++ b/PacerCore/Sources/PacerCore/Forecast/Engine/UsageIntelligenceEngine.swift
@@ -921,6 +921,16 @@ public actor UsageIntelligenceEngine {
     /// walk-forward over completed cycles, residual = truth − projection
     /// (percentage points), bucketed by `rlStratum` with a `"pooled"` fallback
     /// always present.
+    ///
+    /// **Per-cycle blocks below `conformalBlockMinCycles`:** residuals from
+    /// one cycle's eight cuts are strongly correlated (a heavy week blows all
+    /// of them at once), so counting them separately overstates the effective
+    /// sample — on the 7d window's thin history that produced 80% bands with
+    /// 12% realized coverage. With few cycles each cycle therefore
+    /// contributes its MEDIAN residual per bucket (effective n = cycles,
+    /// honest); with plentiful cycles the within-cycle spread is real tail
+    /// information and per-cut counting resumes (5h holds 0.785 coverage).
+    /// Validated fold-robust in research/harness (2026-07-06).
     static func stratifiedRLCalibrators(
         model: any BurnTrajectory.Model,
         history: [BurnTrajectory.Cycle],
@@ -928,9 +938,10 @@ public actor UsageIntelligenceEngine {
         calendar: Calendar,
         cutFractions: [Double] = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
     ) -> [String: ConformalCalibrator] {
-        var byStratum: [String: [Double]] = [:]
-        var pooled: [Double] = []
-        for cycle in history {
+        // (cycle index, residual) pairs per bucket, then grouped per the rule.
+        var byStratum: [String: [(cycle: Int, residual: Double)]] = [:]
+        var pooled: [(cycle: Int, residual: Double)] = []
+        for (ci, cycle) in history.enumerated() {
             let trueFinal = cycle.samples.map { $0.usedPercentage }.max() ?? 0
             guard trueFinal > 0 else { continue }
             for cf in cutFractions {
@@ -941,13 +952,22 @@ public actor UsageIntelligenceEngine {
                     samples: seen, now: cutNow, cycleStart: cycle.cycleStart, resetsAt: cycle.resetsAt)
                 guard let projection = model.fit(partial) else { continue }
                 let residual = trueFinal - projection(cycle.resetsAt)
-                pooled.append(residual)
-                byStratum[rlStratum(cutFraction: cf, cycleStart: cycle.cycleStart, calendar: calendar), default: []].append(residual)
+                pooled.append((ci, residual))
+                byStratum[rlStratum(cutFraction: cf, cycleStart: cycle.cycleStart, calendar: calendar), default: []].append((ci, residual))
             }
         }
-        var out: [String: ConformalCalibrator] = ["pooled": ConformalCalibrator(mode: .additive, residuals: pooled)]
-        for (key, residuals) in byStratum where residuals.count >= rlStratumMinScores {
-            out[key] = ConformalCalibrator(mode: .additive, residuals: residuals)
+        let blocks = history.count < EngineParams.current.conformalBlockMinCycles
+        func residuals(_ pairs: [(cycle: Int, residual: Double)]) -> [Double] {
+            guard blocks else { return pairs.map { $0.residual } }
+            let byCycle = Dictionary(grouping: pairs, by: { $0.cycle })
+            return byCycle.values.map { EngineSelfEval.median($0.map { $0.residual }) }
+        }
+        var out: [String: ConformalCalibrator] = ["pooled": ConformalCalibrator(mode: .additive, residuals: residuals(pooled))]
+        for (key, pairs) in byStratum {
+            let rs = residuals(pairs)
+            if rs.count >= rlStratumMinScores {
+                out[key] = ConformalCalibrator(mode: .additive, residuals: rs)
+            }
         }
         return out
     }

--- a/PacerCore/Tests/PacerCoreTests/ConformalBlockGroupingTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ConformalBlockGroupingTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+/// Per-cycle block grouping in the stratified RL calibrators: with few
+/// completed cycles, each cycle contributes ONE (median) residual per bucket
+/// instead of one per cut — the honest effective sample size that fixed the
+/// 7d bands' 12% realized coverage on an 80% claim.
+@Suite("Conformal block grouping")
+struct ConformalBlockGroupingTests {
+
+    static var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+    static let base = utc.date(from: DateComponents(year: 2026, month: 6, day: 1))!
+
+    /// `count` completed 5h-style cycles, linear 0→80% with 15-min sampling.
+    private func cycles(_ count: Int) -> [BurnTrajectory.Cycle] {
+        (0..<count).map { i in
+            let start = Self.base.addingTimeInterval(Double(i) * 6 * 3600)
+            let reset = start.addingTimeInterval(5 * 3600)
+            var samples: [BurnTrajectory.Sample] = []
+            var t = 0.0
+            while t <= 5 * 3600 {
+                samples.append(.init(at: start.addingTimeInterval(t),
+                                     usedPercentage: 80 * t / (5 * 3600)))
+                t += 15 * 60
+            }
+            return .init(samples: samples, cycleStart: start, resetsAt: reset)
+        }
+    }
+
+    @Test func fewCyclesYieldOneResidualPerCyclePerBucket() {
+        let history = cycles(10)   // 10 < conformalBlockMinCycles(40) → blocks
+        let cals = UsageIntelligenceEngine.stratifiedRLCalibrators(
+            model: BurnTrajectory.LinearRecent(), history: history,
+            duration: 5 * 3600, calendar: Self.utc)
+        let pooled = cals["pooled"]
+        #expect(pooled != nil)
+        // Per-cut counting would give ~10 cycles × 8 cuts = ~80 residuals;
+        // block grouping must give exactly one per cycle.
+        #expect(pooled?.count == 10)
+    }
+
+    @Test func manyCyclesKeepPerCutResiduals() {
+        let history = cycles(45)   // 45 ≥ 40 → per-cut residuals resume
+        let cals = UsageIntelligenceEngine.stratifiedRLCalibrators(
+            model: BurnTrajectory.LinearRecent(), history: history,
+            duration: 5 * 3600, calendar: Self.utc)
+        let n = cals["pooled"]?.count ?? 0
+        #expect(n > 45, "expected per-cut residuals (~45×8), got \(n)")
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/EngineParamsTests.swift
@@ -35,13 +35,14 @@ struct EngineParamsTests {
         #expect(p.linearRecentLookbackFraction == 0.3)
         #expect(p.recencyHalfLifeFraction == 0.15)
         #expect(p.shadowPromotionMinPeriods == 15)
+        #expect(p.conformalBlockMinCycles == 40)
     }
 
     @Test func versionTagMatchesPythonHarness() {
         // research/harness/pacer_replay.py `Params().version_tag()` computes
         // the same FNV-1a over the same canonical string; this pin catches
         // either side drifting. Update BOTH when a knob is added/changed.
-        #expect(EngineParams.current.versionTag == "v1-36d9fd53")
+        #expect(EngineParams.current.versionTag == "v1-4c0cc586")
     }
 
     @Test func paramsRoundTripThroughJSON() throws {

--- a/research/harness/.gitignore
+++ b/research/harness/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 __pycache__/
 uv.lock
+reports/

--- a/research/harness/README.md
+++ b/research/harness/README.md
@@ -8,9 +8,17 @@ ship in Swift.
 
 ```
 uv run pacer_replay.py            # score the shipping configuration
+uv run pacer_replay.py --conformal-mode cuts   # calibration experiments
 uv run sweep.py                   # grid-sweep the EngineParams knobs
 uv run sweep.py --full --json     # bigger grid, machine-readable
+uv run weekly_check.py            # the standing check (drift/promotions/sweep)
+uv run weekly_check.py --install-agent   # LaunchAgent: Mondays 09:23
 ```
+
+`weekly_check.py` is the loop's heartbeat: replay vs `baselines.json`,
+shadow-promotion progress from the app's own record, and the default sweep —
+one line appended to `reports/log.jsonl` every run, a macOS notification only
+when something is actionable. Deterministic, no LLM in the loop.
 
 The store (`pacer.sqlite` in the app group) is copied to a temp dir and opened
 read-only — the live app is never touched. A full-history replay takes ~1s,

--- a/research/harness/baselines.json
+++ b/research/harness/baselines.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Reference scores for weekly_check.py drift alarms — update when a deliberate change moves them (2026-07-06, params v1-4c0cc586).",
+  "five_hour": {"medianAbsErrorPP": 4.61, "coverage80": 0.761},
+  "seven_day": {"medianAbsErrorPP": 1.0, "coverage80": 0.75}
+}

--- a/research/harness/pacer_replay.py
+++ b/research/harness/pacer_replay.py
@@ -59,6 +59,7 @@ class Params:
     linear_recent_lookback_fraction: float = 0.3
     recency_half_life_fraction: float = 0.15
     shadow_promotion_min_periods: int = 15
+    conformal_block_min_cycles: int = 40
 
     def canonical(self) -> str:
         def g(v: float) -> str:
@@ -73,6 +74,7 @@ class Params:
             f"linearRecentLookbackFraction={g(self.linear_recent_lookback_fraction)}",
             f"recencyHalfLifeFraction={g(self.recency_half_life_fraction)}",
             f"shadowPromotionMinPeriods={self.shadow_promotion_min_periods}",
+            f"conformalBlockMinCycles={self.conformal_block_min_cycles}",
         ])
 
     def version_tag(self) -> str:
@@ -468,19 +470,69 @@ def stratum_key(cut_fraction: float, cycle_start: float) -> str:
     return f"{phase}|{regime}"
 
 
-def gated_quantile(residuals: list[float], p: float, min_residuals: int) -> float | None:
-    n = len(residuals)
-    if n < min_residuals:
+# Weighted residuals: list of (weight, residual). Unweighted modes use w=1.
+WeightedResiduals = list[tuple[float, float]]
+
+
+def kish_n(pairs: WeightedResiduals) -> float:
+    """Effective sample size under weights — (Σw)²/Σw²; equals n when w≡1."""
+    sw = sum(w for w, _ in pairs)
+    sww = sum(w * w for w, _ in pairs)
+    return (sw * sw / sww) if sww > 0 else 0.0
+
+
+def gated_quantile(pairs: WeightedResiduals, p: float, min_residuals: int) -> float | None:
+    """Conformal quantile with the (n+1) adjustment, gated on EFFECTIVE sample
+    size. Weighted form: target mass p·(Σw + w_test) with w_test = max weight
+    (the conservative choice for the unseen case)."""
+    if kish_n(pairs) < min_residuals:
         return None
-    rank = math.ceil((n + 1) * p)
-    return sorted(residuals)[min(max(rank, 1), n) - 1]
+    ordered = sorted(pairs, key=lambda x: x[1])
+    w_test = max(w for w, _ in ordered)
+    target = p * (sum(w for w, _ in ordered) + w_test)
+    acc = 0.0
+    for w, r in ordered:
+        acc += w
+        if acc >= target:
+            return r
+    return ordered[-1][1]
 
 
-def collect_residuals(model_fit, params: Params, history: list[Cycle]) -> dict[str, list[float]]:
+def mode_stratum(mode: str, cut_fraction: float, cycle_start: float) -> str:
+    if mode == "cut-matched":
+        return f"cut={cut_fraction:.2f}"
+    return stratum_key(cut_fraction, cycle_start)
+
+
+def collect_residuals(model_fit, params: Params, history: list[Cycle],
+                      mode: str = "cuts") -> dict[str, WeightedResiduals]:
     """Walk-forward residuals (truth_final − projection at reset), stratified,
-    with the pooled fallback — port of stratifiedRLCalibrators."""
-    by: dict[str, list[float]] = {"pooled": []}
-    for cyc in history:
+    with the pooled fallback — port of stratifiedRLCalibrators.
+
+    `mode` is the calibration experiment knob (NOT part of Params — it only
+    joins EngineParams once a winner ships):
+    - "cuts" (shipping behavior): every (cycle, cut) residual is its own
+      calibration case. Residuals from one cycle are strongly correlated (a
+      heavy week blows all 8 at once), so this OVERSTATES the effective n —
+      the suspected cause of the 7d under-coverage.
+    - "block": one residual per (cycle, stratum) — the median of that cycle's
+      residuals in the stratum. Honest effective n ≈ cycle count.
+    - "cut-matched": strata keyed by cut fraction instead of phase×regime
+      (each stratum ≈ one residual per cycle, matched to where you are in
+      the window).
+    - "recency": like "cuts" but residuals decay with cycle age
+      (half-life 5 cycles) — weighted conformal, gated on Kish effective n.
+    - "auto" (SHIPPING as of conformalBlockMinCycles): "block" while the
+      window has fewer than `params.conformal_block_min_cycles` completed
+      cycles (scarce cycles ⇒ the inflation actively distorts quantiles —
+      measured 0.12 fold coverage on 7d), else "cuts" (plentiful cycles ⇒
+      within-cycle spread adds real tail information — 5h holds 0.785).
+    """
+    raw: dict[str, list[tuple[int, float]]] = {"pooled": []}
+    n_cycles = len(history)
+    if mode == "auto":
+        mode = "block" if n_cycles < params.conformal_block_min_cycles else "cuts"
+    for ci, cyc in enumerate(history):
         true_final = cyc.final
         if true_final <= 0:
             continue
@@ -494,9 +546,29 @@ def collect_residuals(model_fit, params: Params, history: list[Cycle]) -> dict[s
             if proj is None:
                 continue
             residual = true_final - proj(cyc.resets_at)
-            by["pooled"].append(residual)
-            by.setdefault(stratum_key(cf, cyc.cycle_start), []).append(residual)
-    return {k: v for k, v in by.items() if k == "pooled" or len(v) >= params.rl_stratum_min_scores}
+            raw["pooled"].append((ci, residual))
+            raw.setdefault(mode_stratum(mode, cf, cyc.cycle_start), []).append((ci, residual))
+
+    def reduce(pairs: list[tuple[int, float]]) -> WeightedResiduals:
+        if mode in ("cuts", "cut-matched"):
+            return [(1.0, r) for _, r in pairs]
+        if mode == "recency":
+            return [(0.5 ** ((n_cycles - 1 - ci) / 5.0), r) for ci, r in pairs]
+        if mode == "block":
+            by_cycle: dict[int, list[float]] = {}
+            for ci, r in pairs:
+                by_cycle.setdefault(ci, []).append(r)
+            out: WeightedResiduals = []
+            for rs in by_cycle.values():
+                rs.sort()
+                n = len(rs)
+                out.append((1.0, rs[n // 2] if n % 2 else (rs[n // 2 - 1] + rs[n // 2]) / 2))
+            return out
+        raise ValueError(f"unknown conformal mode {mode!r}")
+
+    by = {k: reduce(v) for k, v in raw.items()}
+    return {k: v for k, v in by.items()
+            if k == "pooled" or kish_n(v) >= params.rl_stratum_min_scores}
 
 
 def best_method(record: dict[str, dict[str, list[float]]], window: str, params: Params) -> str | None:
@@ -542,7 +614,8 @@ class CaseScore:
     band_stated: bool
 
 
-def replay_window(window: str, samples, activity_grid, params: Params) -> list[CaseScore]:
+def replay_window(window: str, samples, activity_grid, params: Params,
+                  conformal_mode: str = "auto") -> list[CaseScore]:
     duration = WINDOW_SECONDS[window]
     cycles = segment(samples, duration)
     completed = cycles[:-1] if cycles else []   # last group = current/live
@@ -563,7 +636,7 @@ def replay_window(window: str, samples, activity_grid, params: Params) -> list[C
         # the cut — resolve once per cycle (the walk over cuts is the hot loop).
         chosen = best_method(record, window, params) or (
             "diurnal-rate" if window == "seven_day" else "recency-weighted")
-        residuals = collect_residuals(roster[chosen], params, history)
+        residuals = collect_residuals(roster[chosen], params, history, mode=conformal_mode)
 
         for cf in RL_CUT_FRACTIONS:
             cut_now = cyc.cycle_start + cyc.duration * cf
@@ -578,17 +651,19 @@ def replay_window(window: str, samples, activity_grid, params: Params) -> list[C
             raw = proj(cyc.resets_at) + anchor
             point = min(100.0, max(partial.used_now, raw))
 
-            strat = residuals.get(stratum_key(cf, cyc.cycle_start), residuals.get("pooled", []))
+            strat = residuals.get(mode_stratum(conformal_mode, cf, cyc.cycle_start),
+                                  residuals.get("pooled", []))
             lo = gated_quantile(strat, 0.1, params.conformal_min_residuals)
             hi = gated_quantile(strat, 0.9, params.conformal_min_residuals)
             band_stated = lo is not None and hi is not None
             covered = (min(raw + lo, raw + hi) <= truth <= max(raw + lo, raw + hi)) if band_stated else None
             pb10 = pinball(truth, raw + lo, 0.1) if band_stated else None
             pb90 = pinball(truth, raw + hi, 0.9) if band_stated else None
-            # Hit probability: empirical share of residual-shifted outcomes ≥100
+            # Hit probability: weighted share of residual-shifted outcomes ≥100
             # (conformal predictive), falling back to the deterministic call.
-            if len(strat) >= params.conformal_min_residuals:
-                p_hit = sum(1 for r in strat if raw + r >= 100.0) / len(strat)
+            if kish_n(strat) >= params.conformal_min_residuals:
+                total_w = sum(w for w, _ in strat)
+                p_hit = sum(w for w, r in strat if raw + r >= 100.0) / total_w
             else:
                 p_hit = 1.0 if point >= 100.0 else 0.0
             scores.append(CaseScore(i, cf, chosen, abs(point - truth), covered,
@@ -639,16 +714,20 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--store", help="path to pacer.sqlite (default: app group)")
     ap.add_argument("--window", choices=["five_hour", "seven_day"], help="one window only")
+    ap.add_argument("--conformal-mode", default="auto",
+                    choices=["auto", "cuts", "block", "cut-matched", "recency"],
+                    help="calibration experiment (see collect_residuals; 'auto' = shipping behavior)")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     args = ap.parse_args()
 
     conn = open_copy(locate_store(args.store))
     grid = load_activity_grid(conn)
     params = Params()
-    report = {"paramsVersion": params.version_tag(), "params": params.canonical(), "windows": {}}
+    report = {"paramsVersion": params.version_tag(), "params": params.canonical(),
+              "conformalMode": args.conformal_mode, "windows": {}}
     for window in ([args.window] if args.window else ["five_hour", "seven_day"]):
         samples = load_rate_samples(conn, window)
-        scores = replay_window(window, samples, grid, params)
+        scores = replay_window(window, samples, grid, params, conformal_mode=args.conformal_mode)
         report["windows"][window] = summarize(scores)
     if args.json:
         print(json.dumps(report, indent=2))

--- a/research/harness/weekly_check.py
+++ b/research/harness/weekly_check.py
@@ -1,0 +1,167 @@
+"""Weekly self-improvement check — deterministic, no LLM required.
+
+Runs the walk-forward replay against the live store, compares against the
+committed baselines, checks shadow-candidate promotion progress from the
+app's own eval record, and runs the default parameter sweep. Emits a macOS
+notification ONLY when something is actionable:
+
+- 80%-band coverage drifted outside [0.70, 0.92] (on ≥ 20 banded cases)
+- median |end-at-reset error| worsened ≥ 25% vs baseline
+- a shadow candidate reached its promotion floor (once per candidate)
+- the sweep found a fold-robust parameter improvement
+
+Every run appends one JSON line to reports/log.jsonl regardless, so the
+history of checks is inspectable. Scheduled by a LaunchAgent (see
+`uv run weekly_check.py --install-agent`); quiet weeks cost zero attention.
+"""
+
+from __future__ import annotations
+
+import json
+import plistlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pacer_replay import (
+    Params, load_activity_grid, load_rate_samples, locate_store, open_copy,
+    replay_window, summarize,
+)
+from sweep import DEFAULT_GRID, fold_medians, robust_improvement
+
+HERE = Path(__file__).resolve().parent
+REPORTS = HERE / "reports"
+BASELINES = HERE / "baselines.json"
+
+SHADOWS = {"rl-five_hour": ["kalman-trend", "diurnal-rate"], "rl-seven_day": ["kalman-trend"]}
+COVERAGE_OK = (0.70, 0.92)
+MIN_BANDED_FOR_ALARM = 20
+MEDIAN_WORSEN_FACTOR = 1.25
+
+
+def notify(title: str, body: str) -> None:
+    subprocess.run(["osascript", "-e",
+                    f'display notification "{body}" with title "{title}"'], check=False)
+
+
+def banded_cases(scores) -> int:
+    return sum(1 for s in scores if s.covered80 is not None)
+
+
+def shadow_progress(conn) -> dict[str, dict[str, int]]:
+    """Distinct scored periods per shadow method per surface, from the app's
+    own persisted record (the same numbers the promotion gate reads)."""
+    out: dict[str, dict[str, int]] = {}
+    for surface, methods in SHADOWS.items():
+        for m in methods:
+            n = conn.execute(
+                "SELECT COUNT(DISTINCT ZPERIODKEY) FROM ZENGINEEVALOUTCOME "
+                "WHERE ZSURFACE = ? AND ZMETHOD = ?", (surface, m)).fetchone()[0]
+            out.setdefault(surface, {})[m] = int(n)
+    return out
+
+
+def run_check() -> int:
+    conn = open_copy(locate_store(None))
+    grid = load_activity_grid(conn)
+    params = Params()
+    baselines = json.loads(BASELINES.read_text()) if BASELINES.exists() else {}
+    actionable: list[str] = []
+    result = {"at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+              "paramsVersion": params.version_tag(), "windows": {}, "shadows": {}}
+
+    all_scores = {}
+    for window in ("five_hour", "seven_day"):
+        samples = load_rate_samples(conn, window)
+        scores = replay_window(window, samples, grid, params)
+        all_scores[window] = scores
+        s = summarize(scores)
+        result["windows"][window] = {k: s.get(k) for k in
+                                     ("cases", "medianAbsErrorPP", "coverage80", "bandStatedShare", "brier")}
+        base = baselines.get(window, {})
+        cov = s.get("coverage80")
+        if cov is not None and banded_cases(scores) >= MIN_BANDED_FOR_ALARM \
+                and not (COVERAGE_OK[0] <= cov <= COVERAGE_OK[1]):
+            actionable.append(f"{window}: coverage drifted to {cov}")
+        med, base_med = s.get("medianAbsErrorPP"), base.get("medianAbsErrorPP")
+        if med and base_med and med > base_med * MEDIAN_WORSEN_FACTOR:
+            actionable.append(f"{window}: median error {med}pp vs baseline {base_med}pp")
+
+    # Shadow promotion progress (notify once per candidate crossing the floor).
+    REPORTS.mkdir(exist_ok=True)
+    seen_file = REPORTS / "promotions-seen.json"
+    seen = set(json.loads(seen_file.read_text())) if seen_file.exists() else set()
+    progress = shadow_progress(conn)
+    result["shadows"] = progress
+    for surface, methods in progress.items():
+        for m, n in methods.items():
+            key = f"{surface}|{m}"
+            if n >= params.shadow_promotion_min_periods and key not in seen:
+                actionable.append(f"{m} reached its promotion floor on {surface} ({n} cycles)")
+                seen.add(key)
+    seen_file.write_text(json.dumps(sorted(seen)))
+
+    # Parameter sweep (default grid) with the fold-robust adoption rule.
+    keys = sorted(DEFAULT_GRID)
+    import itertools
+    from dataclasses import replace
+    base_folds = {w: fold_medians(all_scores[w]) for w in all_scores}
+    base_meds = {w: result["windows"][w]["medianAbsErrorPP"] for w in all_scores}
+    for values in itertools.product(*(DEFAULT_GRID[k] for k in keys)):
+        cand = replace(Params(), **dict(zip(keys, values)))
+        if cand.canonical() == Params().canonical():
+            continue
+        for window in all_scores:
+            samples = load_rate_samples(conn, window)
+            scores = replay_window(window, samples, grid, cand)
+            s = summarize(scores)
+            if robust_improvement(base_folds[window], fold_medians(scores),
+                                  base_meds[window], s.get("medianAbsErrorPP"), s.get("coverage80")):
+                actionable.append(
+                    f"{window}: sweep found fold-robust improvement {cand.version_tag()} "
+                    f"(median {s.get('medianAbsErrorPP')}pp) — {cand.canonical()}")
+
+    result["actionable"] = actionable
+    with (REPORTS / "log.jsonl").open("a") as f:
+        f.write(json.dumps(result) + "\n")
+    if actionable:
+        notify("Pacer prediction check", "; ".join(actionable)[:200])
+        print("ACTIONABLE:\n  " + "\n  ".join(actionable))
+    else:
+        print("quiet week — nothing actionable")
+    for w, s in result["windows"].items():
+        print(f"  {w}: {s}")
+    print(f"  shadows: {progress}")
+    return 0
+
+
+def install_agent() -> int:
+    """Install the LaunchAgent that runs this check weekly (Mon 09:23)."""
+    uv = subprocess.run(["/bin/zsh", "-lc", "command -v uv"],
+                        capture_output=True, text=True).stdout.strip()
+    if not uv:
+        print("uv not found on PATH", file=sys.stderr)
+        return 1
+    label = "com.ericandrechek.pacer.harness-weekly"
+    logs = Path.home() / "Library/Logs/Pacer"
+    logs.mkdir(parents=True, exist_ok=True)
+    plist = {
+        "Label": label,
+        "ProgramArguments": [uv, "run", "--project", str(HERE), str(HERE / "weekly_check.py")],
+        "WorkingDirectory": str(HERE),
+        "StartCalendarInterval": {"Weekday": 1, "Hour": 9, "Minute": 23},
+        "StandardOutPath": str(logs / "harness-weekly.log"),
+        "StandardErrorPath": str(logs / "harness-weekly.log"),
+    }
+    dest = Path.home() / "Library/LaunchAgents" / f"{label}.plist"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(plistlib.dumps(plist))
+    subprocess.run(["launchctl", "unload", str(dest)], capture_output=True)
+    subprocess.run(["launchctl", "load", str(dest)], check=True)
+    print(f"installed + loaded {dest} (runs Mondays 09:23; log: {logs / 'harness-weekly.log'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(install_agent() if "--install-agent" in sys.argv else run_check())


### PR DESCRIPTION
Round 2 of the prediction feedback loop — the first changes *driven by* the replay harness shipped in #116.

## What's here

- **fix(forecast): per-cycle block conformal below a cycle-count threshold.** The 7d bands claimed 80% but covered 59% (first fold: 12%) because every (cycle, cut) residual was counted as independent while one cycle's eight cut-residuals move together. Below `EngineParams.conformalBlockMinCycles` (40) completed cycles, each cycle now contributes its median residual per bucket — honest effective n. Replayed 7d: coverage 0.589→0.75, pinball 7.5→5.4; 5h live behavior unchanged (past the threshold). Fold-robust in the harness; cut-matched-5h and recency-weighted variants were tested and rejected (hysteresis held). Params tag → `v1-4c0cc586`, cross-language parity re-pinned.
- **feat(ui): shadow-model progress + earned record in compare-models.** Shadow candidates show "earning trust — N of 15 cycles" until they clear the promotion floor; footer names the selected model with the depth of evidence behind the pick. No number appears twice.
- **feat(research): weekly_check.py** — deterministic watchdog (replay vs committed baselines, shadow-promotion progress from the app's own record, fold-robust sweep), notifying only when actionable; `--install-agent` writes a LaunchAgent (maintainer-installed, not auto).

## Measured along the way

From the app's own backfilled record, the 5h shadow verdict is already in: kalman-trend (5.41pp median miss) and diurnal-rate (5.16pp) **lose** to the simple candidates (4.45–4.96pp) over 79 cycles — the promotion gate correctly keeps them off the display. The 7d kalman verdict needs ~10 more weekly cycles.

## Testing

541 PacerCore tests green (incl. new block-grouping + updated parity tests); `make verify` green; installed locally and running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrjwqXhsrvSuG9GaA9rE4j