### PR TITLE
Adaptive multi-token OAuth polling + Tokens settings UI

### DIFF
--- a/App/Background/AppBackgroundService.swift
+++ b/App/Background/AppBackgroundService.swift
@@ -102,11 +102,15 @@ final class AppBackgroundService {
         // Claude's stores only ~once per token lifetime and keep working if
         // the user logs out of Claude Code / removes Desktop. Tests and
         // Settings probes use the default in-memory store (no real keychain).
-        let oauthClient = OAuthClient(heldStore: KeychainCredentialStore())
+        let oauthClient = OAuthClient(
+            heldStore: KeychainCredentialStore(),
+            desktopKeyStore: KeychainDesktopKeyStore()
+        )
         let scanCoordinator = ScanCoordinator(
             container: container,
             configuration: ScanCoordinator.Configuration(costMode: costMode),
-            oauthClient: oauthClient
+            oauthClient: oauthClient,
+            oauthPoolStore: KeychainTokenPoolStore()
         )
         coordinator = scanCoordinator
 

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -38,6 +38,7 @@ struct SettingsView: View {
                     NotificationTestCard()
                 }
                 SettingsSection("Authentication") {
+                    TokensCard()
                     DesktopCredentialsCard()
                     OAuthTokenOverrideCard()
                 }
@@ -1258,69 +1259,271 @@ private struct OAuthTokenOverrideCard: View {
     ///     production poller would do it. Useful for confirming a
     ///     fresh `claude login` produced a working token before
     ///     trusting Pacer's next poll.
+    /// Route the test through the running poller so the reading is
+    /// persisted and counts against that token's budget — instead of a
+    /// separate throwaway request that races the poller's own polls.
     private func runTest() {
         let token = trimmedDraft
         testInProgress = true
         testResult = nil
         Task { @MainActor in
-            let client: OAuthClient
+            let outcome: TokenTestResult
             if token.isEmpty {
-                // Production path: real keychain, no override.
-                client = OAuthClient(tokenOverride: { nil })
+                // Empty field ⇒ test the token Pacer reads from the
+                // keychain. Resolve it here, then route the raw token
+                // through the poller like any other.
+                switch KeychainOAuth().read() {
+                case .success(let cred):
+                    outcome = await TokenPoolStatus.shared.testAdHoc(token: cred.accessToken)
+                case .failure:
+                    outcome = .failure(reason: "No readable Claude Code token in the keychain.")
+                }
             } else {
-                // Draft path: deliberately broken keychain so the
-                // result reflects the typed token alone.
-                let brokenKeychain = KeychainOAuth(rawReader: { .failure(.notFound) })
-                client = OAuthClient(
-                    keychain: brokenKeychain,
-                    tokenOverride: { token }
-                )
+                outcome = await TokenPoolStatus.shared.testAdHoc(token: token)
             }
-            let result = await client.fetchUsage()
             testInProgress = false
-            testResult = Self.classify(result)
+            testResult = Self.classify(outcome)
         }
     }
 
-    /// Translate the typed OAuthClient outcome into a user-facing
-    /// result. We don't surface raw HTTP bodies — they're noisy and
-    /// usually point at the same actionable advice ("get a fresh token").
-    private static func classify(
-        _ result: Result<RateLimitSnapshot, OAuthClientError>
-    ) -> TestResult {
+    /// Map the poller's test outcome to the card's status line. The
+    /// poller already distills HTTP errors into human messages.
+    private static func classify(_ result: TokenTestResult) -> TestResult {
         switch result {
-        case .success(let snapshot):
-            return .success(
-                fiveHourPct: snapshot.fiveHour?.usedPercentage,
-                sevenDayPct: snapshot.sevenDay?.usedPercentage
-            )
-        case .failure(.unauthorized):
-            return .failure(message: "Anthropic rejected this token (401). It may be expired or revoked — fetch a fresh one.")
-        case .failure(.rateLimited):
-            return .failure(message: "Rate-limited by Anthropic (429). Wait a moment and try again.")
-        case .failure(.transport):
-            return .failure(message: "Network error. Check your connection and retry.")
-        case .failure(.http(403, _)):
-            // 403 ≠ 401: Anthropic accepted the token as valid auth
-            // but won't honor it for /api/oauth/usage. Almost always
-            // means the token lacks the `user:sessions:claude_code`
-            // scope — i.e. it came from `claude setup-token` or a
-            // web-console API key rather than the interactive
-            // `claude login` flow.
-            return .failure(message: "Token rejected for this endpoint (403). Use a token from `claude logout && claude login`, not `claude setup-token` or a console API key.")
-        case .failure(.http(let status, _)):
-            return .failure(message: "Anthropic returned HTTP \(status).")
-        case .failure(.responseSchemaMismatch):
-            return .failure(message: "Anthropic's response didn't match Pacer's expected shape. Likely a server-side change.")
-        case .failure(.credentialsNotFound),
-             .failure(.keychainAccessDenied),
-             .failure(.keychainMalformed),
-             .failure(.keychainStatus),
-             .failure(.tokenExpired):
-            // The override path shouldn't reach any of these. Surface a
-            // generic message rather than crashing — keeps the UI honest
-            // if the client's failure modes ever expand.
-            return .failure(message: "Pacer hit an unexpected internal error while testing.")
+        case .success(let fh, let sd):
+            return .success(fiveHourPct: fh, sevenDayPct: sd)
+        case .foreignAccount(let org):
+            let suffix = org.map { " (\($0.prefix(8))…)" } ?? ""
+            return .failure(message: "This token belongs to a different account\(suffix) — Pacer keeps it out of the pool.")
+        case .failure(let reason):
+            return .failure(message: reason)
+        case .unavailable:
+            return .failure(message: "Pacer's poller isn't running yet — try again in a moment.")
+        }
+    }
+}
+
+// MARK: - Token pool
+
+/// Live view of the OAuth token pool the poller cycles through — where
+/// each token comes from, which account it's tied to, when it expires,
+/// its health, and a Test that routes through the poller (so it persists
+/// and counts against that token's budget instead of racing it).
+private struct TokensCard: View {
+    @State private var pool = TokenPoolStatus.shared
+
+    var body: some View {
+        PacerCard("Tokens", trailing: {
+            cadenceHeader
+        }, content: {
+            if pool.lanes.isEmpty {
+                Text("No tokens yet — sign into Claude Code, or add one below.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    columnHeader
+                    ForEach(pool.lanes) { lane in
+                        Divider().opacity(0.35)
+                        TokenLaneRow(lane: lane)
+                    }
+                }
+            }
+        }, footer: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Pacer spreads usage polls across every token it can read for your account, so it refreshes more often while you're active without exceeding any single token's rate limit. Tokens are cycled by priority (top first).")
+                Text("Add more by enabling Claude Desktop below (its tokens join the pool) or pasting one in “OAuth token override”. Testing a token here fetches real usage through the poller — it updates your history and counts against that token's budget.")
+                    .padding(.top, 2)
+            }
+        })
+    }
+
+    private var cadenceHeader: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(pool.isActive ? Color.green : Color.secondary.opacity(0.6))
+                .frame(width: 7, height: 7)
+            Text(cadenceText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var cadenceText: String {
+        let n = pool.lanes.filter { $0.account != .foreign }.count
+        let tokens = "\(n) token\(n == 1 ? "" : "s")"
+        guard let seconds = pool.effectiveIntervalSeconds else { return tokens }
+        return "Updating ~\(Self.formatInterval(seconds)) · \(tokens) · \(pool.isActive ? "active" : "idle")"
+    }
+
+    static func formatInterval(_ s: TimeInterval) -> String {
+        if s < 90 { return "\(Int(s.rounded()))s" }
+        let m = s / 60
+        return m.rounded() == m ? "\(Int(m)) min" : String(format: "%.1f min", m)
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: 10) {
+            Text("SOURCE").frame(width: 148, alignment: .leading)
+            Text("ACCOUNT").frame(width: 96, alignment: .leading)
+            Text("STATUS").frame(width: 74, alignment: .leading)
+            Text("EXPIRES").frame(width: 66, alignment: .leading)
+            Text("UPDATED").frame(width: 70, alignment: .leading)
+            Spacer(minLength: 0)
+        }
+        .font(.system(size: 9, weight: .semibold))
+        .tracking(0.5)
+        .foregroundStyle(.tertiary)
+        .padding(.bottom, 6)
+    }
+}
+
+/// One row in the token pool. Owns its own Test in-flight state.
+private struct TokenLaneRow: View {
+    let lane: TokenLaneStatus
+    @State private var testing = false
+    @State private var result: TokenTestResult?
+
+    var body: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 7) {
+                Image(systemName: Self.icon(lane.source))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 15)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(Self.name(lane.source))
+                        .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
+                    Text("#\(lane.priority + 1) · …\(lane.id.suffix(4))")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .frame(width: 148, alignment: .leading)
+
+            Text(accountText)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: 96, alignment: .leading)
+                .help(lane.organizationId ?? "")
+
+            statusPill
+                .frame(width: 74, alignment: .leading)
+
+            Text(expiresText)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .frame(width: 66, alignment: .leading)
+
+            Text(updatedText)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+
+            Spacer(minLength: 4)
+
+            testControl
+        }
+        .padding(.vertical, 7)
+    }
+
+    @ViewBuilder private var testControl: some View {
+        HStack(spacing: 5) {
+            if let result, !testing { resultIcon(result) }
+            if testing {
+                ProgressView().controlSize(.small)
+            } else {
+                Button("Test") { runTest() }
+                    .controlSize(.small)
+                    .help("Fetch usage with this token through the poller (persists + counts against its budget).")
+            }
+        }
+    }
+
+    private func runTest() {
+        testing = true
+        result = nil
+        Task { @MainActor in
+            let r = await TokenPoolStatus.shared.testLane(id: lane.id)
+            result = r
+            testing = false
+        }
+    }
+
+    @ViewBuilder private func resultIcon(_ r: TokenTestResult) -> some View {
+        switch r {
+        case .success:
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.system(size: 12)).help("Valid")
+        case .foreignAccount:
+            Image(systemName: "person.crop.circle.badge.xmark").foregroundStyle(.purple).font(.system(size: 12)).help("Different account")
+        case .failure(let reason):
+            Image(systemName: "xmark.circle.fill").foregroundStyle(.red).font(.system(size: 12)).help(reason)
+        case .unavailable:
+            Image(systemName: "questionmark.circle").foregroundStyle(.secondary).font(.system(size: 12)).help("Poller not running")
+        }
+    }
+
+    private var statusPill: some View {
+        let info = statusInfo
+        return Text(info.0)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(info.1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(info.1.opacity(0.14)))
+    }
+
+    private var statusInfo: (String, Color) {
+        let now = Date()
+        if let exp = lane.expiresAt, exp < now { return ("expired", .red) }
+        if lane.account == .foreign { return ("other acct", .purple) }
+        if let cd = lane.cooldownUntil, cd > now { return ("cooling", .orange) }
+        if lane.account == .primary { return ("active", .green) }
+        return ("pending", .gray)
+    }
+
+    private var accountText: String {
+        guard let org = lane.organizationId else { return "—" }
+        return "…\(org.suffix(6))"
+    }
+
+    private var expiresText: String {
+        guard let exp = lane.expiresAt else { return "—" }
+        if exp < Date() { return "expired" }
+        return Self.relative.localizedString(for: exp, relativeTo: Date())
+    }
+
+    private var updatedText: String {
+        guard let last = lane.lastPolledAt else { return "never" }
+        return Self.relative.localizedString(for: last, relativeTo: Date())
+    }
+
+    private static let relative: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    private static func name(_ s: CredentialCandidate.Source) -> String {
+        switch s {
+        case .keychain: return "Claude Code"
+        case .desktop:  return "Claude Desktop"
+        case .override: return "Manual override"
+        case .held:     return "Saved by Pacer"
+        }
+    }
+
+    private static func icon(_ s: CredentialCandidate.Source) -> String {
+        switch s {
+        case .keychain: return "terminal"
+        case .desktop:  return "desktopcomputer"
+        case .override: return "key.fill"
+        case .held:     return "lock.fill"
         }
     }
 }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -40,7 +40,6 @@ struct SettingsView: View {
                 SettingsSection("Authentication") {
                     TokensCard()
                     DesktopCredentialsCard()
-                    OAuthTokenOverrideCard()
                 }
                 SettingsSection("Data") {
                     CostCalculationCard()
@@ -1098,211 +1097,6 @@ private struct DesktopCredentialsCard: View {
     }
 }
 
-/// Manual OAuth access-token override. When non-empty, the OAuth poller
-/// uses this token instead of the keychain / `.credentials.json` copy.
-/// Escape hatch for environments where neither source is readable (a
-/// sandboxed/SSH context), or while a fresh token propagates.
-///
-/// Must be a `user:profile`-scoped interactive access token (the
-/// `accessToken` from the keychain blob). A `claude setup-token` value is
-/// `user:inference`-only and `/api/oauth/usage` rejects it with 401.
-///
-/// UX shape: draft state local to the card, committed to `@AppStorage`
-/// only on Save. Test runs a one-off `OAuthClient.fetchUsage()` with the
-/// *draft* (not the saved value), so the user can validate before
-/// committing — same one-call shape the poller itself uses, no
-/// special-case server hit.
-private struct OAuthTokenOverrideCard: View {
-    @AppStorage(PacerSettings.Key.oauthTokenOverride, store: PacerSettings.store)
-    private var savedOverride: String = ""
-
-    @State private var draft: String = ""
-    @State private var testResult: TestResult?
-    @State private var testInProgress: Bool = false
-
-    /// Result of running the Test button against the draft token. Kept
-    /// alongside the UI rather than persisted — once the user types
-    /// anything, the prior verdict is no longer authoritative.
-    private enum TestResult: Equatable {
-        case success(fiveHourPct: Double?, sevenDayPct: Double?)
-        case failure(message: String)
-    }
-
-    private var trimmedDraft: String {
-        draft.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    private var draftIsEmpty: Bool { trimmedDraft.isEmpty }
-    private var isDirty: Bool { draft != savedOverride }
-
-    var body: some View {
-        PacerCard("OAuth token override", content: {
-            VStack(alignment: .leading, spacing: 10) {
-                TextField("Paste OAuth access token", text: $draft, axis: .vertical)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(size: 11, design: .monospaced))
-                    .lineLimit(2...4)
-                    .onChange(of: draft) { _, _ in
-                        // Editing invalidates the prior test verdict.
-                        testResult = nil
-                    }
-
-                HStack(spacing: 8) {
-                    statusLabel
-                    Spacer(minLength: 8)
-                    Button(draftIsEmpty ? "Test keychain" : "Test") { runTest() }
-                        .controlSize(.small)
-                        .disabled(testInProgress)
-                        .help(draftIsEmpty
-                            ? "Tests the OAuth token Pacer currently reads from the Claude Code keychain."
-                            : "Tests the token in the field above (not yet saved).")
-                    Button("Save") {
-                        savedOverride = draft
-                        // Saving a different value invalidates the prior test;
-                        // the saved value is now what the poller will use.
-                        testResult = nil
-                    }
-                    .controlSize(.small)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(!isDirty || testInProgress)
-                    Button("Clear") {
-                        draft = ""
-                        savedOverride = ""
-                        testResult = nil
-                    }
-                    .controlSize(.small)
-                    .disabled(draftIsEmpty && savedOverride.isEmpty || testInProgress)
-                }
-            }
-        }, footer: {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Normally Pacer reads the token itself — from the Claude Code keychain entry, or from `~/.claude/.credentials.json` when the keychain isn't readable (Linux, or macOS over SSH). Only paste here if neither works for you.")
-                Text("Paste the interactive `user:profile` access token (NOT a `claude setup-token`, which lacks the scope the usage endpoint needs). Fetch it after signing into Claude Code:")
-                    .padding(.top, 2)
-                Text("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                Text("Access tokens last ~8 hours; re-paste when Pacer's chip turns yellow again.")
-                    .padding(.top, 2)
-            }
-        })
-        .onAppear { draft = savedOverride }
-    }
-
-    /// Single source of truth for the status icon + caption sitting to
-    /// the left of the action buttons. Test result takes precedence
-    /// (the user just asked for it) over saved/dirty state.
-    @ViewBuilder
-    private var statusLabel: some View {
-        if testInProgress {
-            ProgressView()
-                .controlSize(.small)
-            Text("Testing…")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        } else if let result = testResult {
-            switch result {
-            case .success(let fh, let sd):
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .font(.system(size: 12))
-                Text("Valid · \(formatSuccess(fiveHour: fh, sevenDay: sd))")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            case .failure(let msg):
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.red)
-                    .font(.system(size: 12))
-                Text(msg)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-                    .lineLimit(3)
-            }
-        } else if isDirty {
-            Image(systemName: "pencil")
-                .foregroundStyle(.orange)
-                .font(.system(size: 12))
-            Text("Unsaved changes")
-                .font(.caption)
-                .foregroundStyle(.orange)
-        } else if !savedOverride.isEmpty {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-                .font(.system(size: 12))
-            Text("Saved · Pacer is using this token")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        } else {
-            Image(systemName: "key")
-                .foregroundStyle(.tertiary)
-                .font(.system(size: 12))
-            Text("Empty · Pacer reads from keychain")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .lineLimit(1)
-        }
-    }
-
-    private func formatSuccess(fiveHour: Double?, sevenDay: Double?) -> String {
-        let f = fiveHour.map { "5h=\(Int($0.rounded()))%" } ?? "5h=—"
-        let s = sevenDay.map { "7d=\(Int($0.rounded()))%" } ?? "7d=—"
-        return "\(f), \(s)"
-    }
-
-    /// Run one OAuth request, mirroring whichever path the poller
-    /// itself would take right now:
-    ///   - draft non-empty: test the *draft*, with a broken keychain
-    ///     underneath so the result reflects the typed token alone.
-    ///   - draft empty: test the live keychain read, exactly as the
-    ///     production poller would do it. Useful for confirming a
-    ///     fresh `claude login` produced a working token before
-    ///     trusting Pacer's next poll.
-    /// Route the test through the running poller so the reading is
-    /// persisted and counts against that token's budget — instead of a
-    /// separate throwaway request that races the poller's own polls.
-    private func runTest() {
-        let token = trimmedDraft
-        testInProgress = true
-        testResult = nil
-        Task { @MainActor in
-            let outcome: TokenTestResult
-            if token.isEmpty {
-                // Empty field ⇒ test the token Pacer reads from the
-                // keychain. Resolve it here, then route the raw token
-                // through the poller like any other.
-                switch KeychainOAuth().read() {
-                case .success(let cred):
-                    outcome = await TokenPoolStatus.shared.testAdHoc(token: cred.accessToken)
-                case .failure:
-                    outcome = .failure(reason: "No readable Claude Code token in the keychain.")
-                }
-            } else {
-                outcome = await TokenPoolStatus.shared.testAdHoc(token: token)
-            }
-            testInProgress = false
-            testResult = Self.classify(outcome)
-        }
-    }
-
-    /// Map the poller's test outcome to the card's status line. The
-    /// poller already distills HTTP errors into human messages.
-    private static func classify(_ result: TokenTestResult) -> TestResult {
-        switch result {
-        case .success(let fh, let sd):
-            return .success(fiveHourPct: fh, sevenDayPct: sd)
-        case .foreignAccount(let org):
-            let suffix = org.map { " (\($0.prefix(8))…)" } ?? ""
-            return .failure(message: "This token belongs to a different account\(suffix) — Pacer keeps it out of the pool.")
-        case .failure(let reason):
-            return .failure(message: reason)
-        case .unavailable:
-            return .failure(message: "Pacer's poller isn't running yet — try again in a moment.")
-        }
-    }
-}
-
 // MARK: - Token pool
 
 /// Live view of the OAuth token pool the poller cycles through — where
@@ -1311,33 +1105,109 @@ private struct OAuthTokenOverrideCard: View {
 /// and counts against that token's budget instead of racing it).
 private struct TokensCard: View {
     @State private var pool = TokenPoolStatus.shared
+    @State private var draft: String = ""
+    @State private var adding = false
+    @State private var addResult: TokenTestResult?
 
     var body: some View {
         PacerCard("Tokens", trailing: {
             cadenceHeader
         }, content: {
-            if pool.lanes.isEmpty {
-                Text("No tokens yet — sign into Claude Code, or add one below.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 4)
-            } else {
-                VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                if pool.lanes.isEmpty {
+                    Text("No tokens yet — sign into Claude Code, enable Claude Desktop below, or add one manually.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 4)
+                } else {
                     columnHeader
                     ForEach(pool.lanes) { lane in
                         Divider().opacity(0.35)
                         TokenLaneRow(lane: lane)
                     }
                 }
+                addTokenRow
             }
         }, footer: {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Pacer spreads usage polls across every token it can read for your account, so it refreshes more often while you're active without exceeding any single token's rate limit. Tokens are cycled by priority (top first).")
-                Text("Add more by enabling Claude Desktop below (its tokens join the pool) or pasting one in “OAuth token override”. Testing a token here fetches real usage through the poller — it updates your history and counts against that token's budget.")
+                Text("Claude Code and (if enabled below) Claude Desktop are read automatically. Only *add* a token Pacer can't read here — e.g. from another Mac, where you'd run:")
+                    .padding(.top, 2)
+                Text("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                Text("…then paste the result above. It must be a `user:profile` token, and only tokens for this same account are kept.")
                     .padding(.top, 2)
             }
         })
+    }
+
+    private var addTokenRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Divider().opacity(0.35).padding(.top, 4)
+            HStack(spacing: 8) {
+                TextField("Paste a token to add (e.g. from another Mac)", text: $draft)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+                    .onSubmit(add)
+                    .onChange(of: draft) { _, _ in addResult = nil }
+                if adding {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button("Add", action: add)
+                        .controlSize(.small)
+                        .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            if let addResult { addResultLabel(addResult) }
+        }
+        .padding(.top, 8)
+    }
+
+    @ViewBuilder private func addResultLabel(_ r: TokenTestResult) -> some View {
+        switch r {
+        case .success(let fh, let sd):
+            addLabel("checkmark.circle.fill", .green, "Added · \(Self.usage(fh, sd))")
+        case .alreadyTracked:
+            addLabel("info.circle.fill", .gray, "Already tracking this token — nothing added.")
+        case .foreignAccount:
+            addLabel("person.crop.circle.badge.xmark", .purple, "That token is a different account — not added.")
+        case .failure(let reason):
+            addLabel("xmark.circle.fill", .red, reason)
+        case .unavailable:
+            addLabel("xmark.circle.fill", .red, "Pacer's poller isn't running — try again in a moment.")
+        }
+    }
+
+    private func addLabel(_ icon: String, _ color: Color, _ text: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon).foregroundStyle(color).font(.system(size: 11))
+            Text(text).font(.caption).foregroundStyle(color).lineLimit(2)
+        }
+    }
+
+    private static func usage(_ fh: Double?, _ sd: Double?) -> String {
+        let f = fh.map { "5h \(Int($0.rounded()))%" } ?? "5h —"
+        let s = sd.map { "7d \(Int($0.rounded()))%" } ?? "7d —"
+        return "\(f), \(s)"
+    }
+
+    private func add() {
+        let token = draft
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        adding = true
+        addResult = nil
+        Task { @MainActor in
+            let r = await TokenPoolStatus.shared.addManualToken(token)
+            addResult = r
+            adding = false
+            switch r {
+            case .success, .alreadyTracked: draft = ""
+            default: break
+            }
+        }
     }
 
     private var cadenceHeader: some View {
@@ -1373,7 +1243,7 @@ private struct TokensCard: View {
             Text("EXPIRES").frame(width: 58, alignment: .leading)
             Text("UPDATED").frame(width: 66, alignment: .leading)
                 .help("When Pacer last fetched usage with this token")
-            Color.clear.frame(width: 48)   // aligns over the Test button
+            Color.clear.frame(width: 78)   // aligns over the Remove/Test controls
         }
         .font(.system(size: 9, weight: .semibold))
         .tracking(0.5)
@@ -1386,6 +1256,8 @@ private struct TokensCard: View {
 private struct TokenLaneRow: View {
     let lane: TokenLaneStatus
     @State private var testing = false
+    @State private var cooling = false
+    @State private var removing = false
     @State private var result: TokenTestResult?
 
     var body: some View {
@@ -1433,10 +1305,27 @@ private struct TokenLaneRow: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 66, alignment: .leading)
 
-            testControl
-                .frame(width: 48, alignment: .trailing)
+            trailingControls
+                .frame(width: 78, alignment: .trailing)
         }
         .padding(.vertical, 7)
+    }
+
+    @ViewBuilder private var trailingControls: some View {
+        HStack(spacing: 6) {
+            // Manually-added tokens can be removed; auto-sourced ones can't
+            // (they'd just be rediscovered).
+            if lane.source == .override {
+                Button { remove() } label: {
+                    Image(systemName: "trash").font(.system(size: 11))
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+                .disabled(removing)
+                .help("Remove this manually-added token")
+            }
+            testControl
+        }
     }
 
     @ViewBuilder private var testControl: some View {
@@ -1447,7 +1336,10 @@ private struct TokenLaneRow: View {
             } else {
                 Button("Test") { runTest() }
                     .controlSize(.small)
-                    .help("Fetch usage with this token through the poller (persists + counts against its budget).")
+                    .disabled(cooling)
+                    .help(cooling
+                        ? "Just tested — give it a moment before testing again."
+                        : "Fetch usage with this token through the poller (persists + counts against its budget).")
             }
         }
     }
@@ -1459,6 +1351,19 @@ private struct TokenLaneRow: View {
             let r = await TokenPoolStatus.shared.testLane(id: lane.id)
             result = r
             testing = false
+            // Brief cooldown so rapid re-clicks can't spend the token's
+            // budget into a 429.
+            cooling = true
+            try? await Task.sleep(nanoseconds: 20_000_000_000)
+            cooling = false
+        }
+    }
+
+    private func remove() {
+        removing = true
+        Task { @MainActor in
+            await TokenPoolStatus.shared.removeManualToken(id: lane.id)
+            // Lane vanishes from pool.lanes → this row is removed.
         }
     }
 
@@ -1470,6 +1375,8 @@ private struct TokenLaneRow: View {
             Image(systemName: "person.crop.circle.badge.xmark").foregroundStyle(.purple).font(.system(size: 12)).help("Different account")
         case .failure(let reason):
             Image(systemName: "xmark.circle.fill").foregroundStyle(.red).font(.system(size: 12)).help(reason)
+        case .alreadyTracked:
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.system(size: 12)).help("Already tracked")
         case .unavailable:
             Image(systemName: "questionmark.circle").foregroundStyle(.secondary).font(.system(size: 12)).help("Poller not running")
         }
@@ -1521,7 +1428,7 @@ private struct TokenLaneRow: View {
         switch s {
         case .keychain: return "Claude Code"
         case .desktop:  return "Claude Desktop"
-        case .override: return "Manual override"
+        case .override: return "Manual"
         case .held:     return "Saved by Pacer"
         }
     }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -1234,7 +1234,16 @@ private struct TokensCard: View {
             cadenceHeader
         }, content: {
             VStack(alignment: .leading, spacing: 0) {
-                if pool.lanes.isEmpty {
+                if !pool.hasLoaded {
+                    HStack(spacing: 6) {
+                        ProgressView().controlSize(.small)
+                        Text("Loading tokens…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+                } else if pool.lanes.isEmpty {
                     Text("No tokens yet — sign into Claude Code, enable Claude Desktop below, or add one manually.")
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -1103,6 +1103,46 @@ private struct DesktopCredentialsCard: View {
 /// each token comes from, which account it's tied to, when it expires,
 /// its health, and a Test that routes through the poller (so it persists
 /// and counts against that token's budget instead of racing it).
+/// A one-line shell command in monospace with a click-to-copy button that
+/// flips to a checkmark (+ a trackpad haptic) for feedback, so the user
+/// doesn't have to select the text by hand.
+private struct CopyableCommand: View {
+    let command: String
+    @State private var copied = false
+    init(_ command: String) { self.command = command }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(command)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: copy) {
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 11))
+                    .foregroundStyle(copied ? Color.green : Color.secondary)
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.borderless)
+            .help(copied ? "Copied!" : "Copy command")
+        }
+    }
+
+    private func copy() {
+        #if canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(command, forType: .string)
+        NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
+        #endif
+        withAnimation { copied = true }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_600_000_000)
+            withAnimation { copied = false }
+        }
+    }
+}
+
 private struct TokensCard: View {
     @State private var pool = TokenPoolStatus.shared
     @State private var draft: String = ""
@@ -1134,10 +1174,7 @@ private struct TokensCard: View {
                 Text("Pacer spreads usage polls across every token it can read for your account, so it refreshes more often while you're active without exceeding any single token's rate limit. Tokens are cycled by priority (top first).")
                 Text("Claude Code and (if enabled below) Claude Desktop are read automatically. Only *add* a token Pacer can't read here — e.g. from another Mac, where you'd run:")
                     .padding(.top, 2)
-                Text("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
+                CopyableCommand("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
                 Text("…then paste the result above. It must be a `user:profile` token, and only tokens for this same account are kept.")
                     .padding(.top, 2)
             }
@@ -1201,12 +1238,12 @@ private struct TokensCard: View {
         addResult = nil
         Task { @MainActor in
             let r = await TokenPoolStatus.shared.addManualToken(token)
-            addResult = r
             adding = false
-            switch r {
-            case .success, .alreadyTracked: draft = ""
-            default: break
-            }
+            // NB: do NOT clear `draft` here — that fires the field's
+            // onChange, which resets `addResult` and hides the result the
+            // user needs to see. Leave the token in place; editing it (or
+            // a new paste) clears the message via onChange.
+            addResult = r
         }
     }
 
@@ -1256,7 +1293,6 @@ private struct TokensCard: View {
 private struct TokenLaneRow: View {
     let lane: TokenLaneStatus
     @State private var testing = false
-    @State private var cooling = false
     @State private var removing = false
     @State private var result: TokenTestResult?
 
@@ -1336,12 +1372,20 @@ private struct TokenLaneRow: View {
             } else {
                 Button("Test") { runTest() }
                     .controlSize(.small)
-                    .disabled(cooling)
-                    .help(cooling
-                        ? "Just tested — give it a moment before testing again."
+                    .disabled(recentlyPolled)
+                    .help(recentlyPolled
+                        ? "Just fetched — its data is current; give it a moment."
                         : "Fetch usage with this token through the poller (persists + counts against its budget).")
             }
         }
+    }
+
+    /// True if this lane was polled (by a Test or the auto-cadence) within
+    /// the last 20s. Derived from the shared `lastPolledAt`, so the Test
+    /// cooldown survives tab switches — unlike a view-local flag would.
+    private var recentlyPolled: Bool {
+        guard let last = lane.lastPolledAt else { return false }
+        return Date().timeIntervalSince(last) < 20
     }
 
     private func runTest() {
@@ -1351,11 +1395,6 @@ private struct TokenLaneRow: View {
             let r = await TokenPoolStatus.shared.testLane(id: lane.id)
             result = r
             testing = false
-            // Brief cooldown so rapid re-clicks can't spend the token's
-            // budget into a 429.
-            cooling = true
-            try? await Task.sleep(nanoseconds: 20_000_000_000)
-            cooling = false
         }
     }
 

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -1367,13 +1367,13 @@ private struct TokensCard: View {
 
     private var columnHeader: some View {
         HStack(spacing: 10) {
-            Text("SOURCE").frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
-            Text("ACCOUNT").frame(minWidth: 70, maxWidth: .infinity, alignment: .leading)
-            Text("STATUS").frame(width: 74, alignment: .leading)
-            Text("EXPIRES").frame(width: 62, alignment: .leading)
-            Text("UPDATED").frame(width: 74, alignment: .leading)
+            Text("SOURCE").frame(width: 145, alignment: .leading)
+            Text("ACCOUNT").frame(minWidth: 90, maxWidth: .infinity, alignment: .leading)
+            Text("STATUS").frame(width: 72, alignment: .leading)
+            Text("EXPIRES").frame(width: 58, alignment: .leading)
+            Text("UPDATED").frame(width: 66, alignment: .leading)
                 .help("When Pacer last fetched usage with this token")
-            Color.clear.frame(width: 56)   // aligns over the Test button
+            Color.clear.frame(width: 48)   // aligns over the Test button
         }
         .font(.system(size: 9, weight: .semibold))
         .tracking(0.5)
@@ -1408,32 +1408,33 @@ private struct TokenLaneRow: View {
                         .help("Token fingerprint \(lane.id)")
                 }
             }
-            .frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
+            .frame(width: 145, alignment: .leading)
 
-            // ACCOUNT — flexible; middle-truncates, hover for the full org id.
+            // ACCOUNT — the sole flexible column: fills the slack, shows the
+            // full org id, middle-truncates + hover only when too narrow.
             Text(accountText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .frame(minWidth: 70, maxWidth: .infinity, alignment: .leading)
+                .frame(minWidth: 90, maxWidth: .infinity, alignment: .leading)
                 .help(lane.organizationId ?? "")
 
             statusPill
-                .frame(width: 74, alignment: .leading)
+                .frame(width: 72, alignment: .leading)
 
             Text(expiresText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 62, alignment: .leading)
+                .frame(width: 58, alignment: .leading)
 
             Text(updatedText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 74, alignment: .leading)
+                .frame(width: 66, alignment: .leading)
 
             testControl
-                .frame(width: 56, alignment: .trailing)
+                .frame(width: 48, alignment: .trailing)
         }
         .padding(.vertical, 7)
     }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -60,6 +60,10 @@ struct SettingsView: View {
             // the cards sit consistently flush with the sidebar.
             .frame(maxWidth: 760, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .topLeading)
+            // Click anywhere off a text field to dismiss its focus ring.
+            #if canImport(AppKit)
+            .background(FocusResignOnClick())
+            #endif
         }
     }
 }
@@ -1103,17 +1107,45 @@ private struct DesktopCredentialsCard: View {
 /// each token comes from, which account it's tied to, when it expires,
 /// its health, and a Test that routes through the poller (so it persists
 /// and counts against that token's budget instead of racing it).
-/// A one-line shell command shown as a code block with a click-to-copy
-/// button that flips to a checkmark (+ a trackpad haptic). The button is
-/// fixed-width so the flip can't reflow the row; the command scrolls
-/// horizontally rather than wrapping.
+/// Fixed column widths shared by the Tokens header and rows so they line
+/// up exactly. SOURCE is the flexible column (fills the remainder).
+fileprivate enum TokenCol {
+    static let account: CGFloat = 244
+    static let status: CGFloat = 78
+    static let expires: CGFloat = 64
+    static let updated: CGFloat = 76
+    static let trash: CGFloat = 24
+    static let spacing: CGFloat = 12
+}
+
+#if canImport(AppKit)
+/// Transparent click-catcher placed behind content: a click on empty space
+/// resigns the window's first responder (dismissing a TextField's focus
+/// ring), while clicks on real controls still reach them (they sit in
+/// front). Fixes "the paste field stays focused when I click elsewhere".
+private struct FocusResignOnClick: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { CatcherView() }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+    private final class CatcherView: NSView {
+        override func mouseDown(with event: NSEvent) {
+            window?.makeFirstResponder(nil)
+            super.mouseDown(with: event)
+        }
+    }
+}
+#endif
+
+/// A one-line shell command shown as a code block. The whole box is
+/// click-to-copy (button flips to a checkmark + trackpad haptic); the
+/// command scrolls horizontally with a right-edge fade so it's clear it
+/// continues past the copy button rather than being all there is.
 private struct CopyableCommand: View {
     let command: String
     @State private var copied = false
     init(_ command: String) { self.command = command }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 14) {
             Image(systemName: "terminal")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
@@ -1125,26 +1157,27 @@ private struct CopyableCommand: View {
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
-            Button(action: copy) {
-                Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(copied ? Color.green : Color.secondary)
-                    .frame(width: 16, height: 14)   // fixed → the flip can't shift layout
-                    .contentTransition(.symbolEffect(.replace))
-            }
-            .buttonStyle(.plain)
-            .help(copied ? "Copied!" : "Copy command")
+            .mask(
+                LinearGradient(
+                    stops: [.init(color: .black, location: 0),
+                            .init(color: .black, location: 0.88),
+                            .init(color: .clear, location: 1.0)],
+                    startPoint: .leading, endPoint: .trailing
+                )
+            )
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(copied ? Color.green : Color.secondary)
+                .frame(width: 18, height: 16)   // fixed → the flip can't shift layout
+                .contentTransition(.symbolEffect(.replace))
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(Color.primary.opacity(0.06))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Color.primary.opacity(0.06)))
+        .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(Color.primary.opacity(0.08), lineWidth: 1))
+        .contentShape(Rectangle())
+        .onTapGesture(perform: copy)
+        .help(copied ? "Copied!" : "Click to copy")
     }
 
     private func copy() {
@@ -1161,10 +1194,9 @@ private struct CopyableCommand: View {
     }
 }
 
-/// Live view of the OAuth token pool the poller cycles through — where each
-/// token comes from, its account, expiry, health, and when it last polled;
-/// plus an inline "add a token" field. No per-row Test button (auto-polling
-/// keeps everything current; a newly-added token is validated on add).
+/// Live view of the OAuth token pool the poller cycles through — source,
+/// account, expiry, health, and when each last polled; plus an inline
+/// "add a token" field.
 private struct TokensCard: View {
     @State private var pool = TokenPoolStatus.shared
     @State private var draft: String = ""
@@ -1195,23 +1227,14 @@ private struct TokensCard: View {
             }
         }, footer: {
             VStack(alignment: .leading, spacing: 4) {
-                if let org = primaryOrg {
-                    Text("All tokens are for account \(org).")
-                }
                 Text("Pacer spreads usage polls across every token it can read for your account, so it refreshes more often while you're active without exceeding any single token's rate limit.")
                 Text("Claude Code and (if enabled below) Claude Desktop are read automatically. Only *add* a token Pacer can't read here — e.g. from another Mac, where you'd run this in Terminal:")
                     .padding(.top, 2)
                 CopyableCommand("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
+                    .padding(.vertical, 6)
                 Text("…then paste the result above. It must be a `user:profile` token, and only tokens for this same account are kept.")
-                    .padding(.top, 2)
             }
         })
-    }
-
-    /// The account all tokens belong to (shown once instead of on every row).
-    private var primaryOrg: String? {
-        pool.lanes.first(where: { $0.account == .primary })?.organizationId
-            ?? pool.lanes.first?.organizationId
     }
 
     private var cadenceHeader: some View {
@@ -1240,13 +1263,14 @@ private struct TokensCard: View {
     }
 
     private var columnHeader: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: TokenCol.spacing) {
             Text("SOURCE").frame(maxWidth: .infinity, alignment: .leading)
-            Text("STATUS").frame(width: 82, alignment: .leading)
-            Text("EXPIRES").frame(width: 72, alignment: .leading)
-            Text("UPDATED").frame(width: 82, alignment: .leading)
+            Text("ACCOUNT").frame(width: TokenCol.account, alignment: .leading)
+            Text("STATUS").frame(width: TokenCol.status, alignment: .leading)
+            Text("EXPIRES").frame(width: TokenCol.expires, alignment: .leading)
+            Text("UPDATED").frame(width: TokenCol.updated, alignment: .leading)
                 .help("When Pacer last fetched usage with this token")
-            Color.clear.frame(width: 24)   // trash column (manual rows only)
+            Color.clear.frame(width: TokenCol.trash)   // trash column (manual rows only)
         }
         .font(.system(size: 9, weight: .semibold))
         .tracking(0.5)
@@ -1275,10 +1299,6 @@ private struct TokensCard: View {
             if let addResult { addResultLabel(addResult) }
         }
         .padding(.top, 8)
-        // Click anywhere in the card off the field to dismiss its focus ring.
-        .background(
-            Color.clear.contentShape(Rectangle()).onTapGesture { fieldFocused = false }
-        )
     }
 
     @ViewBuilder private func addResultLabel(_ r: TokenTestResult) -> some View {
@@ -1327,9 +1347,7 @@ private struct TokensCard: View {
             let r = await TokenPoolStatus.shared.addManualToken(token)
             adding = false
             fieldFocused = false
-            // NB: don't clear `draft` — that fires onChange → wipes addResult.
-            addResult = r
-            // Flash the matching row when it's a duplicate.
+            addResult = r   // NB: don't clear `draft` — onChange would wipe this.
             if case .alreadyTracked(_, let fp) = r {
                 highlightId = fp
                 Task { @MainActor in
@@ -1349,7 +1367,7 @@ private struct TokenLaneRow: View {
     @State private var removing = false
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: TokenCol.spacing) {
             HStack(spacing: 7) {
                 Image(systemName: Self.icon(lane.source))
                     .font(.system(size: 12))
@@ -1369,26 +1387,37 @@ private struct TokenLaneRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
+            Text(lane.organizationId ?? "—")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(width: TokenCol.account, alignment: .leading)
+                .help(lane.organizationId ?? "")
+
             statusPill
-                .frame(width: 82, alignment: .leading)
+                .frame(width: TokenCol.status, alignment: .leading)
 
             Text(expiresText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 72, alignment: .leading)
+                .frame(width: TokenCol.expires, alignment: .leading)
 
             Text(updatedText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 82, alignment: .leading)
+                .frame(width: TokenCol.updated, alignment: .leading)
 
             removeControl
-                .frame(width: 24, alignment: .trailing)
+                .frame(width: TokenCol.trash, alignment: .trailing)
         }
         .padding(.vertical, 7)
         .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(highlighted ? Color.accentColor.opacity(0.14) : Color.clear)
+            // Bleed the highlight outward so it wraps the source icon and
+            // reaches the card edges, without shifting the row content.
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(highlighted ? Color.accentColor.opacity(0.16) : Color.clear)
+                .padding(.horizontal, -10)
         )
         .animation(.easeInOut(duration: 0.25), value: highlighted)
     }
@@ -1409,7 +1438,6 @@ private struct TokenLaneRow: View {
         removing = true
         Task { @MainActor in
             await TokenPoolStatus.shared.removeManualToken(id: lane.id)
-            // Lane vanishes from pool.lanes → this row is removed.
         }
     }
 

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -1103,30 +1103,48 @@ private struct DesktopCredentialsCard: View {
 /// each token comes from, which account it's tied to, when it expires,
 /// its health, and a Test that routes through the poller (so it persists
 /// and counts against that token's budget instead of racing it).
-/// A one-line shell command in monospace with a click-to-copy button that
-/// flips to a checkmark (+ a trackpad haptic) for feedback, so the user
-/// doesn't have to select the text by hand.
+/// A one-line shell command shown as a code block with a click-to-copy
+/// button that flips to a checkmark (+ a trackpad haptic). The button is
+/// fixed-width so the flip can't reflow the row; the command scrolls
+/// horizontally rather than wrapping.
 private struct CopyableCommand: View {
     let command: String
     @State private var copied = false
     init(_ command: String) { self.command = command }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(command)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        HStack(spacing: 8) {
+            Image(systemName: "terminal")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(command)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
             Button(action: copy) {
                 Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .font(.system(size: 11))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(copied ? Color.green : Color.secondary)
+                    .frame(width: 16, height: 14)   // fixed → the flip can't shift layout
                     .contentTransition(.symbolEffect(.replace))
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.plain)
             .help(copied ? "Copied!" : "Copy command")
         }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     private func copy() {
@@ -1143,11 +1161,17 @@ private struct CopyableCommand: View {
     }
 }
 
+/// Live view of the OAuth token pool the poller cycles through — where each
+/// token comes from, its account, expiry, health, and when it last polled;
+/// plus an inline "add a token" field. No per-row Test button (auto-polling
+/// keeps everything current; a newly-added token is validated on add).
 private struct TokensCard: View {
     @State private var pool = TokenPoolStatus.shared
     @State private var draft: String = ""
     @State private var adding = false
     @State private var addResult: TokenTestResult?
+    @State private var highlightId: String?
+    @FocusState private var fieldFocused: Bool
 
     var body: some View {
         PacerCard("Tokens", trailing: {
@@ -1164,15 +1188,18 @@ private struct TokensCard: View {
                     columnHeader
                     ForEach(pool.lanes) { lane in
                         Divider().opacity(0.35)
-                        TokenLaneRow(lane: lane)
+                        TokenLaneRow(lane: lane, highlighted: lane.id == highlightId)
                     }
                 }
                 addTokenRow
             }
         }, footer: {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Pacer spreads usage polls across every token it can read for your account, so it refreshes more often while you're active without exceeding any single token's rate limit. Tokens are cycled by priority (top first).")
-                Text("Claude Code and (if enabled below) Claude Desktop are read automatically. Only *add* a token Pacer can't read here — e.g. from another Mac, where you'd run:")
+                if let org = primaryOrg {
+                    Text("All tokens are for account \(org).")
+                }
+                Text("Pacer spreads usage polls across every token it can read for your account, so it refreshes more often while you're active without exceeding any single token's rate limit.")
+                Text("Claude Code and (if enabled below) Claude Desktop are read automatically. Only *add* a token Pacer can't read here — e.g. from another Mac, where you'd run this in Terminal:")
                     .padding(.top, 2)
                 CopyableCommand("security find-generic-password -s 'Claude Code-credentials' -w | jq -r .claudeAiOauth.accessToken")
                 Text("…then paste the result above. It must be a `user:profile` token, and only tokens for this same account are kept.")
@@ -1181,70 +1208,10 @@ private struct TokensCard: View {
         })
     }
 
-    private var addTokenRow: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Divider().opacity(0.35).padding(.top, 4)
-            HStack(spacing: 8) {
-                TextField("Paste a token to add (e.g. from another Mac)", text: $draft)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(size: 11, design: .monospaced))
-                    .onSubmit(add)
-                    .onChange(of: draft) { _, _ in addResult = nil }
-                if adding {
-                    ProgressView().controlSize(.small)
-                } else {
-                    Button("Add", action: add)
-                        .controlSize(.small)
-                        .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                }
-            }
-            if let addResult { addResultLabel(addResult) }
-        }
-        .padding(.top, 8)
-    }
-
-    @ViewBuilder private func addResultLabel(_ r: TokenTestResult) -> some View {
-        switch r {
-        case .success(let fh, let sd):
-            addLabel("checkmark.circle.fill", .green, "Added · \(Self.usage(fh, sd))")
-        case .alreadyTracked:
-            addLabel("info.circle.fill", .gray, "Already tracking this token — nothing added.")
-        case .foreignAccount:
-            addLabel("person.crop.circle.badge.xmark", .purple, "That token is a different account — not added.")
-        case .failure(let reason):
-            addLabel("xmark.circle.fill", .red, reason)
-        case .unavailable:
-            addLabel("xmark.circle.fill", .red, "Pacer's poller isn't running — try again in a moment.")
-        }
-    }
-
-    private func addLabel(_ icon: String, _ color: Color, _ text: String) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: icon).foregroundStyle(color).font(.system(size: 11))
-            Text(text).font(.caption).foregroundStyle(color).lineLimit(2)
-        }
-    }
-
-    private static func usage(_ fh: Double?, _ sd: Double?) -> String {
-        let f = fh.map { "5h \(Int($0.rounded()))%" } ?? "5h —"
-        let s = sd.map { "7d \(Int($0.rounded()))%" } ?? "7d —"
-        return "\(f), \(s)"
-    }
-
-    private func add() {
-        let token = draft
-        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        adding = true
-        addResult = nil
-        Task { @MainActor in
-            let r = await TokenPoolStatus.shared.addManualToken(token)
-            adding = false
-            // NB: do NOT clear `draft` here — that fires the field's
-            // onChange, which resets `addResult` and hides the result the
-            // user needs to see. Leave the token in place; editing it (or
-            // a new paste) clears the message via onChange.
-            addResult = r
-        }
+    /// The account all tokens belong to (shown once instead of on every row).
+    private var primaryOrg: String? {
+        pool.lanes.first(where: { $0.account == .primary })?.organizationId
+            ?? pool.lanes.first?.organizationId
     }
 
     private var cadenceHeader: some View {
@@ -1273,32 +1240,116 @@ private struct TokensCard: View {
     }
 
     private var columnHeader: some View {
-        HStack(spacing: 10) {
-            Text("SOURCE").frame(width: 145, alignment: .leading)
-            Text("ACCOUNT").frame(minWidth: 90, maxWidth: .infinity, alignment: .leading)
-            Text("STATUS").frame(width: 72, alignment: .leading)
-            Text("EXPIRES").frame(width: 58, alignment: .leading)
-            Text("UPDATED").frame(width: 66, alignment: .leading)
+        HStack(spacing: 12) {
+            Text("SOURCE").frame(maxWidth: .infinity, alignment: .leading)
+            Text("STATUS").frame(width: 82, alignment: .leading)
+            Text("EXPIRES").frame(width: 72, alignment: .leading)
+            Text("UPDATED").frame(width: 82, alignment: .leading)
                 .help("When Pacer last fetched usage with this token")
-            Color.clear.frame(width: 78)   // aligns over the Remove/Test controls
+            Color.clear.frame(width: 24)   // trash column (manual rows only)
         }
         .font(.system(size: 9, weight: .semibold))
         .tracking(0.5)
         .foregroundStyle(.tertiary)
         .padding(.bottom, 6)
     }
+
+    private var addTokenRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Divider().opacity(0.35).padding(.top, 4)
+            HStack(spacing: 8) {
+                TextField("Paste a token to add (e.g. from another Mac)", text: $draft)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+                    .focused($fieldFocused)
+                    .onSubmit(add)
+                    .onChange(of: draft) { _, _ in addResult = nil }
+                if adding {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button("Add", action: add)
+                        .controlSize(.small)
+                        .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            if let addResult { addResultLabel(addResult) }
+        }
+        .padding(.top, 8)
+        // Click anywhere in the card off the field to dismiss its focus ring.
+        .background(
+            Color.clear.contentShape(Rectangle()).onTapGesture { fieldFocused = false }
+        )
+    }
+
+    @ViewBuilder private func addResultLabel(_ r: TokenTestResult) -> some View {
+        switch r {
+        case .success(let fh, let sd):
+            addLabel("checkmark.circle.fill", .green, "Added · \(Self.usage(fh, sd))")
+        case .alreadyTracked(let source, let fp):
+            addLabel("info.circle.fill", .gray, "Already tracking this — it's your \(Self.sourceName(source)) token (…\(String(fp.suffix(4)))).")
+        case .foreignAccount:
+            addLabel("person.crop.circle.badge.xmark", .purple, "That token is a different account — not added.")
+        case .failure(let reason):
+            addLabel("xmark.circle.fill", .red, reason)
+        case .unavailable:
+            addLabel("xmark.circle.fill", .red, "Pacer's poller isn't running — try again in a moment.")
+        }
+    }
+
+    private func addLabel(_ icon: String, _ color: Color, _ text: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon).foregroundStyle(color).font(.system(size: 11))
+            Text(text).font(.caption).foregroundStyle(color).lineLimit(2)
+        }
+    }
+
+    private static func usage(_ fh: Double?, _ sd: Double?) -> String {
+        let f = fh.map { "5h \(Int($0.rounded()))%" } ?? "5h —"
+        let s = sd.map { "7d \(Int($0.rounded()))%" } ?? "7d —"
+        return "\(f), \(s)"
+    }
+
+    private static func sourceName(_ s: CredentialCandidate.Source) -> String {
+        switch s {
+        case .keychain: return "Claude Code"
+        case .desktop:  return "Claude Desktop"
+        case .override: return "manually-added"
+        case .held:     return "saved"
+        }
+    }
+
+    private func add() {
+        let token = draft
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        adding = true
+        addResult = nil
+        Task { @MainActor in
+            let r = await TokenPoolStatus.shared.addManualToken(token)
+            adding = false
+            fieldFocused = false
+            // NB: don't clear `draft` — that fires onChange → wipes addResult.
+            addResult = r
+            // Flash the matching row when it's a duplicate.
+            if case .alreadyTracked(_, let fp) = r {
+                highlightId = fp
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 2_500_000_000)
+                    if highlightId == fp { highlightId = nil }
+                }
+            }
+        }
+    }
 }
 
-/// One row in the token pool. Owns its own Test in-flight state.
+/// One row in the token pool. Manually-added rows carry a Remove button;
+/// auto-sourced rows don't (they'd just be rediscovered).
 private struct TokenLaneRow: View {
     let lane: TokenLaneStatus
-    @State private var testing = false
+    let highlighted: Bool
     @State private var removing = false
-    @State private var result: TokenTestResult?
 
     var body: some View {
-        HStack(spacing: 10) {
-            // SOURCE — flexible; the id sub-line truncates first when narrow.
+        HStack(spacing: 12) {
             HStack(spacing: 7) {
                 Image(systemName: Self.icon(lane.source))
                     .font(.system(size: 12))
@@ -1316,85 +1367,41 @@ private struct TokenLaneRow: View {
                         .help("Token fingerprint \(lane.id)")
                 }
             }
-            .frame(width: 145, alignment: .leading)
-
-            // ACCOUNT — the sole flexible column: fills the slack, shows the
-            // full org id, middle-truncates + hover only when too narrow.
-            Text(accountText)
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(minWidth: 90, maxWidth: .infinity, alignment: .leading)
-                .help(lane.organizationId ?? "")
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             statusPill
-                .frame(width: 72, alignment: .leading)
+                .frame(width: 82, alignment: .leading)
 
             Text(expiresText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 58, alignment: .leading)
+                .frame(width: 72, alignment: .leading)
 
             Text(updatedText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 66, alignment: .leading)
+                .frame(width: 82, alignment: .leading)
 
-            trailingControls
-                .frame(width: 78, alignment: .trailing)
+            removeControl
+                .frame(width: 24, alignment: .trailing)
         }
         .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(highlighted ? Color.accentColor.opacity(0.14) : Color.clear)
+        )
+        .animation(.easeInOut(duration: 0.25), value: highlighted)
     }
 
-    @ViewBuilder private var trailingControls: some View {
-        HStack(spacing: 6) {
-            // Manually-added tokens can be removed; auto-sourced ones can't
-            // (they'd just be rediscovered).
-            if lane.source == .override {
-                Button { remove() } label: {
-                    Image(systemName: "trash").font(.system(size: 11))
-                }
-                .buttonStyle(.borderless)
-                .foregroundStyle(.secondary)
-                .disabled(removing)
-                .help("Remove this manually-added token")
+    @ViewBuilder private var removeControl: some View {
+        if lane.source == .override {
+            Button { remove() } label: {
+                Image(systemName: "trash").font(.system(size: 11))
             }
-            testControl
-        }
-    }
-
-    @ViewBuilder private var testControl: some View {
-        HStack(spacing: 5) {
-            if let result, !testing { resultIcon(result) }
-            if testing {
-                ProgressView().controlSize(.small)
-            } else {
-                Button("Test") { runTest() }
-                    .controlSize(.small)
-                    .disabled(recentlyPolled)
-                    .help(recentlyPolled
-                        ? "Just fetched — its data is current; give it a moment."
-                        : "Fetch usage with this token through the poller (persists + counts against its budget).")
-            }
-        }
-    }
-
-    /// True if this lane was polled (by a Test or the auto-cadence) within
-    /// the last 20s. Derived from the shared `lastPolledAt`, so the Test
-    /// cooldown survives tab switches — unlike a view-local flag would.
-    private var recentlyPolled: Bool {
-        guard let last = lane.lastPolledAt else { return false }
-        return Date().timeIntervalSince(last) < 20
-    }
-
-    private func runTest() {
-        testing = true
-        result = nil
-        Task { @MainActor in
-            let r = await TokenPoolStatus.shared.testLane(id: lane.id)
-            result = r
-            testing = false
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .disabled(removing)
+            .help("Remove this manually-added token")
         }
     }
 
@@ -1403,21 +1410,6 @@ private struct TokenLaneRow: View {
         Task { @MainActor in
             await TokenPoolStatus.shared.removeManualToken(id: lane.id)
             // Lane vanishes from pool.lanes → this row is removed.
-        }
-    }
-
-    @ViewBuilder private func resultIcon(_ r: TokenTestResult) -> some View {
-        switch r {
-        case .success:
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.system(size: 12)).help("Valid")
-        case .foreignAccount:
-            Image(systemName: "person.crop.circle.badge.xmark").foregroundStyle(.purple).font(.system(size: 12)).help("Different account")
-        case .failure(let reason):
-            Image(systemName: "xmark.circle.fill").foregroundStyle(.red).font(.system(size: 12)).help(reason)
-        case .alreadyTracked:
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.system(size: 12)).help("Already tracked")
-        case .unavailable:
-            Image(systemName: "questionmark.circle").foregroundStyle(.secondary).font(.system(size: 12)).help("Poller not running")
         }
     }
 
@@ -1440,10 +1432,6 @@ private struct TokenLaneRow: View {
         return ("pending", .gray)
     }
 
-    private var accountText: String {
-        lane.organizationId ?? "—"
-    }
-
     private var expiresText: String {
         guard let exp = lane.expiresAt else { return "—" }
         if exp < Date() { return "expired" }
@@ -1452,7 +1440,6 @@ private struct TokenLaneRow: View {
 
     private var updatedText: String {
         guard let last = lane.lastPolledAt else { return "never" }
-        // A just-now poll can round to a spurious "in 0s"; clamp it.
         if abs(Date().timeIntervalSince(last)) < 10 { return "just now" }
         return Self.relative.localizedString(for: last, relativeTo: Date())
     }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -1367,12 +1367,13 @@ private struct TokensCard: View {
 
     private var columnHeader: some View {
         HStack(spacing: 10) {
-            Text("SOURCE").frame(width: 148, alignment: .leading)
-            Text("ACCOUNT").frame(width: 96, alignment: .leading)
+            Text("SOURCE").frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
+            Text("ACCOUNT").frame(minWidth: 70, maxWidth: .infinity, alignment: .leading)
             Text("STATUS").frame(width: 74, alignment: .leading)
-            Text("EXPIRES").frame(width: 66, alignment: .leading)
-            Text("UPDATED").frame(width: 70, alignment: .leading)
-            Spacer(minLength: 0)
+            Text("EXPIRES").frame(width: 62, alignment: .leading)
+            Text("UPDATED").frame(width: 74, alignment: .leading)
+                .help("When Pacer last fetched usage with this token")
+            Color.clear.frame(width: 56)   // aligns over the Test button
         }
         .font(.system(size: 9, weight: .semibold))
         .tracking(0.5)
@@ -1389,6 +1390,7 @@ private struct TokenLaneRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
+            // SOURCE — flexible; the id sub-line truncates first when narrow.
             HStack(spacing: 7) {
                 Image(systemName: Self.icon(lane.source))
                     .font(.system(size: 12))
@@ -1398,18 +1400,23 @@ private struct TokenLaneRow: View {
                     Text(Self.name(lane.source))
                         .font(.system(size: 12, weight: .medium))
                         .lineLimit(1)
-                    Text("#\(lane.priority + 1) · …\(lane.id.suffix(4))")
+                    Text("#\(lane.priority + 1) · \(lane.id)")
                         .font(.system(size: 9))
                         .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .help("Token fingerprint \(lane.id)")
                 }
             }
-            .frame(width: 148, alignment: .leading)
+            .frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
 
+            // ACCOUNT — flexible; middle-truncates, hover for the full org id.
             Text(accountText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .frame(width: 96, alignment: .leading)
+                .truncationMode(.middle)
+                .frame(minWidth: 70, maxWidth: .infinity, alignment: .leading)
                 .help(lane.organizationId ?? "")
 
             statusPill
@@ -1418,16 +1425,15 @@ private struct TokenLaneRow: View {
             Text(expiresText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 66, alignment: .leading)
+                .frame(width: 62, alignment: .leading)
 
             Text(updatedText)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .frame(width: 70, alignment: .leading)
-
-            Spacer(minLength: 4)
+                .frame(width: 74, alignment: .leading)
 
             testControl
+                .frame(width: 56, alignment: .trailing)
         }
         .padding(.vertical, 7)
     }
@@ -1488,8 +1494,7 @@ private struct TokenLaneRow: View {
     }
 
     private var accountText: String {
-        guard let org = lane.organizationId else { return "—" }
-        return "…\(org.suffix(6))"
+        lane.organizationId ?? "—"
     }
 
     private var expiresText: String {
@@ -1500,6 +1505,8 @@ private struct TokenLaneRow: View {
 
     private var updatedText: String {
         guard let last = lane.lastPolledAt else { return "never" }
+        // A just-now poll can round to a spurious "in 0s"; clamp it.
+        if abs(Date().timeIntervalSince(last)) < 10 { return "just now" }
         return Self.relative.localizedString(for: last, relativeTo: Date())
     }
 

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -60,11 +60,11 @@ struct SettingsView: View {
             // the cards sit consistently flush with the sidebar.
             .frame(maxWidth: 760, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .topLeading)
-            // Click anywhere off a text field to dismiss its focus ring.
-            #if canImport(AppKit)
-            .background(FocusResignOnClick())
-            #endif
         }
+        // Click anywhere off a text field to dismiss its focus ring.
+        #if canImport(AppKit)
+        .modifier(DismissFocusOnOutsideClick())
+        #endif
     }
 }
 
@@ -1107,77 +1107,101 @@ private struct DesktopCredentialsCard: View {
 /// each token comes from, which account it's tied to, when it expires,
 /// its health, and a Test that routes through the poller (so it persists
 /// and counts against that token's budget instead of racing it).
-/// Fixed column widths shared by the Tokens header and rows so they line
-/// up exactly. SOURCE is the flexible column (fills the remainder).
+/// Column widths shared by the Tokens header and rows so they line up
+/// exactly. SOURCE and ACCOUNT are both flexible (they split the leftover
+/// evenly and are the first to truncate as the window narrows — hover to
+/// see them in full); STATUS/EXPIRES/UPDATED/trash are fixed and small.
 fileprivate enum TokenCol {
-    static let account: CGFloat = 244
-    static let status: CGFloat = 78
-    static let expires: CGFloat = 64
-    static let updated: CGFloat = 76
+    static let status: CGFloat = 76
+    static let expires: CGFloat = 58
+    static let updated: CGFloat = 72
     static let trash: CGFloat = 24
     static let spacing: CGFloat = 12
 }
 
 #if canImport(AppKit)
-/// Transparent click-catcher placed behind content: a click on empty space
-/// resigns the window's first responder (dismissing a TextField's focus
-/// ring), while clicks on real controls still reach them (they sit in
-/// front). Fixes "the paste field stays focused when I click elsewhere".
-private struct FocusResignOnClick: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView { CatcherView() }
-    func updateNSView(_ nsView: NSView, context: Context) {}
-    private final class CatcherView: NSView {
-        override func mouseDown(with event: NSEvent) {
-            window?.makeFirstResponder(nil)
-            super.mouseDown(with: event)
-        }
+/// Dismisses text-field focus when the user clicks anything that isn't a
+/// text field. SwiftUI on macOS keeps a `TextField` focused until another
+/// responder takes over, and a background click-catcher can't fix it —
+/// opaque SwiftUI views above it swallow the click. A window-level mouse
+/// monitor is the reliable route: on any left click, if the hit view
+/// isn't the field editor, resign first responder (which clears the
+/// SwiftUI `@FocusState` too). Clicking into an unfocused field still
+/// focuses it, since the click proceeds normally afterward.
+private struct DismissFocusOnOutsideClick: ViewModifier {
+    @State private var monitor: Any?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                guard monitor == nil else { return }
+                monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { event in
+                    guard let window = event.window else { return event }
+                    let hit = window.contentView?.hitTest(event.locationInWindow)
+                    // The field editor of a focused NSTextField is an NSTextView.
+                    if !(hit is NSTextView) {
+                        window.makeFirstResponder(nil)
+                    }
+                    return event
+                }
+            }
+            .onDisappear {
+                if let monitor { NSEvent.removeMonitor(monitor) }
+                monitor = nil
+            }
     }
 }
 #endif
 
-/// A one-line shell command shown as a code block. The whole box is
-/// click-to-copy (button flips to a checkmark + trackpad haptic); the
-/// command scrolls horizontally with a right-edge fade so it's clear it
-/// continues past the copy button rather than being all there is.
+/// A one-line shell command shown as a code block. The entire box is a
+/// single click-to-copy button (flips to a checkmark + trackpad haptic).
+/// The command is clipped with a right-edge fade so it's clear it runs
+/// past the copy icon rather than being all there is; hover shows it in
+/// full. It's deliberately not text-selectable — a stray click-drag used
+/// to leave text stuck-highlighted, and copying is one click anyway.
 private struct CopyableCommand: View {
     let command: String
     @State private var copied = false
     init(_ command: String) { self.command = command }
 
     var body: some View {
-        HStack(spacing: 14) {
-            Image(systemName: "terminal")
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-            ScrollView(.horizontal, showsIndicators: false) {
+        Button(action: copy) {
+            HStack(spacing: 14) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
                 Text(command)
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(.primary)
-                    .textSelection(.enabled)
                     .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            .mask(
-                LinearGradient(
-                    stops: [.init(color: .black, location: 0),
-                            .init(color: .black, location: 0.88),
-                            .init(color: .clear, location: 1.0)],
-                    startPoint: .leading, endPoint: .trailing
-                )
-            )
-            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .fixedSize(horizontal: true, vertical: false)   // draw at full width…
+                    .frame(maxWidth: .infinity, alignment: .leading) // …clipped to the box
+                    .clipped()
+                    .mask(
+                        LinearGradient(
+                            stops: [.init(color: .black, location: 0),
+                                    .init(color: .black, location: 0.9),
+                                    .init(color: .clear, location: 1.0)],
+                            startPoint: .leading, endPoint: .trailing
+                        )
+                    )
+                ZStack {
+                    Image(systemName: "doc.on.doc").opacity(copied ? 0 : 1)
+                    Image(systemName: "checkmark").foregroundStyle(.green).opacity(copied ? 1 : 0)
+                }
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(copied ? Color.green : Color.secondary)
+                .foregroundStyle(.secondary)
                 .frame(width: 18, height: 16)   // fixed → the flip can't shift layout
-                .contentTransition(.symbolEffect(.replace))
+                .animation(.easeInOut(duration: 0.15), value: copied)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Color.primary.opacity(0.06)))
+            .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(Color.primary.opacity(0.08), lineWidth: 1))
+            .contentShape(Rectangle())
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Color.primary.opacity(0.06)))
-        .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(Color.primary.opacity(0.08), lineWidth: 1))
-        .contentShape(Rectangle())
-        .onTapGesture(perform: copy)
-        .help(copied ? "Copied!" : "Click to copy")
+        .buttonStyle(.plain)
+        .help(copied ? "Copied!" : command)
     }
 
     private func copy() {
@@ -1186,10 +1210,10 @@ private struct CopyableCommand: View {
         NSPasteboard.general.setString(command, forType: .string)
         NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
         #endif
-        withAnimation { copied = true }
+        copied = true
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_600_000_000)
-            withAnimation { copied = false }
+            copied = false
         }
     }
 }
@@ -1265,12 +1289,12 @@ private struct TokensCard: View {
     private var columnHeader: some View {
         HStack(spacing: TokenCol.spacing) {
             Text("SOURCE").frame(maxWidth: .infinity, alignment: .leading)
-            Text("ACCOUNT").frame(width: TokenCol.account, alignment: .leading)
+            Text("ACCOUNT").frame(maxWidth: .infinity, alignment: .leading)
             Text("STATUS").frame(width: TokenCol.status, alignment: .leading)
             Text("EXPIRES").frame(width: TokenCol.expires, alignment: .leading)
             Text("UPDATED").frame(width: TokenCol.updated, alignment: .leading)
                 .help("When Pacer last fetched usage with this token")
-            Color.clear.frame(width: TokenCol.trash)   // trash column (manual rows only)
+            Color.clear.frame(width: TokenCol.trash, height: 1)   // trash column (manual rows only)
         }
         .font(.system(size: 9, weight: .semibold))
         .tracking(0.5)
@@ -1392,7 +1416,7 @@ private struct TokenLaneRow: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .frame(width: TokenCol.account, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .help(lane.organizationId ?? "")
 
             statusPill
@@ -1422,15 +1446,21 @@ private struct TokenLaneRow: View {
         .animation(.easeInOut(duration: 0.25), value: highlighted)
     }
 
-    @ViewBuilder private var removeControl: some View {
-        if lane.source == .override {
-            Button { remove() } label: {
-                Image(systemName: "trash").font(.system(size: 11))
+    // Always occupies the trash column's width (even for auto rows with no
+    // button) so every row's columns line up with the header.
+    private var removeControl: some View {
+        Group {
+            if lane.source == .override {
+                Button { remove() } label: {
+                    Image(systemName: "trash").font(.system(size: 11))
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+                .disabled(removing)
+                .help("Remove this manually-added token")
+            } else {
+                Color.clear.frame(width: 1, height: 1)
             }
-            .buttonStyle(.borderless)
-            .foregroundStyle(.secondary)
-            .disabled(removing)
-            .help("Remove this manually-added token")
         }
     }
 

--- a/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
+++ b/PacerCore/Sources/PacerCore/Auth/DesktopOAuth.swift
@@ -105,6 +105,39 @@ public struct DesktopOAuth: Sendable {
         }
     }
 
+    // MARK: - Layered read (cached-key path)
+
+    /// The encrypted cache blobs from `config.json` — a file-only read, no
+    /// keychain, so it never prompts. nil when Desktop isn't installed.
+    public func readCacheBlobs() -> [String]? {
+        cacheReader()
+    }
+
+    /// Read the `Claude Safe Storage` AES key. THIS is the only
+    /// prompt-risking step (a foreign-app keychain item), so callers gate
+    /// it behind the cached-key fast path.
+    public func readKey() -> Result<Data, DesktopOAuthError> {
+        keyReader()
+    }
+
+    /// Decrypt the given blobs with a SPECIFIC key and return the
+    /// `user:profile` credentials, freshest first. Empty when the key
+    /// can't decrypt them (⇒ the key rotated, e.g. a Desktop reinstall) or
+    /// nothing carries a profile token. No keychain access, so no prompt.
+    public func profileCredentials(fromBlobs blobs: [String], keyPassword: Data) -> [OAuthCredential] {
+        var merged: [String: Any] = [:]
+        var decryptedAny = false
+        for blob in blobs {
+            guard let plain = Self.decrypt(blobBase64: blob, keyPassword: keyPassword),
+                  let obj = try? JSONSerialization.jsonObject(with: plain) as? [String: Any]
+            else { continue }
+            decryptedAny = true
+            merged.merge(obj) { _, new in new }
+        }
+        guard decryptedAny else { return [] }
+        return Self.profileCredentials(cache: merged)
+    }
+
     /// Read + decrypt + merge every cache blob into one dict. Shared by
     /// `read()` / `readAll()`.
     private func decryptedCache() -> Result<[String: Any], DesktopOAuthError> {

--- a/PacerCore/Sources/PacerCore/Auth/TokenFormat.swift
+++ b/PacerCore/Sources/PacerCore/Auth/TokenFormat.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Cheap, offline sanity-check of a pasted OAuth token — so an obviously
+/// wrong paste (an API key, a session key, truncated text) is rejected
+/// instantly with a helpful message, *before* we spend a network request
+/// on it. What we can verify from the string alone is limited: the token
+/// is opaque, so its **expiry, source, and scope are NOT encoded in it** —
+/// those only come from the source (keychain blob) or the server's
+/// response (a 200 confirms `user:profile` access; a 403 means it lacks
+/// the scope). So this is a *format* gate, not a full validation.
+///
+/// The shape is derived from the tokens Pacer already reads: a Claude
+/// `user:profile` access token is `sk-ant-oat01-` (OAuth Access Token,
+/// version 01) followed by a base64url body.
+public enum TokenFormat {
+    /// Prefix of the interactive `user:profile` OAuth access token that
+    /// `/api/oauth/usage` accepts.
+    public static let oauthPrefix = "sk-ant-oat01-"
+
+    public enum Verdict: Sendable, Equatable {
+        case ok
+        /// Fails the format gate; the string is a user-facing reason.
+        case invalid(String)
+    }
+
+    /// base64url alphabet used by the token body.
+    private static let bodyAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    )
+
+    public static func validate(_ raw: String) -> Verdict {
+        let t = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t.isEmpty { return .invalid("Empty.") }
+
+        // Recognizable wrong *kinds* of Anthropic key → specific guidance.
+        if t.hasPrefix("sk-ant-api") {
+            return .invalid("That's an API key (sk-ant-api…), not a Claude OAuth token — the usage endpoint needs the interactive user:profile access token.")
+        }
+        if t.hasPrefix("sk-ant-sid") {
+            return .invalid("That's a session key (sk-ant-sid…), not the user:profile OAuth access token.")
+        }
+        guard t.hasPrefix(oauthPrefix) else {
+            return .invalid("Doesn't look like a Claude OAuth token — it should start with “\(oauthPrefix)”.")
+        }
+
+        let body = t.dropFirst(oauthPrefix.count)
+        if body.count < 40 {
+            return .invalid("Token looks truncated — did the whole thing get copied?")
+        }
+        guard body.unicodeScalars.allSatisfy({ Self.bodyAllowed.contains($0) }) else {
+            return .invalid("Token has unexpected characters — check for stray spaces or line breaks.")
+        }
+        return .ok
+    }
+}

--- a/PacerCore/Sources/PacerCore/Auth/TokenPoolStore.swift
+++ b/PacerCore/Sources/PacerCore/Auth/TokenPoolStore.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Security
+
+/// One token Pacer has persisted for the account, with the source it
+/// originally came from (so the Tokens UI still labels it correctly after
+/// a restart, and the Desktop layered-read logic knows which cached
+/// tokens are Desktop-origin).
+public struct StoredToken: Codable, Sendable, Equatable {
+    public let credential: OAuthCredential
+    public let source: CredentialCandidate.Source
+    public init(credential: OAuthCredential, source: CredentialCandidate.Source) {
+        self.credential = credential
+        self.source = source
+    }
+}
+
+/// Persists the whole set of account tokens in Pacer's own keychain, so
+/// the poller's lane pool survives a restart without re-reading Claude's
+/// stores — a superset of the single-slot `HeldCredentialStoring`. Reads
+/// are silent (Pacer's app-private item); the OS encrypts at rest.
+public protocol TokenPoolStoring: Sendable {
+    func loadAll() -> [StoredToken]
+    func saveAll(_ tokens: [StoredToken])
+    func clear()
+}
+
+/// Production pool store: one generic-password item holding a JSON array.
+public struct KeychainTokenPoolStore: TokenPoolStoring {
+    public static let service = "com.ericandrechek.pacer.oauth.pool"
+    public static let account = "primary"
+
+    public init() {}
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: Self.account,
+        ]
+    }
+
+    public func loadAll() -> [StoredToken] {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var out: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data,
+              let tokens = try? JSONDecoder().decode([StoredToken].self, from: data)
+        else { return [] }
+        return tokens
+    }
+
+    public func saveAll(_ tokens: [StoredToken]) {
+        guard let data = try? JSONEncoder().encode(tokens) else { return }
+        let update: [String: Any] = [kSecValueData as String: data]
+        let status = SecItemUpdate(baseQuery as CFDictionary, update as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = baseQuery
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            SecItemAdd(add as CFDictionary, nil)
+        }
+    }
+
+    public func clear() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+}
+
+/// In-memory pool store — the default, so tests and Settings probes never
+/// touch the real keychain; production opts into `KeychainTokenPoolStore`.
+public final class EphemeralTokenPoolStore: TokenPoolStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var tokens: [StoredToken]
+    public init(_ tokens: [StoredToken] = []) { self.tokens = tokens }
+    public func loadAll() -> [StoredToken] {
+        lock.lock(); defer { lock.unlock() }; return tokens
+    }
+    public func saveAll(_ tokens: [StoredToken]) {
+        lock.lock(); self.tokens = tokens; lock.unlock()
+    }
+    public func clear() {
+        lock.lock(); tokens = []; lock.unlock()
+    }
+}
+
+/// Persists Claude Desktop's `Claude Safe Storage` AES key in Pacer's own
+/// keychain. That key is Chromium/Electron's OSCrypt key — generated once
+/// per Desktop install and reused for its lifetime (token refreshes
+/// re-encrypt with the SAME key), so caching it lets us decrypt every
+/// future `config.json` change WITHOUT re-reading `Claude Safe Storage` —
+/// which is the only step that can pop the macOS approval. We only go back
+/// to the source key if our cached one fails to decrypt (a Desktop
+/// reinstall rotated it).
+///
+/// This is a more sensitive secret than the tokens (it's long-lived and
+/// can decrypt all of Desktop's safeStorage), so it lives in Pacer's
+/// app-private, Secure-Enclave-protected keychain item like everything
+/// else — a capability Pacer already exercises on demand, now persisted.
+public protocol DesktopKeyStoring: Sendable {
+    func load() -> Data?
+    func save(_ key: Data)
+    func clear()
+}
+
+public struct KeychainDesktopKeyStore: DesktopKeyStoring {
+    public static let service = "com.ericandrechek.pacer.desktop.safestorage.key"
+    public static let account = "primary"
+
+    public init() {}
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: Self.account,
+        ]
+    }
+
+    public func load() -> Data? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var out: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data
+        else { return nil }
+        return data
+    }
+
+    public func save(_ key: Data) {
+        let update: [String: Any] = [kSecValueData as String: key]
+        let status = SecItemUpdate(baseQuery as CFDictionary, update as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = baseQuery
+            add[kSecValueData as String] = key
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            SecItemAdd(add as CFDictionary, nil)
+        }
+    }
+
+    public func clear() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+}
+
+public final class EphemeralDesktopKeyStore: DesktopKeyStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var key: Data?
+    public init(_ key: Data? = nil) { self.key = key }
+    public func load() -> Data? {
+        lock.lock(); defer { lock.unlock() }; return key
+    }
+    public func save(_ key: Data) {
+        lock.lock(); self.key = key; lock.unlock()
+    }
+    public func clear() {
+        lock.lock(); key = nil; lock.unlock()
+    }
+}

--- a/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
+++ b/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
@@ -1147,6 +1147,14 @@ public final class ScanCoordinator {
                 projectAttributionChanged: needsPathMigration
             )
             Task { @MainActor in postScanCycleSummary(summary) }
+            // Poll-on-wake: fresh Claude usage just landed, so nudge the
+            // OAuth poller to re-evaluate its cadence — an idle→active
+            // transition polls promptly instead of waiting out the idle
+            // interval. The scheduler still enforces the per-token floor,
+            // so this can never cause an over-poll.
+            if let oauthPoller {
+                Task { await oauthPoller.notifyActivity() }
+            }
         }
         phase.notifMs = tickMs()
 

--- a/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
+++ b/PacerCore/Sources/PacerCore/Coordination/ScanCoordinator.swift
@@ -331,7 +331,8 @@ public final class ScanCoordinator {
         configuration: Configuration = Configuration(),
         statsCacheURL: URL? = nil,
         resolver: ClaudePathResolver = ClaudePathResolver(),
-        oauthClient: OAuthClient? = nil
+        oauthClient: OAuthClient? = nil,
+        oauthPoolStore: TokenPoolStoring = EphemeralTokenPoolStore()
     ) {
         self.container = container
         self.configuration = configuration
@@ -347,7 +348,8 @@ public final class ScanCoordinator {
             self.oauthPoller = OAuthPoller(
                 client: oauthClient,
                 container: container,
-                configuration: configuration.oauthPolling
+                configuration: configuration.oauthPolling,
+                poolStore: oauthPoolStore
             )
         } else {
             self.oauthPoller = nil

--- a/PacerCore/Sources/PacerCore/Models/TokenLaneMeta.swift
+++ b/PacerCore/Sources/PacerCore/Models/TokenLaneMeta.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+
+/// Persisted per-token scheduling metadata for the OAuth poll pool.
+///
+/// The tokens themselves live in Pacer's keychain (`TokenPoolStoring`);
+/// this is the *derived* state the poller learns by polling — which
+/// account a token resolved to, when it last polled, whether it's cooling
+/// down — keyed by the token's opaque fingerprint (`OAuthPoller.laneId`).
+///
+/// Persisting it means the Settings "Tokens" table shows real status,
+/// account, expiry and "updated" immediately on launch instead of a row
+/// of placeholders until the first poll lands — and the poller restores
+/// each lane's cooldown / last-polled / account so it doesn't re-poll a
+/// just-polled token (spending its budget) right after a restart.
+///
+/// No secret lives here (no token bytes — only the fingerprint), but the
+/// org id is account-identifying, so like the rest of Pacer's data it
+/// stays in the local App Group store and never leaves the device.
+@Model
+public final class TokenLaneMeta {
+    /// The lane's opaque fingerprint (`OAuthPoller.laneId`) — 12 hex chars
+    /// of the token's SHA-256. Unique so writes upsert by token identity.
+    @Attribute(.unique) public var id: String
+    /// `CredentialCandidate.Source.rawValue` — keychain / desktop / held / override.
+    public var sourceRaw: String
+    /// The account (`anthropic-organization-id`) this token resolved to.
+    public var organizationId: String?
+    /// `AccountStatus` raw string — unknown / primary / foreign.
+    public var accountRaw: String
+    /// Local token expiry, when known.
+    public var expiresAt: Date?
+    public var lastPolledAt: Date?
+    public var cooldownUntil: Date?
+    public var consecutiveFailures: Int
+    /// When this row was last written — lets a stale-pool cleanup prune
+    /// metadata for tokens that have gone away.
+    public var updatedAt: Date
+
+    public init(
+        id: String,
+        sourceRaw: String,
+        organizationId: String?,
+        accountRaw: String,
+        expiresAt: Date?,
+        lastPolledAt: Date?,
+        cooldownUntil: Date?,
+        consecutiveFailures: Int,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.sourceRaw = sourceRaw
+        self.organizationId = organizationId
+        self.accountRaw = accountRaw
+        self.expiresAt = expiresAt
+        self.lastPolledAt = lastPolledAt
+        self.cooldownUntil = cooldownUntil
+        self.consecutiveFailures = consecutiveFailures
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - AccountStatus <-> raw string
+
+extension OAuthPollScheduler.AccountStatus {
+    public var rawValue: String {
+        switch self {
+        case .unknown: return "unknown"
+        case .primary: return "primary"
+        case .foreign: return "foreign"
+        }
+    }
+
+    public init(rawValue: String) {
+        switch rawValue {
+        case "primary": self = .primary
+        case "foreign": self = .foreign
+        default:        self = .unknown
+        }
+    }
+}

--- a/PacerCore/Sources/PacerCore/PacerStore.swift
+++ b/PacerCore/Sources/PacerCore/PacerStore.swift
@@ -118,6 +118,7 @@ public enum PacerStore {
         ForecastModelOutcome.self,
         EngineEvalOutcome.self,
         PredictionSnapshot.self,
+        TokenLaneMeta.self,
     ]
 
     public static func makeModelContainer() throws -> ModelContainer {

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -280,8 +280,14 @@ public struct OAuthClient: Sendable {
             out.append(CredentialCandidate(credential: cred, source: source))
         }
 
+        // Order matters for the source LABEL of a token that appears in
+        // more than one place: a live source (Claude Code keychain /
+        // Claude Desktop) wins over our held copy, so a token is shown by
+        // where it actually lives. "Saved by Pacer" then surfaces only for
+        // a genuine survivor — a token we still hold that no live source
+        // has anymore (e.g. after logout) — which is exactly the case the
+        // held store exists to cover.
         if case .success(let c) = keychain.read() { add(c, .keychain) }
-        if let held = heldStore.load() { add(held, .held) }
         if desktopEnabled() {
             let fingerprint = desktop.cacheFingerprint()
             if desktopGate.shouldRead(fingerprint: fingerprint) {
@@ -291,6 +297,7 @@ public struct OAuthClient: Sendable {
                 }
             }
         }
+        if let held = heldStore.load() { add(held, .held) }
 
         // Freshest first (nil expiry sorts as "never expires" ⇒ leads);
         // ties broken by token so the ordering is deterministic.

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -272,12 +272,10 @@ public struct OAuthClient: Sendable {
     ///   caller (the poller) already holds, used only to decide the Desktop
     ///   escalation.
     public func candidateCredentials(cachedDesktopTokens: [OAuthCredential] = []) -> [CredentialCandidate] {
-        if let override = tokenOverride() {
-            return [CredentialCandidate(
-                credential: OAuthCredential(accessToken: override, expiresAt: nil, subscriptionType: nil),
-                source: .override
-            )]
-        }
+        // Manually-added tokens are no longer a "sole override" that
+        // replaces auto-discovery — they live in the poller's pool as
+        // `.override` lanes and are seeded from there, so here we only
+        // gather the live sources and let them union into the pool.
         let referenceNow = now()
         let usable: (OAuthCredential) -> Bool = { [rejected] cred in
             !rejected.isRejected(cred.accessToken)

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -62,7 +62,7 @@ public enum OAuthClientError: Error, Sendable {
 /// (keychain / manual override) when deciding which lane establishes
 /// the account the whole pool is guarded against.
 public struct CredentialCandidate: Sendable, Equatable {
-    public enum Source: String, Sendable, Equatable {
+    public enum Source: String, Sendable, Equatable, Codable {
         case override, keychain, held, desktop
     }
     public let credential: OAuthCredential
@@ -119,6 +119,12 @@ public struct OAuthClient: Sendable {
     /// reliably silence — only when its tokens actually changed. See
     /// `DesktopReadGate`.
     private let desktopGate: DesktopReadGate
+    /// Pacer's cached copy of Claude Desktop's `Claude Safe Storage` AES
+    /// key. Since that key is stable for the life of the Desktop install,
+    /// caching it lets `candidateCredentials` decrypt every future
+    /// `config.json` change without re-reading the (prompt-risking)
+    /// keychain item. See `KeychainDesktopKeyStore`.
+    private let desktopKeyStore: DesktopKeyStoring
 
     /// How long before a held token's expiry we go back to the sources for a
     /// fresher one. Until then we serve the held copy without touching
@@ -134,7 +140,8 @@ public struct OAuthClient: Sendable {
         desktopEnabled: @escaping @Sendable () -> Bool = { PacerPreferences.desktopCredentialsEnabled() },
         heldStore: HeldCredentialStoring = EphemeralCredentialStore(),
         rejected: RejectedTokens = RejectedTokens(),
-        desktopGate: DesktopReadGate = DesktopReadGate()
+        desktopGate: DesktopReadGate = DesktopReadGate(),
+        desktopKeyStore: DesktopKeyStoring = EphemeralDesktopKeyStore()
     ) {
         self.keychain = keychain
         self.transport = transport
@@ -145,6 +152,7 @@ public struct OAuthClient: Sendable {
         self.heldStore = heldStore
         self.rejected = rejected
         self.desktopGate = desktopGate
+        self.desktopKeyStore = desktopKeyStore
     }
 
     /// Production transport: `URLSession.shared.data(for:)` plus the
@@ -254,13 +262,16 @@ public struct OAuthClient: Sendable {
     /// tagged with its source. The multi-token poller unions these into
     /// its persistent lane set.
     ///
-    /// Reads Claude Code's keychain (silent) and our held copy always;
-    /// reads opted-in Claude Desktop only when its token file changed
-    /// since the last read (the `DesktopReadGate`, to avoid re-prompting)
-    /// — so Desktop tokens surface on the first call and again on
-    /// rotation, and the poller keeps the lanes alive in between. A
-    /// manual override, when set, is returned as the sole candidate.
-    public func candidateCredentials() -> [CredentialCandidate] {
+    /// Reads Claude Code's keychain (silent) and, for opted-in Claude
+    /// Desktop, decrypts its token cache with our CACHED AES key — so no
+    /// prompt-risking keychain read unless that key has gone stale (see
+    /// `resolveDesktopTokens`). A manual override, when set, is the sole
+    /// candidate.
+    ///
+    /// - Parameter cachedDesktopTokens: the Desktop-origin tokens the
+    ///   caller (the poller) already holds, used only to decide the Desktop
+    ///   escalation.
+    public func candidateCredentials(cachedDesktopTokens: [OAuthCredential] = []) -> [CredentialCandidate] {
         if let override = tokenOverride() {
             return [CredentialCandidate(
                 credential: OAuthCredential(accessToken: override, expiresAt: nil, subscriptionType: nil),
@@ -289,13 +300,9 @@ public struct OAuthClient: Sendable {
         // held store exists to cover.
         if case .success(let c) = keychain.read() { add(c, .keychain) }
         if desktopEnabled() {
-            let fingerprint = desktop.cacheFingerprint()
-            if desktopGate.shouldRead(fingerprint: fingerprint) {
-                desktopGate.record(fingerprint: fingerprint)
-                if case .success(let creds) = desktop.readAll() {
-                    for c in creds { add(c, .desktop) }
-                }
-            }
+            let (tokens, newKey) = resolveDesktopTokens(cachedDesktop: cachedDesktopTokens, now: referenceNow)
+            if let newKey { desktopKeyStore.save(newKey) }
+            for c in tokens { add(c, .desktop) }
         }
         if let held = heldStore.load() { add(held, .held) }
 
@@ -306,6 +313,44 @@ public struct OAuthClient: Sendable {
             let b = $1.credential.expiresAt ?? .distantFuture
             return a != b ? a > b : $0.credential.accessToken < $1.credential.accessToken
         }
+    }
+
+    /// Resolve Claude Desktop's tokens with the layered fallback that keeps
+    /// us off the `Claude Safe Storage` prompt:
+    ///   1. Decrypt the current `config.json` with our **cached AES key**
+    ///      (file read + AES only — no keychain, no prompt). Because the
+    ///      key is stable for the install's life, this succeeds ~always and
+    ///      also picks up any freshly-rotated tokens.
+    ///   2. If the cached key can't decrypt it (⇒ the key rotated, e.g. a
+    ///      Desktop reinstall) but we still hold working Desktop tokens,
+    ///      keep using those and DEFER the prompt.
+    ///   3. Only when the cached key is stale **and** no cached Desktop
+    ///      token still works do we re-read `Claude Safe Storage` (the one
+    ///      prompt-risking step), caching the fresh key.
+    /// Returns the tokens plus a new key to persist (nil unless step 3 read
+    /// one).
+    private func resolveDesktopTokens(
+        cachedDesktop: [OAuthCredential],
+        now: Date
+    ) -> (tokens: [OAuthCredential], newKey: Data?) {
+        let working = { cachedDesktop.filter { $0.expiresAt == nil || $0.expiresAt! >= now } }
+        guard let blobs = desktop.readCacheBlobs(), !blobs.isEmpty else {
+            return (working(), nil)   // Desktop not installed — keep cached
+        }
+        // Layer 1: cached key (no prompt).
+        if let cachedKey = desktopKeyStore.load() {
+            let creds = desktop.profileCredentials(fromBlobs: blobs, keyPassword: cachedKey)
+            if !creds.isEmpty { return (creds, nil) }
+            // Layer 2: cached key stale, but working cached tokens remain.
+            let stillWorking = working()
+            if !stillWorking.isEmpty { return (stillWorking, nil) }
+        }
+        // Layer 3 (or first-ever read): the only prompt-risking step.
+        guard case .success(let key) = desktop.readKey() else {
+            return (working(), nil)
+        }
+        let creds = desktop.profileCredentials(fromBlobs: blobs, keyPassword: key)
+        return creds.isEmpty ? (working(), nil) : (creds, key)
     }
 
     // MARK: - Credential resolution

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthClient.swift
@@ -57,6 +57,22 @@ public enum OAuthClientError: Error, Sendable {
 /// cooperative-task-cancellable, and `KeychainOAuth.read()` is a fast
 /// synchronous SecItem call. The client is `Sendable` so the poller
 /// actor can hold and call it without isolation hops.
+/// One credential the poller could spend, tagged with where it came
+/// from. `source` lets the poller prefer a primary-account token
+/// (keychain / manual override) when deciding which lane establishes
+/// the account the whole pool is guarded against.
+public struct CredentialCandidate: Sendable, Equatable {
+    public enum Source: String, Sendable, Equatable {
+        case override, keychain, held, desktop
+    }
+    public let credential: OAuthCredential
+    public let source: Source
+    public init(credential: OAuthCredential, source: Source) {
+        self.credential = credential
+        self.source = source
+    }
+}
+
 public struct OAuthClient: Sendable {
 
     /// Anthropic's undocumented usage endpoint. Stable for ~a year;
@@ -144,15 +160,12 @@ public struct OAuthClient: Sendable {
         return (data, http)
     }
 
-    /// One round-trip against `/api/oauth/usage`. Returns the typed
-    /// snapshot or an `OAuthClientError`.
+    /// One round-trip against `/api/oauth/usage` using the auto-resolved
+    /// credential (manual override → keychain → held → opted-in Desktop,
+    /// freshest wins). Used by the Settings probe and any single-token
+    /// caller. The multi-token poller uses `candidateCredentials()` +
+    /// `fetchUsage(using:)` instead so it controls which budget it spends.
     public func fetchUsage() async -> Result<RateLimitSnapshot, OAuthClientError> {
-        // Step 1: resolve the access token. Manual override (Settings
-        // → Authentication) wins when present — we don't even read the
-        // keychain, since the override exists exactly for cases where
-        // the keychain copy is stale (#6). Otherwise: keychain read,
-        // mapping its errors to ours so the caller switches on one
-        // error type.
         let credential: OAuthCredential
         let fromHeldStore: Bool
         switch resolveCredential() {
@@ -162,8 +175,29 @@ public struct OAuthClient: Sendable {
         case .failure(let error):
             return .failure(error)
         }
+        let result = await performFetch(credential: credential)
+        // Preserve the single-token path's behavior: a 401 on the held
+        // copy drops it so the next poll re-derives from the sources.
+        if case .failure(.unauthorized) = result, fromHeldStore {
+            heldStore.clear()
+        }
+        return result
+    }
 
-        // Step 3: build request.
+    /// One round-trip using a SPECIFIC credential, bypassing resolution.
+    /// The multi-token poller calls this per lane so it controls exactly
+    /// which token — and thus which independent rate-limit budget — each
+    /// poll spends. A 401 rejects the token process-wide (so lane
+    /// selection won't re-pick it) but never touches the held store;
+    /// lane lifecycle is the poller's job.
+    public func fetchUsage(using credential: OAuthCredential) async -> Result<RateLimitSnapshot, OAuthClientError> {
+        await performFetch(credential: credential)
+    }
+
+    /// The shared HTTP round-trip: build → send → status-branch → decode.
+    /// On 401 it rejects the token; held-store cleanup is left to the
+    /// caller so the specific-token path doesn't disturb resolution state.
+    private func performFetch(credential: OAuthCredential) async -> Result<RateLimitSnapshot, OAuthClientError> {
         var request = URLRequest(url: Self.endpoint)
         request.httpMethod = "GET"
         request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
@@ -173,8 +207,8 @@ public struct OAuthClient: Sendable {
         // makes proxies and CDNs less likely to vary the response.
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        // Step 4: send. URLSession.data is task-cancellable so a
-        // poller stop propagates here cleanly.
+        // URLSession.data is task-cancellable so a poller stop
+        // propagates here cleanly.
         let data: Data
         let response: HTTPURLResponse
         do {
@@ -183,20 +217,14 @@ public struct OAuthClient: Sendable {
             return .failure(.transport(underlying: error))
         }
 
-        // Step 5: status branching.
         let body = String(data: data, encoding: .utf8) ?? "<non-UTF8 body, \(data.count) bytes>"
         switch response.statusCode {
         case 200..<300:
             break // fall through to decode
         case 401:
-            // This token is bad. Blocklist it so resolution falls through to
-            // the next-freshest candidate, and drop our held copy so the next
-            // poll re-derives from the sources. (`fromHeldStore` is logged
-            // intent; we clear regardless since the held copy may equal the
-            // rejected token.)
-            _ = fromHeldStore
+            // This token is bad. Blocklist it so resolution / lane
+            // selection falls through to the next candidate.
             rejected.reject(credential.accessToken)
-            heldStore.clear()
             return .failure(.unauthorized(body: truncate(body, max: 200)))
         case 429:
             return .failure(.rateLimited(
@@ -206,16 +234,71 @@ public struct OAuthClient: Sendable {
             return .failure(.http(status: response.statusCode, body: truncate(body, max: 200)))
         }
 
-        // Step 6: decode. We tolerate either window being missing/null
-        // and tolerate `resets_at: null`. Only a wholly-broken shape is
-        // a hard failure.
+        // Same-account guard input: the account this response belongs to.
+        let orgId = response.value(forHTTPHeaderField: "anthropic-organization-id")
+
+        // Decode. We tolerate either window being missing/null and
+        // tolerate `resets_at: null`. Only a wholly-broken shape is a
+        // hard failure.
         let snapshot: RateLimitSnapshot
         do {
-            snapshot = try decode(body: data, sampledAt: now())
+            snapshot = try decode(body: data, sampledAt: now(), organizationId: orgId)
         } catch {
             return .failure(.responseSchemaMismatch(error.localizedDescription))
         }
         return .success(snapshot)
+    }
+
+    /// All usable (non-expired, non-rejected) candidate credentials for
+    /// polling, de-duplicated by access token, freshest first, each
+    /// tagged with its source. The multi-token poller unions these into
+    /// its persistent lane set.
+    ///
+    /// Reads Claude Code's keychain (silent) and our held copy always;
+    /// reads opted-in Claude Desktop only when its token file changed
+    /// since the last read (the `DesktopReadGate`, to avoid re-prompting)
+    /// — so Desktop tokens surface on the first call and again on
+    /// rotation, and the poller keeps the lanes alive in between. A
+    /// manual override, when set, is returned as the sole candidate.
+    public func candidateCredentials() -> [CredentialCandidate] {
+        if let override = tokenOverride() {
+            return [CredentialCandidate(
+                credential: OAuthCredential(accessToken: override, expiresAt: nil, subscriptionType: nil),
+                source: .override
+            )]
+        }
+        let referenceNow = now()
+        let usable: (OAuthCredential) -> Bool = { [rejected] cred in
+            !rejected.isRejected(cred.accessToken)
+                && (cred.expiresAt == nil || cred.expiresAt! >= referenceNow)
+        }
+        var out: [CredentialCandidate] = []
+        var seen = Set<String>()
+        func add(_ cred: OAuthCredential, _ source: CredentialCandidate.Source) {
+            guard usable(cred), !seen.contains(cred.accessToken) else { return }
+            seen.insert(cred.accessToken)
+            out.append(CredentialCandidate(credential: cred, source: source))
+        }
+
+        if case .success(let c) = keychain.read() { add(c, .keychain) }
+        if let held = heldStore.load() { add(held, .held) }
+        if desktopEnabled() {
+            let fingerprint = desktop.cacheFingerprint()
+            if desktopGate.shouldRead(fingerprint: fingerprint) {
+                desktopGate.record(fingerprint: fingerprint)
+                if case .success(let creds) = desktop.readAll() {
+                    for c in creds { add(c, .desktop) }
+                }
+            }
+        }
+
+        // Freshest first (nil expiry sorts as "never expires" ⇒ leads);
+        // ties broken by token so the ordering is deterministic.
+        return out.sorted {
+            let a = $0.credential.expiresAt ?? .distantFuture
+            let b = $1.credential.expiresAt ?? .distantFuture
+            return a != b ? a > b : $0.credential.accessToken < $1.credential.accessToken
+        }
     }
 
     // MARK: - Credential resolution
@@ -313,7 +396,7 @@ public struct OAuthClient: Sendable {
 
     private struct DecodeError: Error { let detail: String }
 
-    private func decode(body: Data, sampledAt: Date) throws -> RateLimitSnapshot {
+    private func decode(body: Data, sampledAt: Date, organizationId: String? = nil) throws -> RateLimitSnapshot {
         guard let top = try JSONSerialization.jsonObject(with: body) as? [String: Any] else {
             throw DecodeError(detail: "top level was not a JSON object")
         }
@@ -326,7 +409,8 @@ public struct OAuthClient: Sendable {
             sampledAt: sampledAt,
             fiveHour: decodeWindow(top["five_hour"]),
             sevenDay: decodeWindow(top["seven_day"]),
-            extraUsageCents: Self.decodeExtraUsage(top["extra_usage"])
+            extraUsageCents: Self.decodeExtraUsage(top["extra_usage"]),
+            organizationId: organizationId
         )
     }
 

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPollScheduler.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPollScheduler.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Pure scheduling policy for the multi-token OAuth poller. No I/O, no
+/// clock, no token secrets — it takes the current lane state plus `now`
+/// and returns "poll lane N" or "wait S seconds". That keeps every
+/// cadence/backoff decision unit-testable the same way the old
+/// single-token backoff math was.
+///
+/// ## What it's balancing
+///
+/// The `/api/oauth/usage` endpoint is computed live per request (so
+/// polling more often genuinely yields fresher numbers) but rate-limited
+/// to roughly **one request per 5 minutes per token**, and it advertises
+/// no budget headers — over-poll and you eat a ~30-minute throttle with
+/// no `Retry-After` hint. (See `docs/oauth-usage-endpoint.md` for the
+/// measurements behind these constants.)
+///
+/// The lever: an account often has **several independent tokens** (Claude
+/// Code + Claude Desktop), each with its own budget. So we spread polls
+/// across lanes — each lane no more than once per `perTokenMinInterval`
+/// (the hard invariant that keeps us off the throttle) — to hit a tighter
+/// *effective* endpoint cadence when it matters:
+///
+///   - **Active** (recent Claude usage): aim for `activeInterval` (~2.5
+///     min). Achievable only with ≥2 lanes; with one lane it floors at
+///     `perTokenMinInterval`.
+///   - **Idle**: relax to `idleInterval` — nothing's moving, so be
+///     polite and bank budget. Poll-on-wake (the poller nudging us when
+///     usage resumes) makes the idle→active transition feel instant.
+public struct OAuthPollScheduler: Sendable {
+
+    public struct Tuning: Sendable, Equatable {
+        /// The invariant. No single token is polled more often than this,
+        /// ever — this is what keeps every lane off the ~30-min throttle.
+        public var perTokenMinInterval: TimeInterval
+        /// Target endpoint cadence while actively burning tokens.
+        /// Realized only when there are enough lanes to sustain it.
+        public var activeInterval: TimeInterval
+        /// Endpoint cadence when idle.
+        public var idleInterval: TimeInterval
+        /// How recent the last activity must be to count as "active".
+        /// Wider than `activeInterval` so a short gap between prompts
+        /// doesn't drop us out of fast cadence.
+        public var activeWindow: TimeInterval
+        /// Floor on any returned wait, so a tiny/near-zero delay doesn't
+        /// spin the loop.
+        public var minWait: TimeInterval
+
+        public init(
+            perTokenMinInterval: TimeInterval = 300,
+            activeInterval: TimeInterval = 150,
+            idleInterval: TimeInterval = 600,
+            activeWindow: TimeInterval = 900,
+            minWait: TimeInterval = 1
+        ) {
+            self.perTokenMinInterval = perTokenMinInterval
+            self.activeInterval = activeInterval
+            self.idleInterval = idleInterval
+            self.activeWindow = activeWindow
+            self.minWait = minWait
+        }
+    }
+
+    /// A lane's account relationship to the pool's primary account,
+    /// learned from the `anthropic-organization-id` of its responses.
+    public enum AccountStatus: Sendable, Equatable {
+        /// Not yet polled — eligible, so we poll it once to learn its org.
+        case unknown
+        /// Confirmed same account as the pool's primary — full member.
+        case primary
+        /// A different account — excluded from selection and never
+        /// persisted, so interleaving can't mix two accounts' usage.
+        case foreign
+    }
+
+    public struct LaneState: Sendable, Equatable {
+        public var lastPolledAt: Date?
+        /// Set after a 429/transport failure; the lane is ineligible until
+        /// this passes. The poller grows it per-lane on repeated failures.
+        public var cooldownUntil: Date?
+        public var account: AccountStatus
+
+        public init(lastPolledAt: Date? = nil, cooldownUntil: Date? = nil, account: AccountStatus = .unknown) {
+            self.lastPolledAt = lastPolledAt
+            self.cooldownUntil = cooldownUntil
+            self.account = account
+        }
+    }
+
+    public enum Decision: Sendable, Equatable {
+        case poll(laneIndex: Int)
+        case wait(seconds: TimeInterval)
+    }
+
+    public let tuning: Tuning
+    public init(tuning: Tuning = Tuning()) { self.tuning = tuning }
+
+    /// Decide the next action. Lanes should be ordered by the poller so
+    /// that primary-eligible sources (manual override / Claude Code
+    /// keychain) come first — ties in "least-recently-polled" break by
+    /// index, so a never-polled primary lane is picked before a
+    /// never-polled Desktop lane, letting the primary establish the
+    /// account the pool is guarded against.
+    public func decide(lanes: [LaneState], lastActivityAt: Date?, now: Date) -> Decision {
+        // Non-foreign lanes are the only ones we can ever poll.
+        let usableIdx = lanes.indices.filter { lanes[$0].account != .foreign }
+        guard !usableIdx.isEmpty else { return .wait(seconds: tuning.idleInterval) }
+
+        let active = lastActivityAt.map { now.timeIntervalSince($0) <= tuning.activeWindow } ?? false
+        let target = active ? tuning.activeInterval : tuning.idleInterval
+
+        // When the endpoint-cadence gate next allows a poll: the most
+        // recent poll of any usable lane + target. No prior poll ⇒ now.
+        let lastEndpointPoll = usableIdx.compactMap { lanes[$0].lastPolledAt }.max()
+        let endpointReady = lastEndpointPoll?.addingTimeInterval(target) ?? .distantPast
+
+        // When each lane individually becomes eligible again (per-token
+        // invariant + cooldown), and the earliest such time overall.
+        func laneReadyAt(_ l: LaneState) -> Date {
+            let byInterval = l.lastPolledAt?.addingTimeInterval(tuning.perTokenMinInterval) ?? .distantPast
+            let byCooldown = l.cooldownUntil ?? .distantPast
+            return max(byInterval, byCooldown)
+        }
+        let earliestLaneReady = usableIdx.map { laneReadyAt(lanes[$0]) }.min() ?? .distantPast
+
+        // We may poll no sooner than BOTH gates allow.
+        let nextPoll = max(endpointReady, earliestLaneReady)
+        if now < nextPoll {
+            return .wait(seconds: max(tuning.minWait, nextPoll.timeIntervalSince(now)))
+        }
+
+        // Due: pick the eligible lane polled longest ago (never-polled
+        // sorts oldest), ties broken by index (primary-first ordering).
+        let eligible = usableIdx.filter { laneReadyAt(lanes[$0]) <= now }
+        let pick = eligible.min { a, b in
+            let la = lanes[a].lastPolledAt ?? .distantPast
+            let lb = lanes[b].lastPolledAt ?? .distantPast
+            return la != lb ? la < lb : a < b
+        }
+        // `eligible` is non-empty because earliestLaneReady ≤ nextPoll ≤ now.
+        return .poll(laneIndex: pick ?? usableIdx[0])
+    }
+}

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPollScheduler.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPollScheduler.swift
@@ -22,8 +22,8 @@ import Foundation
 /// *effective* endpoint cadence when it matters:
 ///
 ///   - **Active** (recent Claude usage): the fastest *even* cadence the
-///     lanes can sustain — `max(activeInterval floor, perTokenMin/lanes)`.
-///     5 tokens → ~1 min, 2 → ~2.5 min, 1 → 5 min.
+///     lanes can sustain — `perTokenMin/lanes` (no floor by default).
+///     5 tokens → ~1 min, 10 → ~30s, 2 → ~2.5 min, 1 → 5 min.
 ///   - **Idle**: relax to `idleInterval` — nothing's moving, so be
 ///     polite and bank budget. Poll-on-wake (the poller nudging us when
 ///     usage resumes) makes the idle→active transition feel instant.
@@ -33,10 +33,11 @@ public struct OAuthPollScheduler: Sendable {
         /// The invariant. No single token is polled more often than this,
         /// ever — this is what keeps every lane off the ~30-min throttle.
         public var perTokenMinInterval: TimeInterval
-        /// Floor on the active endpoint cadence — the fastest we'll poll
-        /// even with many tokens (politeness to the shared endpoint). The
-        /// realized active interval is `max(this, perTokenMinInterval /
-        /// usableLanes)`, so more tokens poll faster, down to this floor.
+        /// Optional floor on the active endpoint cadence. Default 0 — no
+        /// floor, so more tokens poll strictly faster. The realized active
+        /// interval is `max(this, perTokenMinInterval / usableLanes)`; the
+        /// per-token invariant (each lane ≤ perTokenMinInterval) is what
+        /// actually keeps us off the throttle regardless of this value.
         public var activeInterval: TimeInterval
         /// Endpoint cadence when idle.
         public var idleInterval: TimeInterval
@@ -50,7 +51,7 @@ public struct OAuthPollScheduler: Sendable {
 
         public init(
             perTokenMinInterval: TimeInterval = 300,
-            activeInterval: TimeInterval = 60,
+            activeInterval: TimeInterval = 0,
             idleInterval: TimeInterval = 600,
             activeWindow: TimeInterval = 900,
             minWait: TimeInterval = 1

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPollScheduler.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPollScheduler.swift
@@ -21,9 +21,9 @@ import Foundation
 /// (the hard invariant that keeps us off the throttle) — to hit a tighter
 /// *effective* endpoint cadence when it matters:
 ///
-///   - **Active** (recent Claude usage): aim for `activeInterval` (~2.5
-///     min). Achievable only with ≥2 lanes; with one lane it floors at
-///     `perTokenMinInterval`.
+///   - **Active** (recent Claude usage): the fastest *even* cadence the
+///     lanes can sustain — `max(activeInterval floor, perTokenMin/lanes)`.
+///     5 tokens → ~1 min, 2 → ~2.5 min, 1 → 5 min.
 ///   - **Idle**: relax to `idleInterval` — nothing's moving, so be
 ///     polite and bank budget. Poll-on-wake (the poller nudging us when
 ///     usage resumes) makes the idle→active transition feel instant.
@@ -33,8 +33,10 @@ public struct OAuthPollScheduler: Sendable {
         /// The invariant. No single token is polled more often than this,
         /// ever — this is what keeps every lane off the ~30-min throttle.
         public var perTokenMinInterval: TimeInterval
-        /// Target endpoint cadence while actively burning tokens.
-        /// Realized only when there are enough lanes to sustain it.
+        /// Floor on the active endpoint cadence — the fastest we'll poll
+        /// even with many tokens (politeness to the shared endpoint). The
+        /// realized active interval is `max(this, perTokenMinInterval /
+        /// usableLanes)`, so more tokens poll faster, down to this floor.
         public var activeInterval: TimeInterval
         /// Endpoint cadence when idle.
         public var idleInterval: TimeInterval
@@ -48,7 +50,7 @@ public struct OAuthPollScheduler: Sendable {
 
         public init(
             perTokenMinInterval: TimeInterval = 300,
-            activeInterval: TimeInterval = 150,
+            activeInterval: TimeInterval = 60,
             idleInterval: TimeInterval = 600,
             activeWindow: TimeInterval = 900,
             minWait: TimeInterval = 1
@@ -107,7 +109,15 @@ public struct OAuthPollScheduler: Sendable {
         guard !usableIdx.isEmpty else { return .wait(seconds: tuning.idleInterval) }
 
         let active = lastActivityAt.map { now.timeIntervalSince($0) <= tuning.activeWindow } ?? false
-        let target = active ? tuning.activeInterval : tuning.idleInterval
+        // Active target = the fastest EVEN cadence the usable lanes can
+        // sustain (each lane ≤ perTokenMinInterval), floored at
+        // activeInterval. More tokens ⇒ faster (5 tokens → 1 min), fewer
+        // ⇒ slower (2 → 2.5 min, 1 → 5 min), never below the floor. Using
+        // the lane-count-aware target here (not the raw floor) keeps the
+        // cadence evenly spaced instead of bunching quick polls then idling.
+        let target: TimeInterval = active
+            ? max(tuning.activeInterval, tuning.perTokenMinInterval / Double(max(usableIdx.count, 1)))
+            : tuning.idleInterval
 
         // When the endpoint-cadence gate next allows a poll: the most
         // recent poll of any usable lane + target. No prior poll ⇒ now.

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -381,7 +381,7 @@ public actor OAuthPoller {
             }
             if matches {
                 lanes[idx].state.account = .primary
-                await persist(snapshot)
+                await persist(snapshot, laneSource: lanes[idx].source)
                 return .success(
                     fiveHourPct: snapshot.fiveHour?.usedPercentage,
                     sevenDayPct: snapshot.sevenDay?.usedPercentage
@@ -506,17 +506,78 @@ public actor OAuthPoller {
         }
     }
 
+    // MARK: - Non-monotonic usage diagnostics
+
+    /// Most recent persisted OAuth sample for a window (or nil).
+    @MainActor
+    private static func latestSample(_ context: ModelContext, window: String) -> RateLimitSample? {
+        var d = FetchDescriptor<RateLimitSample>(
+            predicate: #Predicate { $0.window == window && $0.source == "oauth" },
+            sortBy: [SortDescriptor(\.sampledAt, order: .reverse)]
+        )
+        d.fetchLimit = 1
+        return (try? context.fetch(d))?.first
+    }
+
+    /// Log when a window's utilization *decreases* for a reason that
+    /// isn't one of the two resets we already recognize — i.e. a small
+    /// within-window wobble, the kind a lagging backend replica (possibly
+    /// surfaced by interleaving tokens) could produce. Purely diagnostic:
+    /// one grep-able line, no behavior change. We deliberately do NOT log:
+    ///   - a normal rollover — `resets_at` advanced past the prior anchor;
+    ///   - an off-schedule global reset — a collapse from a meaningful
+    ///     level to ~0 (handled by `GlobalRateLimitReset`).
+    @MainActor
+    private static func logIfUsageWentDown(
+        windowName: String,
+        prior: RateLimitSample?,
+        newUsed: Double,
+        newReset: Date?,
+        laneSource: CredentialCandidate.Source
+    ) {
+        guard let prior else { return }
+        let priorUsed = prior.usedPercentage
+        guard newUsed < priorUsed - 0.01 else { return }   // not a decrease
+
+        // Rollover: the window advanced to a later reset anchor.
+        let rolloverTolerance: TimeInterval = 10 * 60
+        if let pr = prior.resetsAt, let nr = newReset, nr.timeIntervalSince(pr) > rolloverTolerance {
+            return
+        }
+        // Off-schedule global reset: collapse to ~0 on an unchanged anchor.
+        if priorUsed > 5, newUsed < 1 { return }
+
+        let anchor: String
+        if let pr = prior.resetsAt, let nr = newReset {
+            let drift = Int(nr.timeIntervalSince(pr).rounded())
+            anchor = drift == 0 ? "resets_at unchanged" : "resets_at drift \(drift)s"
+        } else {
+            anchor = "resets_at nil"
+        }
+        Log.write("OAuthPoller", String(
+            format: "usage DECREASED (non-reset): %@ %.1f%%→%.1f%% via %@ token; %@ — likely backend replica lag",
+            windowName, priorUsed, newUsed, laneSource.rawValue, anchor
+        ))
+    }
+
     // MARK: - Persistence
 
     /// Write one row per present window. Hops to the main actor for
     /// SwiftData since `ModelContext` is `@MainActor` in our setup.
-    private func persist(_ snapshot: RateLimitSnapshot) async {
+    private func persist(_ snapshot: RateLimitSnapshot, laneSource: CredentialCandidate.Source) async {
         let container = self.container
         let captured = snapshot
         await MainActor.run {
             let context = ModelContext(container)
             var wroteAnyWindow = false
             if let window = captured.fiveHour {
+                Self.logIfUsageWentDown(
+                    windowName: RateLimitWindowName.fiveHour,
+                    prior: Self.latestSample(context, window: RateLimitWindowName.fiveHour),
+                    newUsed: window.usedPercentage,
+                    newReset: window.resetsAt,
+                    laneSource: laneSource
+                )
                 context.insert(RateLimitSample(
                     sampledAt: captured.sampledAt,
                     window: RateLimitWindowName.fiveHour,
@@ -527,6 +588,13 @@ public actor OAuthPoller {
                 wroteAnyWindow = true
             }
             if let window = captured.sevenDay {
+                Self.logIfUsageWentDown(
+                    windowName: RateLimitWindowName.sevenDay,
+                    prior: Self.latestSample(context, window: RateLimitWindowName.sevenDay),
+                    newUsed: window.usedPercentage,
+                    newReset: window.resetsAt,
+                    laneSource: laneSource
+                )
                 context.insert(RateLimitSample(
                     sampledAt: captured.sampledAt,
                     window: RateLimitWindowName.sevenDay,

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -137,6 +137,21 @@ public actor OAuthPoller: TokenPoolTesting {
         var resolvedOrg: String?
     }
 
+    /// Sendable carrier for a lane's persisted metadata — read from and
+    /// written to SwiftData (`TokenLaneMeta`) across the MainActor hop,
+    /// and cached in-memory so lane seeding/rediscovery can restore state
+    /// without a fetch. Keyed by the lane fingerprint (`id`).
+    private struct LaneMetaSnapshot: Sendable {
+        var id: String
+        var sourceRaw: String
+        var organizationId: String?
+        var account: OAuthPollScheduler.AccountStatus
+        var expiresAt: Date?
+        var lastPolledAt: Date?
+        var cooldownUntil: Date?
+        var consecutiveFailures: Int
+    }
+
     private let client: OAuthClient
     private let container: ModelContainer
     private let configuration: Configuration
@@ -161,6 +176,13 @@ public actor OAuthPoller: TokenPoolTesting {
     private let poolStore: TokenPoolStoring
     private var seeded = false
     private var lastSavedPoolTokens: Set<String> = []
+
+    /// Persisted lane metadata (account / cooldown / last-poll / org),
+    /// loaded once per launch so seeded + rediscovered lanes restore their
+    /// status without an immediate re-poll and the Tokens UI isn't blank
+    /// on boot. Written back after every poll and pool mutation.
+    private var persistedMeta: [String: LaneMetaSnapshot] = [:]
+    private var metaLoaded = false
 
     private var loopTask: Task<Void, Never>?
     private var sleeper: Task<Void, Never>?
@@ -221,6 +243,7 @@ public actor OAuthPoller: TokenPoolTesting {
     /// the categorized outcome. Does NOT loop or sleep.
     @discardableResult
     public func runOnce() async -> PollOutcome {
+        await loadPersistedMetaIfNeeded()
         ensureLanes()
         let now = clock.now()
         let idx = lanes.indices
@@ -261,6 +284,7 @@ public actor OAuthPoller: TokenPoolTesting {
     /// spends that token's budget through the same accounting as an auto
     /// poll, never a hidden extra request.
     public func testLane(id: String) async -> TokenTestResult {
+        await loadPersistedMetaIfNeeded()
         ensureLanes()
         guard let idx = lanes.firstIndex(where: { Self.laneId($0.credential.accessToken) == id }) else {
             return .failure(reason: "That token is no longer available.")
@@ -277,6 +301,7 @@ public actor OAuthPoller: TokenPoolTesting {
     public func testAdHoc(token: String) async -> TokenTestResult {
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .failure(reason: "Empty token.") }
+        await loadPersistedMetaIfNeeded()
         ensureLanes()
         if let idx = lanes.firstIndex(where: { $0.credential.accessToken == trimmed }) {
             let outcome = await pollLane(idx)
@@ -311,6 +336,7 @@ public actor OAuthPoller: TokenPoolTesting {
         if case .invalid(let reason) = TokenFormat.validate(trimmed) {
             return .failure(reason: reason)
         }
+        await loadPersistedMetaIfNeeded()
         ensureLanes()
         if let existing = lanes.first(where: { $0.credential.accessToken == trimmed }) {
             return .alreadyTracked(source: existing.source, fingerprint: Self.laneId(existing.credential.accessToken))
@@ -337,6 +363,7 @@ public actor OAuthPoller: TokenPoolTesting {
         // Foreign account / 401 / invalid — don't keep it in the pool.
         let foreignOrg = lane?.resolvedOrg
         lanes.removeAll { $0.credential.accessToken == trimmed }
+        await saveAllLaneMeta()   // prune the rejected lane's metadata
         await publishStatus()
         if case .foreignAccount = outcome { return .foreignAccount(org: foreignOrg) }
         return Self.testResult(from: outcome)
@@ -350,6 +377,7 @@ public actor OAuthPoller: TokenPoolTesting {
         let primary = lanes.filter { $0.state.account == .primary }
         lastSavedPoolTokens = Set(primary.map { $0.credential.accessToken })
         poolStore.saveAll(primary.map { StoredToken(credential: $0.credential, source: $0.source) })
+        await saveAllLaneMeta()   // prune the removed lane's metadata
         await publishStatus()
     }
 
@@ -416,6 +444,12 @@ public actor OAuthPoller: TokenPoolTesting {
             if stopping || Task.isCancelled { return }
         }
 
+        // Restore persisted lane state and publish it before the first poll
+        // so the Tokens UI shows last-known status/account/expiry on launch.
+        await loadPersistedMetaIfNeeded()
+        ensureLanes()
+        await publishStatus()
+
         while !stopping && !Task.isCancelled {
             ensureLanes()
             let activity = await activityProbe()
@@ -473,13 +507,15 @@ public actor OAuthPoller: TokenPoolTesting {
             for stored in poolStore.loadAll() {
                 if let exp = stored.credential.expiresAt, exp < now { continue }
                 if lanes.contains(where: { $0.credential.accessToken == stored.credential.accessToken }) { continue }
-                lanes.append(Lane(
+                var lane = Lane(
                     credential: stored.credential,
                     source: stored.source,
                     state: OAuthPollScheduler.LaneState(),
                     consecutiveFailures: 0,
                     resolvedOrg: nil
-                ))
+                )
+                applyPersistedMeta(to: &lane)   // restore last-known status
+                lanes.append(lane)
             }
         }
         let noUsable = !lanes.contains { $0.state.account != .foreign }
@@ -520,13 +556,15 @@ public actor OAuthPoller: TokenPoolTesting {
     private func mergeCandidates(_ candidates: [CredentialCandidate]) {
         var known = Set(lanes.map { $0.credential.accessToken })
         for candidate in candidates where !known.contains(candidate.credential.accessToken) {
-            lanes.append(Lane(
+            var lane = Lane(
                 credential: candidate.credential,
                 source: candidate.source,
                 state: OAuthPollScheduler.LaneState(),
                 consecutiveFailures: 0,
                 resolvedOrg: nil
-            ))
+            )
+            applyPersistedMeta(to: &lane)   // restore last-known status for a rediscovered token
+            lanes.append(lane)
             known.insert(candidate.credential.accessToken)
         }
     }
@@ -571,6 +609,9 @@ public actor OAuthPoller: TokenPoolTesting {
         if !Self.sameCategory(previous, outcome) {
             Log.write("OAuthPoller", Self.summarize(outcome: outcome, laneCount: lanes.count))
         }
+        // Persist the lane's freshly-learned state (account/org/last-poll/
+        // cooldown) so it survives a restart.
+        await saveAllLaneMeta()
         return outcome
     }
 
@@ -777,6 +818,112 @@ public actor OAuthPoller: TokenPoolTesting {
             format: "usage DECREASED (non-reset): %@ %.1f%%→%.1f%% via %@ token; %@ — likely backend replica lag",
             windowName, priorUsed, newUsed, laneSource.rawValue, anchor
         ))
+    }
+
+    // MARK: - Lane metadata persistence
+
+    /// Load persisted lane metadata once per launch (MainActor for
+    /// SwiftData). Restores the pool's primary org so the same-account
+    /// guard is intact immediately, and populates the cache that
+    /// `ensureLanes`/`mergeCandidates` read to rehydrate lanes.
+    private func loadPersistedMetaIfNeeded() async {
+        guard !metaLoaded else { return }
+        metaLoaded = true
+        let container = self.container
+        let loaded: ([String: LaneMetaSnapshot], String?) = await MainActor.run {
+            let context = ModelContext(container)
+            let rows = (try? context.fetch(FetchDescriptor<TokenLaneMeta>())) ?? []
+            var map: [String: LaneMetaSnapshot] = [:]
+            var primary: String?
+            for r in rows {
+                let account = OAuthPollScheduler.AccountStatus(rawValue: r.accountRaw)
+                map[r.id] = LaneMetaSnapshot(
+                    id: r.id,
+                    sourceRaw: r.sourceRaw,
+                    organizationId: r.organizationId,
+                    account: account,
+                    expiresAt: r.expiresAt,
+                    lastPolledAt: r.lastPolledAt,
+                    cooldownUntil: r.cooldownUntil,
+                    consecutiveFailures: r.consecutiveFailures
+                )
+                if account == .primary, primary == nil { primary = r.organizationId }
+            }
+            return (map, primary)
+        }
+        persistedMeta = loaded.0
+        if primaryOrg == nil { primaryOrg = loaded.1 }
+    }
+
+    /// Restore a freshly-seeded/discovered lane's learned state from the
+    /// persisted cache, so a known token doesn't show as blank/pending or
+    /// get needlessly re-polled right after launch.
+    private func applyPersistedMeta(to lane: inout Lane) {
+        guard let meta = persistedMeta[Self.laneId(lane.credential.accessToken)] else { return }
+        lane.state.account = meta.account
+        lane.state.lastPolledAt = meta.lastPolledAt
+        lane.state.cooldownUntil = meta.cooldownUntil
+        lane.resolvedOrg = meta.organizationId
+        lane.consecutiveFailures = meta.consecutiveFailures
+    }
+
+    private func laneMetaSnapshot(for lane: Lane) -> LaneMetaSnapshot {
+        LaneMetaSnapshot(
+            id: Self.laneId(lane.credential.accessToken),
+            sourceRaw: lane.source.rawValue,
+            organizationId: lane.resolvedOrg,
+            account: lane.state.account,
+            expiresAt: lane.credential.expiresAt,
+            lastPolledAt: lane.state.lastPolledAt,
+            cooldownUntil: lane.state.cooldownUntil,
+            consecutiveFailures: lane.consecutiveFailures
+        )
+    }
+
+    /// Persist all current lanes' metadata (upsert by fingerprint) and
+    /// prune rows for tokens no longer in the pool, so the Tokens table and
+    /// the scheduler restore real state on the next launch. Called after a
+    /// poll and after any pool mutation.
+    private func saveAllLaneMeta() async {
+        let rows = lanes.map { laneMetaSnapshot(for: $0) }
+        // Keep the in-memory cache in step with what we persist.
+        persistedMeta = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0) })
+        let keep = Set(rows.map { $0.id })
+        let now = clock.now()
+        let container = self.container
+        await MainActor.run {
+            let context = ModelContext(container)
+            let existing = (try? context.fetch(FetchDescriptor<TokenLaneMeta>())) ?? []
+            var byId: [String: TokenLaneMeta] = [:]
+            for e in existing { byId[e.id] = e }
+            for row in rows {
+                if let m = byId[row.id] {
+                    m.sourceRaw = row.sourceRaw
+                    m.organizationId = row.organizationId
+                    m.accountRaw = row.account.rawValue
+                    m.expiresAt = row.expiresAt
+                    m.lastPolledAt = row.lastPolledAt
+                    m.cooldownUntil = row.cooldownUntil
+                    m.consecutiveFailures = row.consecutiveFailures
+                    m.updatedAt = now
+                } else {
+                    context.insert(TokenLaneMeta(
+                        id: row.id,
+                        sourceRaw: row.sourceRaw,
+                        organizationId: row.organizationId,
+                        accountRaw: row.account.rawValue,
+                        expiresAt: row.expiresAt,
+                        lastPolledAt: row.lastPolledAt,
+                        cooldownUntil: row.cooldownUntil,
+                        consecutiveFailures: row.consecutiveFailures,
+                        updatedAt: now
+                    ))
+                }
+            }
+            for e in existing where !keep.contains(e.id) { context.delete(e) }
+            do { try context.save() }
+            catch { Log.write("OAuthPoller", "lane-meta persist failed: \(error)") }
+        }
     }
 
     // MARK: - Persistence

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -155,6 +155,13 @@ public actor OAuthPoller: TokenPoolTesting {
     private var lastPollAt: Date?
     private var nextPollAt: Date?
 
+    /// Pacer's persistent token pool (its own keychain). Seeded into lanes
+    /// once per launch so tokens survive a restart without reading Claude's
+    /// stores; re-saved when the confirmed-primary token set changes.
+    private let poolStore: TokenPoolStoring
+    private var seeded = false
+    private var lastSavedPoolTokens: Set<String> = []
+
     private var loopTask: Task<Void, Never>?
     private var sleeper: Task<Void, Never>?
     private var stopping = false
@@ -165,6 +172,7 @@ public actor OAuthPoller: TokenPoolTesting {
         configuration: Configuration = Configuration(),
         clock: PollerClock = SystemPollerClock(),
         activityProbe: (@Sendable () async -> Date?)? = nil,
+        poolStore: TokenPoolStoring = EphemeralTokenPoolStore(),
         random: @escaping RandomSource = { Double.random(in: 0..<1) }
     ) {
         self.client = client
@@ -173,6 +181,7 @@ public actor OAuthPoller: TokenPoolTesting {
         self.clock = clock
         self.scheduler = OAuthPollScheduler(tuning: configuration.scheduler)
         self.activityProbe = activityProbe ?? Self.defaultActivityProbe(container: container)
+        self.poolStore = poolStore
         self.random = random
     }
 
@@ -404,10 +413,29 @@ public actor OAuthPoller: TokenPoolTesting {
     /// remains; always prunes expired lanes; keeps ordering primary-first.
     private func ensureLanes() {
         let now = clock.now()
+        // Seed from Pacer's persisted pool once per launch, so every token
+        // comes back on restart without touching Claude's stores.
+        if !seeded {
+            seeded = true
+            for stored in poolStore.loadAll() {
+                if let exp = stored.credential.expiresAt, exp < now { continue }
+                if lanes.contains(where: { $0.credential.accessToken == stored.credential.accessToken }) { continue }
+                lanes.append(Lane(
+                    credential: stored.credential,
+                    source: stored.source,
+                    state: OAuthPollScheduler.LaneState(),
+                    consecutiveFailures: 0,
+                    resolvedOrg: nil
+                ))
+            }
+        }
         let noUsable = !lanes.contains { $0.state.account != .foreign }
         let stale = lastDiscoveryAt.map { now.timeIntervalSince($0) >= configuration.laneRediscoverInterval } ?? true
         if stale || noUsable {
-            mergeCandidates(client.candidateCredentials())
+            // Hand the client our Desktop-origin tokens so its layered read
+            // can decide whether it even needs to touch Claude Desktop.
+            let cachedDesktop = lanes.filter { $0.source == .desktop }.map { $0.credential }
+            mergeCandidates(client.candidateCredentials(cachedDesktopTokens: cachedDesktop))
             lastDiscoveryAt = now
         }
         // Drop lanes whose token has expired locally (server would 401).
@@ -416,6 +444,20 @@ public actor OAuthPoller: TokenPoolTesting {
             return false
         }
         sortLanes()
+        savePool()
+    }
+
+    /// Persist the confirmed same-account tokens to Pacer's keychain so
+    /// they survive a restart. Only `.primary` lanes — never a foreign
+    /// (different-account) or not-yet-confirmed token — and only when the
+    /// token set actually changed, to avoid a keychain write every poll.
+    private func savePool() {
+        let primary = lanes.filter { $0.state.account == .primary }
+        guard !primary.isEmpty else { return }   // don't wipe the pool pre-confirmation
+        let tokenSet = Set(primary.map { $0.credential.accessToken })
+        guard tokenSet != lastSavedPoolTokens else { return }
+        lastSavedPoolTokens = tokenSet
+        poolStore.saveAll(primary.map { StoredToken(credential: $0.credential, source: $0.source) })
     }
 
     /// Union new candidate tokens into the lane set, preserving the state

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -252,7 +252,7 @@ public actor OAuthPoller: TokenPoolTesting {
     /// Stable, non-reversible id for a token — 12 hex chars of its
     /// SHA-256. The lane's UI identity + test-routing key; never exposes
     /// token bytes.
-    private static func laneId(_ token: String) -> String {
+    static func laneId(_ token: String) -> String {
         SHA256.hash(data: Data(token.utf8)).prefix(6).map { String(format: "%02x", $0) }.joined()
     }
 
@@ -298,6 +298,54 @@ public actor OAuthPoller: TokenPoolTesting {
         case .failure(let error):
             return Self.testFailure(error)
         }
+    }
+
+    /// Add a manually-supplied token as an `.override` lane and poll it
+    /// once to confirm your account. Kept (and persisted) only if it's the
+    /// same account; a duplicate / foreign / invalid token isn't retained.
+    public func addManualToken(_ token: String) async -> TokenTestResult {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(reason: "Empty token.") }
+        ensureLanes()
+        if lanes.contains(where: { $0.credential.accessToken == trimmed }) {
+            return .alreadyTracked
+        }
+        // Unknown local expiry — the server 401s when it lapses.
+        lanes.append(Lane(
+            credential: OAuthCredential(accessToken: trimmed, expiresAt: nil, subscriptionType: nil),
+            source: .override,
+            state: OAuthPollScheduler.LaneState(),
+            consecutiveFailures: 0,
+            resolvedOrg: nil
+        ))
+        sortLanes()
+        guard let idx = lanes.firstIndex(where: { $0.credential.accessToken == trimmed }) else {
+            return .failure(reason: "Couldn't add the token.")
+        }
+        let outcome = await pollLane(idx)
+        let lane = lanes.first(where: { $0.credential.accessToken == trimmed })
+        if lane?.state.account == .primary {
+            savePool()
+            await publishStatus()
+            return Self.testResult(from: outcome)
+        }
+        // Foreign account / 401 / invalid — don't keep it in the pool.
+        let foreignOrg = lane?.resolvedOrg
+        lanes.removeAll { $0.credential.accessToken == trimmed }
+        await publishStatus()
+        if case .foreignAccount = outcome { return .foreignAccount(org: foreignOrg) }
+        return Self.testResult(from: outcome)
+    }
+
+    /// Remove a manually-added (`.override`) lane by its opaque id.
+    public func removeManualToken(id: String) async {
+        lanes.removeAll { $0.source == .override && Self.laneId($0.credential.accessToken) == id }
+        // Force-persist the removal (bypass savePool's "don't wipe" guard) so
+        // the removed token can't reappear from the pool on the next launch.
+        let primary = lanes.filter { $0.state.account == .primary }
+        lastSavedPoolTokens = Set(primary.map { $0.credential.accessToken })
+        poolStore.saveAll(primary.map { StoredToken(credential: $0.credential, source: $0.source) })
+        await publishStatus()
     }
 
     /// Publish a display-safe snapshot of the lane pool + effective

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftData
+import CryptoKit
 
 /// Abstraction over wall-clock time for the poller's loop. Production
 /// uses `SystemPollerClock`. Tests inject a controllable clock so they
@@ -64,7 +65,7 @@ public struct SystemPollerClock: PollerClock {
 ///     never over-poll.
 ///
 /// `start()`/`stop()` symmetrical; safe to call from any context.
-public actor OAuthPoller {
+public actor OAuthPoller: TokenPoolTesting {
 
     public struct Configuration: Sendable {
         /// Cadence policy (per-token floor, active/idle targets, activity
@@ -131,6 +132,9 @@ public actor OAuthPoller {
         let source: CredentialCandidate.Source
         var state: OAuthPollScheduler.LaneState
         var consecutiveFailures: Int
+        /// The account this token resolved to (from a successful poll's
+        /// `anthropic-organization-id`); nil until first polled.
+        var resolvedOrg: String?
     }
 
     private let client: OAuthClient
@@ -144,6 +148,9 @@ public actor OAuthPoller {
     private var lanes: [Lane] = []
     private var primaryOrg: String?
     private var lastDiscoveryAt: Date?
+    /// Most recent activity time seen by the loop, cached so status
+    /// publishes can report active/idle without another probe.
+    private var lastActivityAt: Date?
     private var lastOutcome: PollOutcome?
     private var lastPollAt: Date?
     private var nextPollAt: Date?
@@ -175,6 +182,8 @@ public actor OAuthPoller {
     public func start() {
         guard loopTask == nil else { return }
         stopping = false
+        // Let the Settings "Tokens" section route Test clicks back here.
+        Task { await MainActor.run { TokenPoolStatus.shared.tester = self } }
         loopTask = Task { [weak self] in
             await self?.loop()
         }
@@ -229,6 +238,114 @@ public actor OAuthPoller {
         )
     }
 
+    // MARK: - Manual test + status publishing (TokenPoolTesting)
+
+    /// Stable, non-reversible id for a token — 12 hex chars of its
+    /// SHA-256. The lane's UI identity + test-routing key; never exposes
+    /// token bytes.
+    private static func laneId(_ token: String) -> String {
+        SHA256.hash(data: Data(token.utf8)).prefix(6).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Test an existing lane by id. Routes through the normal poll path so
+    /// the reading is persisted and the lane is stamped — a manual test
+    /// spends that token's budget through the same accounting as an auto
+    /// poll, never a hidden extra request.
+    public func testLane(id: String) async -> TokenTestResult {
+        ensureLanes()
+        guard let idx = lanes.firstIndex(where: { Self.laneId($0.credential.accessToken) == id }) else {
+            return .failure(reason: "That token is no longer available.")
+        }
+        let outcome = await pollLane(idx)
+        await publishStatus()
+        return Self.testResult(from: outcome)
+    }
+
+    /// Test a raw token the UI holds (an unsaved override draft). If it's
+    /// already a lane, route through it (stamped/counted); otherwise poll
+    /// once and persist when it's the same account, so the reading isn't
+    /// thrown away.
+    public func testAdHoc(token: String) async -> TokenTestResult {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(reason: "Empty token.") }
+        ensureLanes()
+        if let idx = lanes.firstIndex(where: { $0.credential.accessToken == trimmed }) {
+            let outcome = await pollLane(idx)
+            await publishStatus()
+            return Self.testResult(from: outcome)
+        }
+        let cred = OAuthCredential(accessToken: trimmed, expiresAt: nil, subscriptionType: nil)
+        switch await client.fetchUsage(using: cred) {
+        case .success(let snap):
+            let org = snap.organizationId
+            let matches: Bool
+            if let primary = primaryOrg { matches = (org == nil || org == primary) }
+            else { primaryOrg = org; matches = true }
+            if matches {
+                await persist(snap, laneSource: .override)
+                return .success(fiveHour: snap.fiveHour?.usedPercentage, sevenDay: snap.sevenDay?.usedPercentage)
+            }
+            return .foreignAccount(org: org)
+        case .failure(let error):
+            return Self.testFailure(error)
+        }
+    }
+
+    /// Publish a display-safe snapshot of the lane pool + effective
+    /// cadence to `TokenPoolStatus.shared` for the Settings section.
+    private func publishStatus() async {
+        let tuning = configuration.scheduler
+        let usable = lanes.filter { $0.state.account != .foreign }.count
+        let active = lastActivityAt.map { clock.now().timeIntervalSince($0) <= tuning.activeWindow } ?? false
+        let realizedActive = max(tuning.activeInterval, tuning.perTokenMinInterval / Double(max(usable, 1)))
+        let effective: TimeInterval? = usable == 0 ? nil : (active ? realizedActive : tuning.idleInterval)
+        let statuses = lanes.enumerated().map { i, lane in
+            TokenLaneStatus(
+                id: Self.laneId(lane.credential.accessToken),
+                source: lane.source,
+                organizationId: lane.resolvedOrg,
+                account: lane.state.account,
+                expiresAt: lane.credential.expiresAt,
+                lastPolledAt: lane.state.lastPolledAt,
+                cooldownUntil: lane.state.cooldownUntil,
+                consecutiveFailures: lane.consecutiveFailures,
+                priority: i
+            )
+        }
+        await MainActor.run {
+            TokenPoolStatus.shared.publish(lanes: statuses, isActive: active, effectiveIntervalSeconds: effective)
+        }
+    }
+
+    private static func testResult(from outcome: PollOutcome) -> TokenTestResult {
+        switch outcome {
+        case .success(let fh, let sd):   return .success(fiveHour: fh, sevenDay: sd)
+        case .foreignAccount:            return .foreignAccount(org: nil)
+        case .rateLimited:               return .failure(reason: "Rate-limited (429). This token is cooling down.")
+        case .unauthorized:              return .failure(reason: "Anthropic rejected this token (401).")
+        case .tokenExpired:              return .failure(reason: "This token is expired.")
+        case .transport:                 return .failure(reason: "Network error. Check your connection.")
+        case .http(let s):               return .failure(reason: "Server returned HTTP \(s).")
+        case .responseSchemaMismatch:    return .failure(reason: "Unexpected response shape from Anthropic.")
+        case .credentialsNotFound:       return .failure(reason: "That token is no longer available.")
+        case .keychainAccessDenied:      return .failure(reason: "Keychain access denied.")
+        case .keychainMalformed, .keychainStatus:
+            return .failure(reason: "Couldn't read the credential.")
+        }
+    }
+
+    private static func testFailure(_ error: OAuthClientError) -> TokenTestResult {
+        switch error {
+        case .rateLimited:            return .failure(reason: "Rate-limited (429). Try again shortly.")
+        case .unauthorized:           return .failure(reason: "Anthropic rejected this token (401). A `claude setup-token` value is user:inference-only and won't work here — paste the user:profile access token.")
+        case .transport:              return .failure(reason: "Network error.")
+        case .http(let s, _):         return .failure(reason: "Server returned HTTP \(s).")
+        case .responseSchemaMismatch: return .failure(reason: "Unexpected response shape.")
+        case .tokenExpired:           return .failure(reason: "This token is expired.")
+        default:                      return .failure(reason: "Couldn't validate this token.")
+        }
+    }
+
     // MARK: - Loop
 
     private func loop() async {
@@ -239,15 +356,18 @@ public actor OAuthPoller {
 
         while !stopping && !Task.isCancelled {
             ensureLanes()
+            let activity = await activityProbe()
+            lastActivityAt = activity
+
             if lanes.allSatisfy({ $0.state.account == .foreign }) || lanes.isEmpty {
                 // Nothing usable — record it once and idle until rediscovery.
                 if lanes.isEmpty { lastOutcome = .credentialsNotFound }
+                await publishStatus()
                 nextPollAt = clock.now().addingTimeInterval(configuration.scheduler.idleInterval)
                 await nap(configuration.scheduler.idleInterval)
                 continue
             }
 
-            let activity = await activityProbe()
             let decision = scheduler.decide(
                 lanes: lanes.map(\.state),
                 lastActivityAt: activity,
@@ -256,8 +376,10 @@ public actor OAuthPoller {
             switch decision {
             case .poll(let idx):
                 _ = await pollLane(idx)
+                await publishStatus()
             case .wait(let seconds):
                 nextPollAt = clock.now().addingTimeInterval(seconds)
+                await publishStatus()
                 await nap(seconds)
             }
         }
@@ -307,7 +429,8 @@ public actor OAuthPoller {
                 credential: candidate.credential,
                 source: candidate.source,
                 state: OAuthPollScheduler.LaneState(),
-                consecutiveFailures: 0
+                consecutiveFailures: 0,
+                resolvedOrg: nil
             ))
             known.insert(candidate.credential.accessToken)
         }
@@ -379,6 +502,7 @@ public actor OAuthPoller {
                 primaryOrg = org
                 matches = true
             }
+            lanes[idx].resolvedOrg = org ?? primaryOrg
             if matches {
                 lanes[idx].state.account = .primary
                 await persist(snapshot, laneSource: lanes[idx].source)

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -312,8 +312,8 @@ public actor OAuthPoller: TokenPoolTesting {
             return .failure(reason: reason)
         }
         ensureLanes()
-        if lanes.contains(where: { $0.credential.accessToken == trimmed }) {
-            return .alreadyTracked
+        if let existing = lanes.first(where: { $0.credential.accessToken == trimmed }) {
+            return .alreadyTracked(source: existing.source, fingerprint: Self.laneId(existing.credential.accessToken))
         }
         // Unknown local expiry — the server 401s when it lapses.
         lanes.append(Lane(

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -306,6 +306,11 @@ public actor OAuthPoller: TokenPoolTesting {
     public func addManualToken(_ token: String) async -> TokenTestResult {
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .failure(reason: "Empty token.") }
+        // Offline format gate first — reject an obviously wrong paste
+        // instantly, without spending a network request on it.
+        if case .invalid(let reason) = TokenFormat.validate(trimmed) {
+            return .failure(reason: reason)
+        }
         ensureLanes()
         if lanes.contains(where: { $0.credential.accessToken == trimmed }) {
             return .alreadyTracked

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -439,16 +439,19 @@ public actor OAuthPoller: TokenPoolTesting {
     // MARK: - Loop
 
     private func loop() async {
+        // Restore persisted lane state and publish it *before* the startup
+        // delay, so the Tokens UI shows last-known status/account/expiry the
+        // instant the window opens instead of flashing "no tokens yet" while
+        // the delay elapses. This only reads the pool + cached metadata; the
+        // delay still gates the first live poll.
+        await loadPersistedMetaIfNeeded()
+        ensureLanes()
+        await publishStatus()
+
         if configuration.startupDelay > 0 {
             await nap(configuration.startupDelay)
             if stopping || Task.isCancelled { return }
         }
-
-        // Restore persisted lane state and publish it before the first poll
-        // so the Tokens UI shows last-known status/account/expiry on launch.
-        await loadPersistedMetaIfNeeded()
-        ensureLanes()
-        await publishStatus()
 
         while !stopping && !Task.isCancelled {
             ensureLanes()

--- a/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/OAuthPoller.swift
@@ -38,65 +38,71 @@ public struct SystemPollerClock: PollerClock {
     }
 }
 
-/// Polls `/api/oauth/usage` on a 5-minute cadence (the server's
-/// aggregation interval — faster polling returns stale data) and
-/// persists each successful observation as one or two
-/// `RateLimitSample` rows (one per window present in the response).
+/// Polls `/api/oauth/usage` with an **adaptive, multi-token cadence**.
 ///
-/// Backoff state machine on errors:
+/// The endpoint computes usage live per request but rate-limits to ~1
+/// poll / 5 min / token with no budget headers (over-poll ⇒ ~30-min
+/// throttle). An account often has several independent tokens (Claude
+/// Code + Claude Desktop), each its own budget. So the poller keeps one
+/// **lane** per discovered token and lets `OAuthPollScheduler` spread
+/// polls across them: a tighter *effective* cadence when you're actively
+/// burning tokens (interleaving two lanes → ~2.5 min), relaxing when
+/// idle, while **no single lane is ever polled more than once per 5
+/// min** — the invariant that keeps every lane off the throttle. With
+/// one token it degrades cleanly to single-lane activity-gating.
 ///
-///   - 200 OK with rows                     →  reset backoff, sleep `baseInterval ± jitter`
-///   - 429 with Retry-After                  →  sleep max(retryAfter, baseInterval), capped at maxBackoff
-///   - 429 without Retry-After               →  exponential backoff (baseInterval × 2^consecutive429s),
-///                                              capped at maxBackoff
-///   - 401 / network / schema error          →  sleep `baseInterval ± jitter`, no backoff growth
-///                                              (these recover on next poll without our help)
-///   - credentials missing / token expired   →  sleep `baseInterval ± jitter`, no log spam
-///   - keychain access denied                →  sleep `baseInterval ± jitter` (one warn-once
-///                                              log; user must approve in foreground app)
+/// Safety rails:
+///   - **Same-account guard.** The first successful poll sets the pool's
+///     primary account (from `anthropic-organization-id`); a lane that
+///     resolves to a different org is marked foreign — never selected,
+///     never persisted — so interleaving can't mix two accounts.
+///   - **Per-lane cooldown.** A 429/transport/5xx cools *that lane*
+///     (exponential, capped); other lanes keep the timeline fresh.
+///   - **Poll-on-wake.** `notifyActivity()` (called by the coordinator
+///     when new usage lands) wakes the loop to re-evaluate — the
+///     scheduler still enforces the per-token floor, so a nudge can
+///     never over-poll.
 ///
-/// Each successful 200 resets `consecutive429s`. The actor is
-/// `start()`/`stop()` symmetrical and safe to call from any context.
+/// `start()`/`stop()` symmetrical; safe to call from any context.
 public actor OAuthPoller {
 
     public struct Configuration: Sendable {
-        /// Steady-state cadence. 5 minutes matches the server's
-        /// aggregation interval — faster polls just return the same
-        /// numbers and waste rate-limit budget.
-        public var baseInterval: TimeInterval
-        /// Jitter range applied to each sleep, ±. Defaults to ±30s so
-        /// a fleet of Pacer instances can't synchronize their wakeups
-        /// (which would create thundering-herd load on Anthropic's
-        /// usage endpoint).
-        public var jitterSeconds: TimeInterval
-        /// Hard cap on any sleep duration. Even on persistent 429s we
-        /// won't sleep longer than this — at the cap, we keep
-        /// re-attempting once an hour so a recovering server is
-        /// noticed within reasonable time.
-        public var maxBackoff: TimeInterval
-        /// Optional delay before the first poll. Useful if the daemon
-        /// wants the JSONL scanner to settle before kicking off a
-        /// network call. Default 0.
+        /// Cadence policy (per-token floor, active/idle targets, activity
+        /// window). See `OAuthPollScheduler.Tuning`.
+        public var scheduler: OAuthPollScheduler.Tuning
+        /// Optional delay before the first discovery + poll. Lets the
+        /// JSONL scanner settle first. Default 0.
         public var startupDelay: TimeInterval
+        /// First cooldown applied to a lane after a failed poll; doubles
+        /// per consecutive failure on that lane.
+        public var laneCooldownBase: TimeInterval
+        /// Cap on a lane's cooldown.
+        public var laneCooldownMax: TimeInterval
+        /// How long a discovered lane set is reused before re-running
+        /// candidate discovery (picks up Desktop token rotation / new
+        /// logins). Discovery also runs whenever no usable lane remains.
+        public var laneRediscoverInterval: TimeInterval
 
         public init(
-            baseInterval: TimeInterval = 5 * 60,
-            jitterSeconds: TimeInterval = 30,
-            maxBackoff: TimeInterval = 60 * 60,
-            startupDelay: TimeInterval = 0
+            scheduler: OAuthPollScheduler.Tuning = .init(),
+            startupDelay: TimeInterval = 0,
+            laneCooldownBase: TimeInterval = 300,
+            laneCooldownMax: TimeInterval = 3600,
+            laneRediscoverInterval: TimeInterval = 1800
         ) {
-            self.baseInterval = baseInterval
-            self.jitterSeconds = jitterSeconds
-            self.maxBackoff = maxBackoff
+            self.scheduler = scheduler
             self.startupDelay = startupDelay
+            self.laneCooldownBase = laneCooldownBase
+            self.laneCooldownMax = laneCooldownMax
+            self.laneRediscoverInterval = laneRediscoverInterval
         }
     }
 
-    /// Categorized outcome of one poll cycle, surfaced for tests and
-    /// for the daemon UI's debug view.
+    /// Categorized outcome of one poll, surfaced for tests and debug UI.
     public enum PollOutcome: Sendable, Equatable {
         case success(fiveHourPct: Double?, sevenDayPct: Double?)
-        case credentialsNotFound
+        case foreignAccount            // succeeded but a different org — dropped
+        case credentialsNotFound       // no usable token / lane at all
         case keychainAccessDenied
         case keychainMalformed
         case keychainStatus(OSStatus)
@@ -108,78 +114,118 @@ public actor OAuthPoller {
         case responseSchemaMismatch
     }
 
-    /// Snapshot of poller state, useful for logging and tests.
     public struct Snapshot: Sendable {
         public let lastOutcome: PollOutcome?
-        public let consecutive429s: Int
+        public let laneCount: Int
+        public let primaryLaneCount: Int
         public let nextPollAt: Date?
         public let lastPollAt: Date?
+        public let primaryOrg: String?
     }
 
     public typealias RandomSource = @Sendable () -> Double
+
+    /// One pollable token + its scheduling state.
+    private struct Lane {
+        let credential: OAuthCredential
+        let source: CredentialCandidate.Source
+        var state: OAuthPollScheduler.LaneState
+        var consecutiveFailures: Int
+    }
 
     private let client: OAuthClient
     private let container: ModelContainer
     private let configuration: Configuration
     private let clock: PollerClock
-    /// Returns a uniform random value in [0,1). Injected so tests can
-    /// freeze jitter to a known value.
+    private let scheduler: OAuthPollScheduler
+    private let activityProbe: @Sendable () async -> Date?
     private let random: RandomSource
 
-    private var loopTask: Task<Void, Never>?
-    private var consecutive429s: Int = 0
+    private var lanes: [Lane] = []
+    private var primaryOrg: String?
+    private var lastDiscoveryAt: Date?
     private var lastOutcome: PollOutcome?
-    private var nextPollAt: Date?
     private var lastPollAt: Date?
+    private var nextPollAt: Date?
+
+    private var loopTask: Task<Void, Never>?
+    private var sleeper: Task<Void, Never>?
+    private var stopping = false
 
     public init(
         client: OAuthClient = OAuthClient(),
         container: ModelContainer,
         configuration: Configuration = Configuration(),
         clock: PollerClock = SystemPollerClock(),
+        activityProbe: (@Sendable () async -> Date?)? = nil,
         random: @escaping RandomSource = { Double.random(in: 0..<1) }
     ) {
         self.client = client
         self.container = container
         self.configuration = configuration
         self.clock = clock
+        self.scheduler = OAuthPollScheduler(tuning: configuration.scheduler)
+        self.activityProbe = activityProbe ?? Self.defaultActivityProbe(container: container)
         self.random = random
     }
 
-    /// Spawn the loop task. Idempotent — calling start twice does
-    /// nothing the second time. The loop runs until `stop()` cancels
-    /// it.
+    // MARK: - Lifecycle
+
+    /// Spawn the loop task. Idempotent.
     public func start() {
         guard loopTask == nil else { return }
+        stopping = false
         loopTask = Task { [weak self] in
             await self?.loop()
         }
     }
 
-    /// Cancel the loop and wait for it to unwind. Safe to call from
-    /// anywhere; idempotent.
+    /// Cancel the loop and wait for it to unwind. Idempotent.
     public func stop() async {
-        guard let task = loopTask else { return }
+        stopping = true
+        sleeper?.cancel()
+        loopTask?.cancel()
+        let task = loopTask
         loopTask = nil
-        task.cancel()
-        await task.value
+        await task?.value
     }
 
-    /// Test entry — run exactly one fetch + persist + state-update.
-    /// Returns the categorized outcome. Does NOT sleep, does NOT loop.
+    /// Wake the loop to re-evaluate cadence — call when fresh Claude
+    /// usage lands so an idle→active transition polls promptly. Safe to
+    /// call at any rate: the scheduler still enforces the per-token
+    /// floor, so a nudge can never cause an over-poll.
+    public func notifyActivity() {
+        sleeper?.cancel()
+    }
+
+    /// Test entry — discover lanes and poll the best eligible one once,
+    /// ignoring the cadence gate (but honoring foreign/cooldown). Returns
+    /// the categorized outcome. Does NOT loop or sleep.
     @discardableResult
     public func runOnce() async -> PollOutcome {
-        await runOneCycle()
+        ensureLanes()
+        let now = clock.now()
+        let idx = lanes.indices
+            .filter {
+                lanes[$0].state.account != .foreign
+                    && (lanes[$0].state.cooldownUntil.map { now >= $0 } ?? true)
+            }
+            .min { (lanes[$0].state.lastPolledAt ?? .distantPast) < (lanes[$1].state.lastPolledAt ?? .distantPast) }
+        guard let idx else {
+            lastOutcome = .credentialsNotFound
+            return .credentialsNotFound
+        }
+        return await pollLane(idx)
     }
 
-    /// Read-only view of current poller state. Tests assert against
-    /// `nextPollAt` to verify backoff math.
     public func snapshot() -> Snapshot {
         Snapshot(
             lastOutcome: lastOutcome,
-            consecutive429s: consecutive429s,
+            laneCount: lanes.count,
+            primaryLaneCount: lanes.filter { $0.state.account == .primary }.count,
             nextPollAt: nextPollAt,
-            lastPollAt: lastPollAt
+            lastPollAt: lastPollAt,
+            primaryOrg: primaryOrg
         )
     }
 
@@ -187,53 +233,211 @@ public actor OAuthPoller {
 
     private func loop() async {
         if configuration.startupDelay > 0 {
-            do {
-                try await clock.sleep(seconds: configuration.startupDelay)
-            } catch {
-                return
-            }
+            await nap(configuration.startupDelay)
+            if stopping || Task.isCancelled { return }
         }
 
-        while !Task.isCancelled {
-            _ = await runOneCycle()
+        while !stopping && !Task.isCancelled {
+            ensureLanes()
+            if lanes.allSatisfy({ $0.state.account == .foreign }) || lanes.isEmpty {
+                // Nothing usable — record it once and idle until rediscovery.
+                if lanes.isEmpty { lastOutcome = .credentialsNotFound }
+                nextPollAt = clock.now().addingTimeInterval(configuration.scheduler.idleInterval)
+                await nap(configuration.scheduler.idleInterval)
+                continue
+            }
 
-            // sleep until nextPollAt (computed inside runOneCycle).
-            let targetDate = nextPollAt ?? clock.now().addingTimeInterval(configuration.baseInterval)
-            let remaining = targetDate.timeIntervalSince(clock.now())
-            do {
-                try await clock.sleep(seconds: remaining)
-            } catch {
-                // CancellationError or anything else — exit cleanly.
-                return
+            let activity = await activityProbe()
+            let decision = scheduler.decide(
+                lanes: lanes.map(\.state),
+                lastActivityAt: activity,
+                now: clock.now()
+            )
+            switch decision {
+            case .poll(let idx):
+                _ = await pollLane(idx)
+            case .wait(let seconds):
+                nextPollAt = clock.now().addingTimeInterval(seconds)
+                await nap(seconds)
             }
         }
     }
 
-    // MARK: - One cycle
+    /// Cancellable sleep. `notifyActivity()` / `stop()` cancel the inner
+    /// task to return early; `try?` swallows the CancellationError so the
+    /// loop simply re-evaluates (or exits on `stopping`).
+    private func nap(_ seconds: TimeInterval) async {
+        guard seconds > 0 else { return }
+        let clock = self.clock
+        let task = Task { _ = try? await clock.sleep(seconds: seconds) }
+        sleeper = task
+        await task.value
+        sleeper = nil
+    }
 
-    private func runOneCycle() async -> PollOutcome {
-        let result = await client.fetchUsage()
+    // MARK: - Lane discovery
+
+    /// Ensure `lanes` reflects the currently available tokens. Rediscovers
+    /// on first run, on the rediscover interval, or when no usable lane
+    /// remains; always prunes expired lanes; keeps ordering primary-first.
+    private func ensureLanes() {
+        let now = clock.now()
+        let noUsable = !lanes.contains { $0.state.account != .foreign }
+        let stale = lastDiscoveryAt.map { now.timeIntervalSince($0) >= configuration.laneRediscoverInterval } ?? true
+        if stale || noUsable {
+            mergeCandidates(client.candidateCredentials())
+            lastDiscoveryAt = now
+        }
+        // Drop lanes whose token has expired locally (server would 401).
+        lanes.removeAll { lane in
+            if let exp = lane.credential.expiresAt, exp < now { return true }
+            return false
+        }
+        sortLanes()
+    }
+
+    /// Union new candidate tokens into the lane set, preserving the state
+    /// of lanes we already hold (Desktop lanes persist between the gated
+    /// keychain re-reads, so we don't lose them when discovery skips a
+    /// re-read).
+    private func mergeCandidates(_ candidates: [CredentialCandidate]) {
+        var known = Set(lanes.map { $0.credential.accessToken })
+        for candidate in candidates where !known.contains(candidate.credential.accessToken) {
+            lanes.append(Lane(
+                credential: candidate.credential,
+                source: candidate.source,
+                state: OAuthPollScheduler.LaneState(),
+                consecutiveFailures: 0
+            ))
+            known.insert(candidate.credential.accessToken)
+        }
+    }
+
+    /// Order primary-eligible sources first so the scheduler's index
+    /// tie-break polls a Claude Code / override token before a Desktop
+    /// one — letting the primary account establish the org guard.
+    private func sortLanes() {
+        func rank(_ s: CredentialCandidate.Source) -> Int {
+            switch s {
+            case .override: return 0
+            case .keychain: return 1
+            case .held:     return 2
+            case .desktop:  return 3
+            }
+        }
+        lanes.sort { a, b in
+            let ra = rank(a.source), rb = rank(b.source)
+            return ra != rb ? ra < rb : a.credential.accessToken < b.credential.accessToken
+        }
+    }
+
+    // MARK: - One poll
+
+    @discardableResult
+    private func pollLane(_ idx: Int) async -> PollOutcome {
+        guard idx < lanes.count else { return .credentialsNotFound }
+        let credential = lanes[idx].credential
+        let result = await client.fetchUsage(using: credential)
         let now = clock.now()
         lastPollAt = now
+        // Guard: the lane array can change across the await (rediscovery
+        // never runs concurrently on the same actor, but be defensive).
+        guard idx < lanes.count, lanes[idx].credential.accessToken == credential.accessToken else {
+            return lastOutcome ?? .transport
+        }
+        lanes[idx].state.lastPolledAt = now
 
-        let previousOutcome = lastOutcome
-        let outcome = await categorize(result)
+        let previous = lastOutcome
+        let outcome = await apply(result: result, laneIndex: idx, now: now)
         lastOutcome = outcome
-        let delay = nextDelaySeconds(for: outcome, result: result)
-        nextPollAt = now.addingTimeInterval(delay)
-
-        // Telemetry for #3: log on outcome-category transitions. A
-        // steady-state failure (.tokenExpired for 16 hours) produces a
-        // single log line, not one per poll; recovery logs once too.
-        if !Self.sameCategory(previousOutcome, outcome) {
-            Log.write("OAuthPoller", Self.summarize(outcome: outcome, delay: delay))
+        if !Self.sameCategory(previous, outcome) {
+            Log.write("OAuthPoller", Self.summarize(outcome: outcome, laneCount: lanes.count))
         }
         return outcome
     }
 
-    /// Two outcomes are "the same category" when their enum case is the
-    /// same, ignoring associated values — so a stream of `.http(503)`
-    /// then `.http(504)` is treated as one ongoing transport problem.
+    /// Apply one poll's result to lane state + persistence, return outcome.
+    private func apply(
+        result: Result<RateLimitSnapshot, OAuthClientError>,
+        laneIndex idx: Int,
+        now: Date
+    ) async -> PollOutcome {
+        switch result {
+        case .success(let snapshot):
+            lanes[idx].consecutiveFailures = 0
+            lanes[idx].state.cooldownUntil = nil
+            // Same-account guard. First success sets the primary org
+            // (even if the header was absent → nil); a lane whose org
+            // differs is marked foreign and never persisted. A missing
+            // header on a later poll is tolerated as a match rather than
+            // dropping a lane over a transient omission.
+            let org = snapshot.organizationId
+            let matches: Bool
+            if let primary = primaryOrg {
+                matches = (org == nil || org == primary)
+            } else {
+                primaryOrg = org
+                matches = true
+            }
+            if matches {
+                lanes[idx].state.account = .primary
+                await persist(snapshot)
+                return .success(
+                    fiveHourPct: snapshot.fiveHour?.usedPercentage,
+                    sevenDayPct: snapshot.sevenDay?.usedPercentage
+                )
+            } else {
+                lanes[idx].state.account = .foreign
+                return .foreignAccount
+            }
+
+        case .failure(.unauthorized):
+            // Token rejected server-side — drop the lane outright.
+            if idx < lanes.count { lanes.remove(at: idx) }
+            return .unauthorized
+
+        case .failure(.tokenExpired):
+            if idx < lanes.count { lanes.remove(at: idx) }
+            return .tokenExpired
+
+        case .failure(.rateLimited(let retryAfter)):
+            cooldownLane(idx, now: now, retryAfter: retryAfter)
+            return .rateLimited(retryAfter: retryAfter)
+
+        case .failure(.transport):
+            cooldownLane(idx, now: now, retryAfter: nil)
+            return .transport
+
+        case .failure(.http(let status, _)):
+            cooldownLane(idx, now: now, retryAfter: nil)
+            return .http(status: status)
+
+        case .failure(.responseSchemaMismatch):
+            cooldownLane(idx, now: now, retryAfter: nil)
+            return .responseSchemaMismatch
+
+        // These come only from the auto-resolve path; a specific-token
+        // poll can't produce them, but map them for completeness.
+        case .failure(.credentialsNotFound):  return .credentialsNotFound
+        case .failure(.keychainAccessDenied): return .keychainAccessDenied
+        case .failure(.keychainMalformed):    return .keychainMalformed
+        case .failure(.keychainStatus(let s)): return .keychainStatus(s)
+        }
+    }
+
+    /// Grow a lane's cooldown exponentially per consecutive failure,
+    /// honoring a larger `Retry-After` when present, capped.
+    private func cooldownLane(_ idx: Int, now: Date, retryAfter: TimeInterval?) {
+        guard idx < lanes.count else { return }
+        lanes[idx].consecutiveFailures += 1
+        let n = lanes[idx].consecutiveFailures
+        let exponential = configuration.laneCooldownBase * pow(2.0, Double(n - 1))
+        let chosen = min(max(retryAfter ?? 0, exponential), configuration.laneCooldownMax)
+        lanes[idx].state.cooldownUntil = now.addingTimeInterval(chosen)
+    }
+
+    // MARK: - Logging helpers
+
     private static func sameCategory(_ a: PollOutcome?, _ b: PollOutcome?) -> Bool {
         switch (a, b) {
         case (nil, nil): return true
@@ -245,101 +449,67 @@ public actor OAuthPoller {
         }
     }
 
-    private static func summarize(outcome: PollOutcome, delay: TimeInterval) -> String {
-        let next = "next=\(Int(delay.rounded()))s"
+    private static func summarize(outcome: PollOutcome, laneCount: Int) -> String {
+        let lanes = "lanes=\(laneCount)"
         switch outcome {
         case .success(let fh, let sd):
             let f = fh.map { String(format: "%.1f%%", $0) } ?? "nil"
             let s = sd.map { String(format: "%.1f%%", $0) } ?? "nil"
-            return "ok 5h=\(f) 7d=\(s); \(next)"
+            return "ok 5h=\(f) 7d=\(s); \(lanes)"
+        case .foreignAccount:
+            return "token is a different account — excluded; \(lanes)"
         case .credentialsNotFound:
-            return "credentials missing — sign into Claude Code; \(next)"
+            return "no usable token — sign into Claude Code; \(lanes)"
         case .keychainAccessDenied:
-            return "keychain access denied — approve in foreground app; \(next)"
+            return "keychain access denied — approve in foreground app; \(lanes)"
         case .keychainMalformed:
-            return "keychain blob malformed; \(next)"
+            return "keychain blob malformed; \(lanes)"
         case .keychainStatus(let status):
-            return "keychain OSStatus=\(status); \(next)"
+            return "keychain OSStatus=\(status); \(lanes)"
         case .tokenExpired:
-            return "access token expired — Claude Code must refresh it; \(next)"
+            return "access token expired — dropped lane; \(lanes)"
         case .unauthorized:
-            return "unauthorized (401); \(next)"
+            return "unauthorized (401) — dropped lane; \(lanes)"
         case .rateLimited(let retryAfter):
             let ra = retryAfter.map { "\(Int($0))s" } ?? "nil"
-            return "rate-limited (429) retryAfter=\(ra); \(next)"
+            return "rate-limited (429) retryAfter=\(ra) — lane cooling; \(lanes)"
         case .http(let status):
-            return "http \(status); \(next)"
+            return "http \(status) — lane cooling; \(lanes)"
         case .transport:
-            return "transport error (network); \(next)"
+            return "transport error (network) — lane cooling; \(lanes)"
         case .responseSchemaMismatch:
-            return "response schema mismatch; \(next)"
+            return "response schema mismatch; \(lanes)"
         }
     }
 
-    private func categorize(_ result: Result<RateLimitSnapshot, OAuthClientError>) async -> PollOutcome {
-        switch result {
-        case .success(let snapshot):
-            await persist(snapshot)
-            consecutive429s = 0
-            return .success(
-                fiveHourPct: snapshot.fiveHour?.usedPercentage,
-                sevenDayPct: snapshot.sevenDay?.usedPercentage
-            )
-        case .failure(.credentialsNotFound):
-            return .credentialsNotFound
-        case .failure(.keychainAccessDenied):
-            return .keychainAccessDenied
-        case .failure(.keychainMalformed):
-            return .keychainMalformed
-        case .failure(.keychainStatus(let status)):
-            return .keychainStatus(status)
-        case .failure(.tokenExpired):
-            return .tokenExpired
-        case .failure(.unauthorized):
-            return .unauthorized
-        case .failure(.rateLimited(let retryAfter)):
-            consecutive429s += 1
-            return .rateLimited(retryAfter: retryAfter)
-        case .failure(.http(let status, _)):
-            return .http(status: status)
-        case .failure(.transport):
-            return .transport
-        case .failure(.responseSchemaMismatch):
-            return .responseSchemaMismatch
+    // MARK: - Activity probe
+
+    /// Default activity signal: the most recent moment Claude Code
+    /// produced usage or a session was seen — the JSONL watcher advances
+    /// both as work happens, so "recent" here means "actively burning".
+    private static func defaultActivityProbe(container: ModelContainer) -> @Sendable () async -> Date? {
+        { @Sendable in
+            await MainActor.run {
+                let context = ModelContext(container)
+                var tokenProbe = FetchDescriptor<TokenSample>(
+                    sortBy: [SortDescriptor(\.sampledAt, order: .reverse)]
+                )
+                tokenProbe.fetchLimit = 1
+                let lastToken = (try? context.fetch(tokenProbe))?.first?.sampledAt
+                var sessionProbe = FetchDescriptor<SessionInfo>(
+                    sortBy: [SortDescriptor(\.lastSeenAt, order: .reverse)]
+                )
+                sessionProbe.fetchLimit = 1
+                let lastSession = (try? context.fetch(sessionProbe))?.first?.lastSeenAt
+                return [lastToken, lastSession].compactMap { $0 }.max()
+            }
         }
-    }
-
-    // MARK: - Backoff math
-
-    private func nextDelaySeconds(
-        for outcome: PollOutcome,
-        result: Result<RateLimitSnapshot, OAuthClientError>
-    ) -> TimeInterval {
-        switch outcome {
-        case .rateLimited(let retryAfter):
-            // 429 path. Use Retry-After if larger than our exponential
-            // schedule; otherwise grow exponentially.
-            let exponential = configuration.baseInterval * pow(2.0, Double(consecutive429s - 1))
-            let chosen = max(retryAfter ?? 0, exponential)
-            return min(chosen, configuration.maxBackoff)
-        case .success, .credentialsNotFound, .keychainAccessDenied,
-             .keychainMalformed, .keychainStatus, .tokenExpired,
-             .unauthorized, .http, .transport, .responseSchemaMismatch:
-            return baseIntervalWithJitter()
-        }
-    }
-
-    private func baseIntervalWithJitter() -> TimeInterval {
-        let r = max(0.0, min(1.0, random()))
-        let offset = (r * 2.0 - 1.0) * configuration.jitterSeconds
-        return max(0, configuration.baseInterval + offset)
     }
 
     // MARK: - Persistence
 
-    /// Write one row per present window. Called from inside the actor;
-    /// hops to the main actor for SwiftData since `ModelContext` is
-    /// `@MainActor` in our setup.
+    /// Write one row per present window. Hops to the main actor for
+    /// SwiftData since `ModelContext` is `@MainActor` in our setup.
     private func persist(_ snapshot: RateLimitSnapshot) async {
         let container = self.container
         let captured = snapshot
@@ -366,11 +536,10 @@ public actor OAuthPoller {
                 ))
                 wroteAnyWindow = true
             }
-            // Extra-usage is account-level (not per-window), so we
-            // write at most one row per snapshot when the field was
-            // present. nil means Anthropic omitted the field for this
-            // account — leave the prior row in place, don't overwrite
-            // with a phantom zero.
+            // Extra-usage is account-level (not per-window); write at most
+            // one row per snapshot when present. nil means the field was
+            // omitted — leave the prior row rather than overwrite with a
+            // phantom zero.
             if let cents = captured.extraUsageCents {
                 context.insert(ExtraUsageSample(
                     sampledAt: captured.sampledAt,
@@ -381,21 +550,10 @@ public actor OAuthPoller {
             }
             do {
                 try context.save()
-                // Tell WidgetKit consumers (pace widgets, mainly) that
-                // a fresh sample landed. The widget extension doesn't
-                // observe SwiftData @Query — without an explicit kick
-                // its timelines refresh on their own ~5min cadence,
-                // which is half the OAuth poll cadence and feels stale.
                 if wroteAnyWindow {
-                    postScanCycleSummary(ScanCycleSummary(
-                        rateLimitsChanged: true
-                    ))
+                    postScanCycleSummary(ScanCycleSummary(rateLimitsChanged: true))
                 }
             } catch {
-                // Disk full / migration mid-flight — log to stderr and
-                // move on. The next successful poll will write fresh
-                // samples; we deliberately don't stop the poller for
-                // a single persistence failure.
                 Log.write("OAuthPoller", "persist failed: \(error)")
             }
         }

--- a/PacerCore/Sources/PacerCore/RateLimit/RateLimitSnapshot.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/RateLimitSnapshot.swift
@@ -33,17 +33,28 @@ public struct RateLimitSnapshot: Sendable, Equatable {
     /// who can exceed quota at metered rates. nil when the response
     /// omits the field or it's a shape we don't recognize.
     public let extraUsageCents: Int?
+    /// The account this observation belongs to, read from the
+    /// `anthropic-organization-id` response header. The multi-token
+    /// poller uses it as a same-account guard: a Desktop token that
+    /// resolves to a *different* organization is dropped from the poll
+    /// pool and its samples are never persisted, so interleaving tokens
+    /// can never mix two accounts' usage into one timeline. nil when the
+    /// header was absent (older server, or a transport that doesn't
+    /// surface it).
+    public let organizationId: String?
 
     public init(
         sampledAt: Date,
         fiveHour: RateLimitWindow?,
         sevenDay: RateLimitWindow?,
-        extraUsageCents: Int? = nil
+        extraUsageCents: Int? = nil,
+        organizationId: String? = nil
     ) {
         self.sampledAt = sampledAt
         self.fiveHour = fiveHour
         self.sevenDay = sevenDay
         self.extraUsageCents = extraUsageCents
+        self.organizationId = organizationId
     }
 }
 

--- a/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
@@ -8,7 +8,9 @@ public enum TokenTestResult: Sendable, Equatable {
     case foreignAccount(org: String?)
     case failure(reason: String)
     /// Add-token only: the token is already in the pool — nothing added.
-    case alreadyTracked
+    /// Carries the matching lane's source + fingerprint so the UI can say
+    /// *which* token it is (and highlight its row).
+    case alreadyTracked(source: CredentialCandidate.Source, fingerprint: String)
     /// The poller isn't running (no background service) — nothing to route to.
     case unavailable
 }

--- a/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
@@ -85,6 +85,10 @@ public final class TokenPoolStatus {
     public static let shared = TokenPoolStatus()
 
     public private(set) var lanes: [TokenLaneStatus] = []
+    /// False until the poller publishes for the first time this launch. Lets
+    /// the Settings section show a brief "loading" state instead of a
+    /// misleading "no tokens yet" before the persisted pool is restored.
+    public private(set) var hasLoaded: Bool = false
     /// Whether the poller currently considers Claude usage "active"
     /// (recent) — drives the faster cadence.
     public private(set) var isActive: Bool = false
@@ -108,6 +112,7 @@ public final class TokenPoolStatus {
         self.isActive = isActive
         self.effectiveIntervalSeconds = effectiveIntervalSeconds
         self.lastUpdated = Date()
+        self.hasLoaded = true
     }
 
     public func testLane(id: String) async -> TokenTestResult {

--- a/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
@@ -7,6 +7,8 @@ public enum TokenTestResult: Sendable, Equatable {
     case success(fiveHour: Double?, sevenDay: Double?)
     case foreignAccount(org: String?)
     case failure(reason: String)
+    /// Add-token only: the token is already in the pool — nothing added.
+    case alreadyTracked
     /// The poller isn't running (no background service) — nothing to route to.
     case unavailable
 }
@@ -57,9 +59,16 @@ public struct TokenLaneStatus: Sendable, Identifiable, Equatable {
 public protocol TokenPoolTesting: AnyObject, Sendable {
     /// Test an existing lane by its opaque `id` (from `TokenLaneStatus`).
     func testLane(id: String) async -> TokenTestResult
-    /// Test a raw token the UI holds (the manual-override draft). If it
-    /// matches a known lane, that lane is stamped too.
+    /// Test a raw token the UI holds. If it matches a known lane, that lane
+    /// is stamped too.
     func testAdHoc(token: String) async -> TokenTestResult
+    /// Add a manually-supplied token (e.g. from another Mac) to the pool as
+    /// a `.override` lane, polling it once to confirm the account. Returns
+    /// `.alreadyTracked` if it's already a lane, `.foreignAccount` /
+    /// `.failure` (and doesn't keep it) if it isn't your account / invalid.
+    func addManualToken(_ token: String) async -> TokenTestResult
+    /// Remove a manually-added (`.override`) lane by its opaque `id`.
+    func removeManualToken(id: String) async
 }
 
 /// Process-wide, MainActor-isolated snapshot of the OAuth token pool —
@@ -105,5 +114,13 @@ public final class TokenPoolStatus {
 
     public func testAdHoc(token: String) async -> TokenTestResult {
         await tester?.testAdHoc(token: token) ?? .unavailable
+    }
+
+    public func addManualToken(_ token: String) async -> TokenTestResult {
+        await tester?.addManualToken(token) ?? .unavailable
+    }
+
+    public func removeManualToken(id: String) async {
+        await tester?.removeManualToken(id: id)
     }
 }

--- a/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
+++ b/PacerCore/Sources/PacerCore/RateLimit/TokenPoolStatus.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Result of a user-initiated token test (the Settings "Test" button),
+/// routed through the poller so it persists like any poll and counts
+/// against that token's budget rather than racing it.
+public enum TokenTestResult: Sendable, Equatable {
+    case success(fiveHour: Double?, sevenDay: Double?)
+    case foreignAccount(org: String?)
+    case failure(reason: String)
+    /// The poller isn't running (no background service) — nothing to route to.
+    case unavailable
+}
+
+/// A display-safe snapshot of one poll lane. Carries no raw token — only
+/// an opaque stable `id` (a hash) for identity + test routing, and the
+/// facts the Tokens settings section shows.
+public struct TokenLaneStatus: Sendable, Identifiable, Equatable {
+    public let id: String
+    public let source: CredentialCandidate.Source
+    public let organizationId: String?
+    public let account: OAuthPollScheduler.AccountStatus
+    public let expiresAt: Date?
+    public let lastPolledAt: Date?
+    public let cooldownUntil: Date?
+    public let consecutiveFailures: Int
+    /// Selection rank (0 = highest priority). Mirrors the poller's
+    /// primary-first ordering.
+    public let priority: Int
+
+    public init(
+        id: String,
+        source: CredentialCandidate.Source,
+        organizationId: String?,
+        account: OAuthPollScheduler.AccountStatus,
+        expiresAt: Date?,
+        lastPolledAt: Date?,
+        cooldownUntil: Date?,
+        consecutiveFailures: Int,
+        priority: Int
+    ) {
+        self.id = id
+        self.source = source
+        self.organizationId = organizationId
+        self.account = account
+        self.expiresAt = expiresAt
+        self.lastPolledAt = lastPolledAt
+        self.cooldownUntil = cooldownUntil
+        self.consecutiveFailures = consecutiveFailures
+        self.priority = priority
+    }
+}
+
+/// Implemented by the poller so the UI can request a poll of a specific
+/// token without reaching into the actor's state. Both routes persist the
+/// result and stamp the lane so a manual test spends the token's budget
+/// through the same accounting as an automatic poll.
+public protocol TokenPoolTesting: AnyObject, Sendable {
+    /// Test an existing lane by its opaque `id` (from `TokenLaneStatus`).
+    func testLane(id: String) async -> TokenTestResult
+    /// Test a raw token the UI holds (the manual-override draft). If it
+    /// matches a known lane, that lane is stamped too.
+    func testAdHoc(token: String) async -> TokenTestResult
+}
+
+/// Process-wide, MainActor-isolated snapshot of the OAuth token pool —
+/// same shape as `PacerToday.shared`. The poller publishes lane status
+/// and the effective cadence here; the Settings "Tokens" section reads
+/// it. A weak `tester` lets the section route "Test" clicks back to the
+/// running poller.
+@MainActor
+@Observable
+public final class TokenPoolStatus {
+
+    public static let shared = TokenPoolStatus()
+
+    public private(set) var lanes: [TokenLaneStatus] = []
+    /// Whether the poller currently considers Claude usage "active"
+    /// (recent) — drives the faster cadence.
+    public private(set) var isActive: Bool = false
+    /// The realized endpoint poll interval given the current lane count
+    /// and active/idle state, for the "updating every ~N" header.
+    public private(set) var effectiveIntervalSeconds: TimeInterval?
+    public private(set) var lastUpdated: Date?
+
+    /// The running poller, set on `start()`. Weak so a stopped poller
+    /// doesn't leak; nil ⇒ tests return `.unavailable`.
+    public weak var tester: (any TokenPoolTesting)?
+
+    private init() {}
+
+    public func publish(
+        lanes: [TokenLaneStatus],
+        isActive: Bool,
+        effectiveIntervalSeconds: TimeInterval?
+    ) {
+        self.lanes = lanes
+        self.isActive = isActive
+        self.effectiveIntervalSeconds = effectiveIntervalSeconds
+        self.lastUpdated = Date()
+    }
+
+    public func testLane(id: String) async -> TokenTestResult {
+        await tester?.testLane(id: id) ?? .unavailable
+    }
+
+    public func testAdHoc(token: String) async -> TokenTestResult {
+        await tester?.testAdHoc(token: token) ?? .unavailable
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/OAuthPollSchedulerTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/OAuthPollSchedulerTests.swift
@@ -58,6 +58,21 @@ import Testing
         #expect(sched.decide(lanes: [a0, b150], lastActivityAt: t0, now: at(300)) == .poll(laneIndex: 0))
     }
 
+    @Test func fiveLanesActiveTargetsOneMinuteFloor() {
+        // 5 usable lanes sustain a 60s endpoint cadence (each lane every
+        // 300s). Lane 0 just polled; the target is 60s, not 150s.
+        var lanes = [Lane(lastPolledAt: t0, account: .primary)]
+        lanes.append(contentsOf: (0..<4).map { _ in Lane(account: .primary) })
+        #expect(sched.decide(lanes: lanes, lastActivityAt: t0, now: t0) == .wait(seconds: 60))
+    }
+
+    @Test func manyLanesNeverGoBelowActiveFloor() {
+        // 10 lanes could sustain 30s, but the 60s floor holds.
+        var lanes = [Lane(lastPolledAt: t0, account: .primary)]
+        lanes.append(contentsOf: (0..<9).map { _ in Lane(account: .primary) })
+        #expect(sched.decide(lanes: lanes, lastActivityAt: t0, now: t0) == .wait(seconds: 60))
+    }
+
     @Test func allLanesWithinMinIntervalWaitsUntilEarliestFrees() {
         let a = Lane(lastPolledAt: at(100), account: .primary)   // free at 400
         let b = Lane(lastPolledAt: at(50), account: .primary)    // free at 350

--- a/PacerCore/Tests/PacerCoreTests/OAuthPollSchedulerTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/OAuthPollSchedulerTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite struct OAuthPollSchedulerTests {
+
+    typealias Lane = OAuthPollScheduler.LaneState
+    typealias Decision = OAuthPollScheduler.Decision
+
+    private let sched = OAuthPollScheduler()   // defaults: min300 active150 idle600 window900
+    private let t0 = Date(timeIntervalSinceReferenceDate: 1_000_000)
+    private func at(_ s: TimeInterval) -> Date { t0.addingTimeInterval(s) }
+
+    // MARK: - First poll
+
+    @Test func neverPolledLanePollsImmediately() {
+        let d = sched.decide(lanes: [Lane()], lastActivityAt: nil, now: t0)
+        #expect(d == .poll(laneIndex: 0))
+    }
+
+    @Test func noUsableLanesWaitsIdle() {
+        let d = sched.decide(lanes: [Lane(account: .foreign)], lastActivityAt: at(0), now: t0)
+        #expect(d == .wait(seconds: 600))
+        let empty = sched.decide(lanes: [], lastActivityAt: nil, now: t0)
+        #expect(empty == .wait(seconds: 600))
+    }
+
+    // MARK: - Single lane: floors at the per-token invariant
+
+    @Test func singleLaneIdleWaitsIdleInterval() {
+        let lanes = [Lane(lastPolledAt: t0, account: .primary)]
+        #expect(sched.decide(lanes: lanes, lastActivityAt: nil, now: t0) == .wait(seconds: 600))
+    }
+
+    @Test func singleLaneActiveFloorsAtPerTokenMinNotActiveInterval() {
+        // One lane can't sustain the 150s active cadence — it must wait
+        // the 300s per-token minimum, never 150s.
+        let lanes = [Lane(lastPolledAt: t0, account: .primary)]
+        #expect(sched.decide(lanes: lanes, lastActivityAt: t0, now: t0) == .wait(seconds: 300))
+    }
+
+    // MARK: - Two lanes: interleave to 2.5-min effective, each 5-min
+
+    @Test func twoLanesActiveInterleaveEvery150EachLaneEvery300() {
+        // A just polled at t0, B never polled. Active.
+        let a0 = Lane(lastPolledAt: t0, account: .primary)
+        let b0 = Lane(account: .primary)
+
+        // Not yet due (endpoint cadence 150 from A's poll).
+        #expect(sched.decide(lanes: [a0, b0], lastActivityAt: t0, now: t0) == .wait(seconds: 150))
+
+        // At +150: A still within its 300 floor, so poll B.
+        #expect(sched.decide(lanes: [a0, b0], lastActivityAt: t0, now: at(150)) == .poll(laneIndex: 1))
+
+        // B polled at +150; A at t0. At +300 A frees; poll A.
+        let b150 = Lane(lastPolledAt: at(150), account: .primary)
+        #expect(sched.decide(lanes: [a0, b150], lastActivityAt: t0, now: at(150)) == .wait(seconds: 150))
+        #expect(sched.decide(lanes: [a0, b150], lastActivityAt: t0, now: at(300)) == .poll(laneIndex: 0))
+    }
+
+    @Test func allLanesWithinMinIntervalWaitsUntilEarliestFrees() {
+        let a = Lane(lastPolledAt: at(100), account: .primary)   // free at 400
+        let b = Lane(lastPolledAt: at(50), account: .primary)    // free at 350
+        // Active, endpoint anchor = max(100,50)=100 -> ready at 250, but
+        // no lane free until 350 -> wait 200 from now=150.
+        #expect(sched.decide(lanes: [a, b], lastActivityAt: t0, now: at(150)) == .wait(seconds: 200))
+    }
+
+    // MARK: - Cooldown + foreign exclusion
+
+    @Test func cooldownLaneSkippedInFavorOfEligible() {
+        let a = Lane(lastPolledAt: t0, cooldownUntil: at(400), account: .primary) // free at 400
+        let b = Lane(account: .primary)                                            // never polled
+        #expect(sched.decide(lanes: [a, b], lastActivityAt: t0, now: at(150)) == .poll(laneIndex: 1))
+    }
+
+    @Test func foreignLaneNeverPicked() {
+        let foreign = Lane(lastPolledAt: nil, account: .foreign)
+        let primary = Lane(lastPolledAt: nil, account: .primary)
+        // Even though foreign is index 0 and never polled, we pick primary.
+        #expect(sched.decide(lanes: [foreign, primary], lastActivityAt: t0, now: t0) == .poll(laneIndex: 1))
+    }
+
+    @Test func unknownLaneIsEligibleForDiscovery() {
+        // An unknown-account lane gets polled (once) so we can learn its org.
+        let d = sched.decide(lanes: [Lane(account: .unknown)], lastActivityAt: t0, now: t0)
+        #expect(d == .poll(laneIndex: 0))
+    }
+
+    // MARK: - Poll-on-wake
+
+    @Test func activityResumingTriggersImmediatePollOncePastPerTokenFloor() {
+        // Single lane last polled at t0, idle since. At +300 the per-token
+        // floor is met; activity arriving flips target to 150 and it polls.
+        let lanes = [Lane(lastPolledAt: t0, account: .primary)]
+        // Still idle at +300 would wait (idle cadence 600 not yet met... actually
+        // endpoint anchor t0+600 vs lane-free t0+300 -> waits to 600).
+        #expect(sched.decide(lanes: lanes, lastActivityAt: nil, now: at(300)) == .wait(seconds: 300))
+        // Activity NOW: active target 150, lane free at 300 <= now -> poll.
+        #expect(sched.decide(lanes: lanes, lastActivityAt: at(300), now: at(300)) == .poll(laneIndex: 0))
+    }
+
+    @Test func wakeStillRespectsPerTokenFloor() {
+        // Activity resuming before the per-token floor can't force an early poll.
+        let lanes = [Lane(lastPolledAt: t0, account: .primary)]
+        #expect(sched.decide(lanes: lanes, lastActivityAt: at(200), now: at(200)) == .wait(seconds: 100))
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/OAuthPollSchedulerTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/OAuthPollSchedulerTests.swift
@@ -58,19 +58,19 @@ import Testing
         #expect(sched.decide(lanes: [a0, b150], lastActivityAt: t0, now: at(300)) == .poll(laneIndex: 0))
     }
 
-    @Test func fiveLanesActiveTargetsOneMinuteFloor() {
+    @Test func fiveLanesActiveTargetsOneMinute() {
         // 5 usable lanes sustain a 60s endpoint cadence (each lane every
-        // 300s). Lane 0 just polled; the target is 60s, not 150s.
+        // 300s). Lane 0 just polled; the target is 300/5 = 60s.
         var lanes = [Lane(lastPolledAt: t0, account: .primary)]
         lanes.append(contentsOf: (0..<4).map { _ in Lane(account: .primary) })
         #expect(sched.decide(lanes: lanes, lastActivityAt: t0, now: t0) == .wait(seconds: 60))
     }
 
-    @Test func manyLanesNeverGoBelowActiveFloor() {
-        // 10 lanes could sustain 30s, but the 60s floor holds.
+    @Test func moreLanesScaleFasterWithNoFloor() {
+        // 10 lanes → 300/10 = 30s, since the default floor is 0.
         var lanes = [Lane(lastPolledAt: t0, account: .primary)]
         lanes.append(contentsOf: (0..<9).map { _ in Lane(account: .primary) })
-        #expect(sched.decide(lanes: lanes, lastActivityAt: t0, now: t0) == .wait(seconds: 60))
+        #expect(sched.decide(lanes: lanes, lastActivityAt: t0, now: t0) == .wait(seconds: 30))
     }
 
     @Test func allLanesWithinMinIntervalWaitsUntilEarliestFrees() {

--- a/PacerCore/Tests/PacerCoreTests/OAuthPollerTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/OAuthPollerTests.swift
@@ -21,25 +21,9 @@ import Testing
         )
     }
 
-    /// Always succeeds with both windows present. Resets are 5h and 7d
-    /// in the future from the injected `sampledAt`.
-    private static func successfulSnapshot(at: Date = .init()) -> RateLimitSnapshot {
-        RateLimitSnapshot(
-            sampledAt: at,
-            fiveHour: RateLimitWindow(
-                usedPercentage: 42.0,
-                resetsAt: at.addingTimeInterval(5 * 3600)
-            ),
-            sevenDay: RateLimitWindow(
-                usedPercentage: 7.5,
-                resetsAt: at.addingTimeInterval(7 * 24 * 3600)
-            )
-        )
-    }
-
-    /// Builds an `OAuthClient` whose underlying transport returns a
-    /// fixed sequence of HTTP results. Each call advances through the
-    /// sequence; the last entry is repeated indefinitely.
+    /// Builds an `OAuthClient` whose transport returns a fixed sequence of
+    /// HTTP results (last entry repeated), keyed off a single keychain
+    /// token. Desktop is disabled so tests never touch the real machine.
     private static func sequencedClient(
         _ outcomes: [HTTPOutcome],
         keychainBlob: Data? = nil
@@ -50,26 +34,24 @@ import Testing
         let outcomes = outcomes
         let transport: OAuthClient.Transport = { _ in
             let i = counter.next()
-            let outcome = outcomes[min(i, outcomes.count - 1)]
-            return try outcome.materialize()
+            return try outcomes[min(i, outcomes.count - 1)].materialize()
         }
-        return OAuthClient(keychain: kc, transport: transport)
+        return OAuthClient(keychain: kc, transport: transport, desktopEnabled: { false })
     }
 
-    private static func defaultKeychainBlob() -> Data {
+    private static func defaultKeychainBlob() -> Data { keychainBlob(token: "tok") }
+
+    private static func keychainBlob(token: String) -> Data {
         let body: [String: Any] = [
             "claudeAiOauth": [
-                "accessToken": "tok",
+                "accessToken": token,
                 "expiresAt": Int64(Date().addingTimeInterval(3600).timeIntervalSince1970) * 1000,
             ]
         ]
         return try! JSONSerialization.data(withJSONObject: body)
     }
 
-    // MARK: - Persistence on success
-
-    /// Helper that runs a fetch and returns a Sendable summary so we
-    /// don't try to ferry `@Model` instances across actor boundaries.
+    /// Sendable summary so we don't ferry `@Model` instances across actors.
     private static func fetchSampleSummaries(
         in container: ModelContainer
     ) async throws -> [(window: String, usedPercentage: Double, hasResetsAt: Bool, source: String)] {
@@ -82,6 +64,8 @@ import Testing
         }
     }
 
+    // MARK: - Persistence on success
+
     @Test func successPersistsBothWindows() async throws {
         let container = try Self.makeContainer()
         let client = Self.sequencedClient([.success(jsonBody: """
@@ -91,9 +75,8 @@ import Testing
         let poller = OAuthPoller(
             client: client,
             container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
-            clock: TestClock(),
-            random: { 0.5 }  // jitter midpoint = no offset
+            configuration: .init(),
+            clock: TestClock()
         )
 
         let outcome = await poller.runOnce()
@@ -120,7 +103,7 @@ import Testing
         let poller = OAuthPoller(
             client: client,
             container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
+            configuration: .init(),
             clock: TestClock()
         )
 
@@ -132,248 +115,91 @@ import Testing
         #expect(rows[0].hasResetsAt == false)  // null preserved as nil
     }
 
-    // MARK: - Backoff math
+    // MARK: - Per-lane cooldown + account guard
 
-    @Test func cleanRunSchedulesBaseIntervalAhead() async throws {
+    /// A 429 cools the lane it hit; with only one lane, the next
+    /// (cadence-ignoring) poll has nothing eligible left to spend.
+    @Test func rateLimited429CoolsTheLane() async throws {
         let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
-        let client = Self.sequencedClient([.success(jsonBody: #"{"five_hour":{"utilization":1,"resets_at":""}}"#)])
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
-            clock: clock,
-            random: { 0.5 }  // no offset
-        )
+        let client = Self.sequencedClient([.status(429), .status(429)])
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
 
-        _ = await poller.runOnce()
-        let snap = await poller.snapshot()
-        #expect(snap.nextPollAt == now.addingTimeInterval(300))
+        let first = await poller.runOnce()
+        if case .rateLimited = first {} else { Issue.record("expected rateLimited, got \(first)") }
+        // Lane is cooling; no other lane to fall back to.
+        #expect(await poller.runOnce() == .credentialsNotFound)
     }
 
-    @Test func jitterAppliesSymmetricallyAroundBase() async throws {
+    /// A 401 drops the lane and rejects the token, so rediscovery filters
+    /// it out — a single-token user then has no lane at all.
+    @Test func unauthorized401DropsTheLaneAndDoesNotRecur() async throws {
         let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
+        let client = Self.sequencedClient([.status(401), .success(jsonBody: #"{"five_hour":{"utilization":1}}"#)])
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
 
-        // Random = 0.0  → jitter = -jitterSeconds
-        let pollerLow = OAuthPoller(
-            client: Self.sequencedClient([.success(jsonBody: #"{"five_hour":{"utilization":1,"resets_at":""}}"#)]),
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 30),
-            clock: clock,
-            random: { 0.0 }
-        )
-        _ = await pollerLow.runOnce()
-        let lowNext = await pollerLow.snapshot().nextPollAt!
-        #expect(lowNext == now.addingTimeInterval(270))
-
-        // Random = 1.0 (technically excluded) — we use 0.999
-        let clockHi = TestClock(start: now)
-        let pollerHi = OAuthPoller(
-            client: Self.sequencedClient([.success(jsonBody: #"{"five_hour":{"utilization":1,"resets_at":""}}"#)]),
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 30),
-            clock: clockHi,
-            random: { 0.999 }
-        )
-        _ = await pollerHi.runOnce()
-        let hiNext = await pollerHi.snapshot().nextPollAt!
-        // 300 + (0.999 * 2 - 1) * 30 = 300 + 0.998*30 ≈ 329.94
-        #expect(abs(hiNext.timeIntervalSince(now) - 329.94) < 0.1)
+        #expect(await poller.runOnce() == .unauthorized)
+        #expect(await poller.runOnce() == .credentialsNotFound)
     }
 
-    @Test func first429UsesExponentialFromBaseInterval() async throws {
-        // First 429: consecutive429s becomes 1, exponential = base * 2^0 = base.
-        // No Retry-After → sleep = max(0, base) = base, capped at maxBackoff.
+    /// Two same-account tokens both persist; a token that resolves to a
+    /// different org is marked foreign, excluded, and never persisted —
+    /// so interleaving can never mix two accounts into one timeline.
+    @Test func foreignAccountTokenExcludedAndNotPersisted() async throws {
         let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
-        let client = Self.sequencedClient([.status(429, body: "rate limited", headers: [:])])
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0, maxBackoff: 3600),
-            clock: clock
-        )
-
-        _ = await poller.runOnce()
-        let snap = await poller.snapshot()
-        if case .rateLimited = snap.lastOutcome {} else {
-            Issue.record("expected rateLimited, got \(String(describing: snap.lastOutcome))")
+        let kc = KeychainOAuth(rawReader: { .success(Self.keychainBlob(token: "tokA")) })
+        let held = EphemeralCredentialStore(OAuthCredential(
+            accessToken: "tokB",
+            expiresAt: Date().addingTimeInterval(3600),
+            subscriptionType: nil
+        ))
+        let counter = AtomicCounter()
+        let outcomes: [HTTPOutcome] = [
+            .success(jsonBody: #"{"five_hour":{"utilization":10}}"#, headers: ["anthropic-organization-id": "orgA"]),
+            .success(jsonBody: #"{"five_hour":{"utilization":99}}"#, headers: ["anthropic-organization-id": "orgB"]),
+        ]
+        let transport: OAuthClient.Transport = { _ in
+            try outcomes[min(counter.next(), outcomes.count - 1)].materialize()
         }
-        #expect(snap.consecutive429s == 1)
-        #expect(snap.nextPollAt == now.addingTimeInterval(300))
-    }
+        let client = OAuthClient(keychain: kc, transport: transport, desktopEnabled: { false }, heldStore: held)
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
 
-    @Test func consecutive429sGrowExponentially() async throws {
-        let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
-        let client = Self.sequencedClient([
-            .status(429),
-            .status(429),
-            .status(429),
-        ])
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0, maxBackoff: 3600),
-            clock: clock
-        )
+        // Lane 0 (keychain, tokA) establishes primary org A and persists.
+        let first = await poller.runOnce()
+        if case .success = first {} else { Issue.record("expected success, got \(first)") }
+        // Lane 1 (held, tokB) resolves to org B → foreign, not persisted.
+        #expect(await poller.runOnce() == .foreignAccount)
 
-        _ = await poller.runOnce()  // 1st 429: 300 * 2^0 = 300
-        clock.advance(by: 1)
-
-        _ = await poller.runOnce()  // 2nd 429: 300 * 2^1 = 600
-        let next2 = await poller.snapshot().nextPollAt!
-        let now2 = clock.now()
-
-        _ = await poller.runOnce()  // 3rd 429: 300 * 2^2 = 1200
-        let next3 = await poller.snapshot().nextPollAt!
-        let now3 = clock.now()
-
-        // Next-poll times are computed from `clock.now()` *during the
-        // cycle*, which we know — verify each delta.
-        let delta2 = next2.timeIntervalSince(now2)
-        let delta3 = next3.timeIntervalSince(now3)
-        #expect(delta2 == 600)
-        #expect(delta3 == 1200)
-    }
-
-    @Test func backoffCapsAtMaxBackoff() async throws {
-        let container = try Self.makeContainer()
-        let clock = TestClock(start: Date(timeIntervalSince1970: 1_000_000))
-        // 6 consecutive 429s: 300, 600, 1200, 2400, 4800 (capped to 3600), 9600 (capped).
-        let client = Self.sequencedClient(Array(repeating: HTTPOutcome.status(429), count: 6))
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0, maxBackoff: 3600),
-            clock: clock
-        )
-        for _ in 0..<6 { _ = await poller.runOnce() }
-        let snap = await poller.snapshot()
-        let delta = snap.nextPollAt!.timeIntervalSince(clock.now())
-        #expect(delta == 3600)  // capped
-    }
-
-    @Test func retryAfterOverridesExponentialWhenLarger() async throws {
-        let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
-        let client = Self.sequencedClient([
-            .status(429, headers: ["Retry-After": "1500"])
-        ])
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0, maxBackoff: 3600),
-            clock: clock
-        )
-
-        _ = await poller.runOnce()
-        let snap = await poller.snapshot()
-        // exponential = 300 (consecutive429s = 1), retryAfter = 1500.
-        // chosen = 1500 < cap 3600.
-        #expect(snap.nextPollAt == now.addingTimeInterval(1500))
-    }
-
-    @Test func retryAfterIgnoredWhenSmallerThanExponential() async throws {
-        // After 3 429s, exponential = 300 * 2^2 = 1200. Retry-After=10
-        // should not shrink that.
-        let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
-        let client = Self.sequencedClient([
-            .status(429),
-            .status(429),
-            .status(429, headers: ["Retry-After": "10"]),
-        ])
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0, maxBackoff: 3600),
-            clock: clock
-        )
-        _ = await poller.runOnce()
-        _ = await poller.runOnce()
-        _ = await poller.runOnce()
-        let snap = await poller.snapshot()
-        let delta = snap.nextPollAt!.timeIntervalSince(clock.now())
-        #expect(delta == 1200)
-    }
-
-    @Test func successResetsBackoff() async throws {
-        let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
-        let client = Self.sequencedClient([
-            .status(429),
-            .status(429),
-            .success(jsonBody: #"{"five_hour":{"utilization":1,"resets_at":""}}"#),
-            .status(429),
-        ])
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0, maxBackoff: 3600),
-            clock: clock
-        )
-
-        _ = await poller.runOnce()  // 1st 429
-        _ = await poller.runOnce()  // 2nd 429 → consecutive=2
-        _ = await poller.runOnce()  // success → consecutive=0
-        _ = await poller.runOnce()  // 1st 429 again → exponential = 300
+        let rows = try await Self.fetchSampleSummaries(in: container)
+        #expect(rows.count == 1)                      // only org A's window
+        #expect(rows.first?.usedPercentage == 10.0)   // not org B's 99
 
         let snap = await poller.snapshot()
-        let delta = snap.nextPollAt!.timeIntervalSince(clock.now())
-        #expect(delta == 300)
-        #expect(snap.consecutive429s == 1)
+        #expect(snap.primaryLaneCount == 1)
+        #expect(snap.primaryOrg == "orgA")
     }
 
-    // MARK: - Other failure paths don't grow backoff
+    // MARK: - Other failure paths
 
-    @Test func transportErrorUsesBaseInterval() async throws {
+    @Test func transportErrorSurfacesAndCoolsLane() async throws {
         struct StubError: Error {}
         let container = try Self.makeContainer()
-        let now = Date(timeIntervalSince1970: 1_000_000)
-        let clock = TestClock(start: now)
         let kc = KeychainOAuth(rawReader: { .success(Self.defaultKeychainBlob()) })
-        let client = OAuthClient(
-            keychain: kc,
-            transport: { _ in throw StubError() }
-        )
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
-            clock: clock,
-            random: { 0.5 }
-        )
+        let client = OAuthClient(keychain: kc, transport: { _ in throw StubError() }, desktopEnabled: { false })
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
+
         let outcome = await poller.runOnce()
-        if case .transport = outcome {} else {
-            Issue.record("expected transport, got \(outcome)")
-        }
-        let snap = await poller.snapshot()
-        #expect(snap.consecutive429s == 0)  // not bumped on transport
-        #expect(snap.nextPollAt == now.addingTimeInterval(300))
+        if case .transport = outcome {} else { Issue.record("expected transport, got \(outcome)") }
+        // Lane cooled; single-lane user has nothing else to poll.
+        #expect(await poller.runOnce() == .credentialsNotFound)
     }
 
-    @Test func credsNotFoundQuietlySleepsBaseInterval() async throws {
+    @Test func credsNotFoundWhenNoToken() async throws {
         let container = try Self.makeContainer()
         let kc = KeychainOAuth(rawReader: { .failure(.notFound) })
-        let client = OAuthClient(keychain: kc, transport: { _ in (Data(), HTTPURLResponse()) })
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
-            clock: TestClock(),
-            random: { 0.5 }
-        )
-        let outcome = await poller.runOnce()
-        #expect(outcome == .credentialsNotFound)
+        let client = OAuthClient(keychain: kc, transport: { _ in (Data(), HTTPURLResponse()) }, desktopEnabled: { false })
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
+
+        #expect(await poller.runOnce() == .credentialsNotFound)
     }
 
     // MARK: - start() / stop() lifecycle
@@ -381,57 +207,41 @@ import Testing
     @Test func startStopIsIdempotent() async throws {
         let container = try Self.makeContainer()
         let client = Self.sequencedClient([.success(jsonBody: #"{"five_hour":{"utilization":1,"resets_at":""}}"#)])
-        let clock = TestClock()
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
-            clock: clock
-        )
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
 
         await poller.start()
         await poller.start()  // double-start is no-op
         await poller.stop()
-        await poller.stop()  // double-stop is no-op
+        await poller.stop()   // double-stop is no-op
     }
 
     @Test func loopExitsCleanlyOnStop() async throws {
         let container = try Self.makeContainer()
         let client = Self.sequencedClient([.success(jsonBody: #"{"five_hour":{"utilization":1,"resets_at":""}}"#)])
-        // TestClock.sleep yields, so the loop drains quickly without
-        // burning CPU; stop() then cancels the next sleep.
-        let clock = TestClock()
-        let poller = OAuthPoller(
-            client: client,
-            container: container,
-            configuration: .init(baseInterval: 300, jitterSeconds: 0),
-            clock: clock
-        )
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(), clock: TestClock())
         await poller.start()
-        // Let the loop run a few iterations.
-        try await Task.sleep(nanoseconds: 50_000_000)  // 50ms
+        try await Task.sleep(nanoseconds: 50_000_000)  // 50ms of loop iterations
         await poller.stop()
-        // If stop() returned, the task fully unwound. No assertion
-        // needed beyond "we got here without hanging."
+        // Reaching here without hanging means the task fully unwound.
     }
 }
 
 // MARK: - Test scaffolding
 
-/// Yieldable HTTP outcome — either a 200 with a JSON body, or a
-/// non-2xx with optional headers and body.
+/// Yieldable HTTP outcome — a 200 with a JSON body (and optional
+/// response headers), or a non-2xx with optional headers and body.
 enum HTTPOutcome: Sendable {
-    case success(jsonBody: String)
+    case success(jsonBody: String, headers: [String: String] = [:])
     case status(_ code: Int, body: String = "{}", headers: [String: String] = [:])
 
     func materialize() throws -> (Data, HTTPURLResponse) {
         switch self {
-        case .success(let body):
+        case .success(let body, let headers):
             let response = HTTPURLResponse(
                 url: OAuthClient.endpoint,
                 statusCode: 200,
                 httpVersion: "HTTP/1.1",
-                headerFields: [:]
+                headerFields: headers
             )!
             return (Data(body.utf8), response)
         case .status(let code, let body, let headers):
@@ -458,10 +268,9 @@ final class AtomicCounter: @unchecked Sendable {
     }
 }
 
-/// Test clock: `now()` advances only when `advance(by:)` is called,
-/// `sleep` is a `Task.yield` so the loop spins quickly. Cancellation
-/// is cooperative — a sleep that runs after `Task.cancel()` throws
-/// `CancellationError`, matching the production clock's behavior.
+/// Test clock: `now()` advances only via `advance(by:)`; `sleep` is a
+/// `Task.yield` so the loop spins quickly. Cancellation is cooperative —
+/// a sleep run after `Task.cancel()` throws, matching production.
 final class TestClock: PollerClock, @unchecked Sendable {
     private let lock = NSLock()
     private var current: Date

--- a/PacerCore/Tests/PacerCoreTests/OAuthPollerTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/OAuthPollerTests.swift
@@ -17,6 +17,7 @@ import Testing
             RateLimitSample.self,
             SessionInfo.self,
             ClaudeCodeMeta.self,
+            TokenLaneMeta.self,
             configurations: config
         )
     }

--- a/PacerCore/Tests/PacerCoreTests/ScanCoordinatorTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ScanCoordinatorTests.swift
@@ -291,7 +291,7 @@ private func makeAssistantLine(
             // Tight timing so the poller fires at least once before
             // stop() — but no real sleep because the loop's first
             // cycle runs immediately.
-            oauthPolling: .init(baseInterval: 60, jitterSeconds: 0)
+            oauthPolling: .init()
         ),
         resolver: resolver,
         oauthClient: client

--- a/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import CommonCrypto
+import SwiftData
+import Testing
+@testable import PacerCore
+
+/// Covers the persistent token pool + the layered Claude Desktop read
+/// (cached-key fast path → cached tokens → Safe Storage only as a last
+/// resort). The "did we read Safe Storage" question is answered by
+/// counting `keyReader` calls.
+@Suite struct TokenPoolLayeredTests {
+
+    private static let testKey = Data("pacer-test-safe-storage-key".utf8)
+    private static let host = "https://api.anthropic.com"
+    private static var futureMs: Int64 { Int64(Date().addingTimeInterval(3600).timeIntervalSince1970) * 1000 }
+
+    final class KeyReadCounter: @unchecked Sendable {
+        private let lock = NSLock(); private var v = 0
+        func bump() { lock.lock(); v += 1; lock.unlock() }
+        var count: Int { lock.lock(); defer { lock.unlock() }; return v }
+    }
+
+    /// Mirror of `DesktopOAuth.decrypt` in the encrypt direction.
+    private func encryptV10(_ plaintext: Data, keyPassword: Data = testKey) -> String {
+        let key = DesktopOAuth.pbkdf2SHA1(password: keyPassword, salt: Data("saltysalt".utf8),
+                                          rounds: 1003, keyLength: kCCKeySizeAES128)!
+        let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+        var out = Data(count: plaintext.count + kCCBlockSizeAES128)
+        var moved = 0
+        let status = out.withUnsafeMutableBytes { o in
+            plaintext.withUnsafeBytes { p in key.withUnsafeBytes { k in iv.withUnsafeBytes { v in
+                CCCrypt(CCOperation(kCCEncrypt), CCAlgorithm(kCCAlgorithmAES), CCOptions(kCCOptionPKCS7Padding),
+                        k.baseAddress, key.count, v.baseAddress, p.baseAddress, plaintext.count,
+                        o.baseAddress, o.count, &moved)
+            }}}
+        }
+        precondition(status == kCCSuccess)
+        out.removeSubrange(moved..<out.count)
+        return (Data("v10".utf8) + out).base64EncodedString()
+    }
+
+    /// A single `user:profile` cache blob for `token`, encrypted with `key`.
+    private func blob(token: String, key: Data = testKey) -> String {
+        let dict: [String: Any] = [
+            "c1:acct:\(Self.host):user:profile": [
+                "token": token, "refreshToken": "r-\(token)",
+                "expiresAt": Self.futureMs, "subscriptionType": "max",
+            ]
+        ]
+        return encryptV10(try! JSONSerialization.data(withJSONObject: dict), keyPassword: key)
+    }
+
+    private func desktopClient(
+        cachedKey: Data?,
+        blobKey: Data = testKey,
+        keyReads: KeyReadCounter
+    ) -> OAuthClient {
+        OAuthClient(
+            keychain: KeychainOAuth(rawReader: { .failure(.notFound) }),
+            desktop: DesktopOAuth(
+                keyReader: { keyReads.bump(); return .success(Self.testKey) },
+                cacheReader: { [self.blob(token: "desk-live", key: blobKey)] }
+            ),
+            desktopEnabled: { true },
+            desktopKeyStore: EphemeralDesktopKeyStore(cachedKey)
+        )
+    }
+
+    // MARK: - Stores round-trip
+
+    @Test func tokenPoolStoreRoundTrips() {
+        let store = EphemeralTokenPoolStore()
+        let toks = [
+            StoredToken(credential: OAuthCredential(accessToken: "a", expiresAt: nil, subscriptionType: nil), source: .keychain),
+            StoredToken(credential: OAuthCredential(accessToken: "b", expiresAt: nil, subscriptionType: nil), source: .desktop),
+        ]
+        store.saveAll(toks)
+        #expect(store.loadAll() == toks)
+        store.clear()
+        #expect(store.loadAll().isEmpty)
+    }
+
+    // MARK: - Layered Desktop resolution
+
+    @Test func cachedKeyDecryptsWithoutReadingSafeStorage() {
+        let keyReads = KeyReadCounter()
+        let client = desktopClient(cachedKey: Self.testKey, keyReads: keyReads)
+        let cands = client.candidateCredentials()
+        #expect(cands.contains { $0.credential.accessToken == "desk-live" && $0.source == .desktop })
+        #expect(keyReads.count == 0)   // Layer 1: never touched Safe Storage
+    }
+
+    @Test func staleKeyKeepsWorkingCachedTokensAndDefersPrompt() {
+        let keyReads = KeyReadCounter()
+        // Cached key is WRONG for the blobs, but we hold a working cached token.
+        let client = desktopClient(cachedKey: Data("wrong".utf8), blobKey: Self.testKey, keyReads: keyReads)
+        let working = OAuthCredential(accessToken: "cached-desk", expiresAt: Date().addingTimeInterval(3600), subscriptionType: nil)
+        let cands = client.candidateCredentials(cachedDesktopTokens: [working])
+        #expect(cands.contains { $0.credential.accessToken == "cached-desk" })
+        #expect(keyReads.count == 0)   // Layer 2: prompt deferred
+    }
+
+    @Test func staleKeyAndExpiredTokensReadsSafeStorageAndCachesKey() {
+        let keyReads = KeyReadCounter()
+        let store = EphemeralDesktopKeyStore(Data("wrong".utf8))
+        let client = OAuthClient(
+            keychain: KeychainOAuth(rawReader: { .failure(.notFound) }),
+            desktop: DesktopOAuth(
+                keyReader: { keyReads.bump(); return .success(Self.testKey) },
+                cacheReader: { [self.blob(token: "desk-live")] }
+            ),
+            desktopEnabled: { true },
+            desktopKeyStore: store
+        )
+        let expired = OAuthCredential(accessToken: "old", expiresAt: Date().addingTimeInterval(-100), subscriptionType: nil)
+        let cands = client.candidateCredentials(cachedDesktopTokens: [expired])
+        #expect(cands.contains { $0.credential.accessToken == "desk-live" })
+        #expect(keyReads.count == 1)          // Layer 3: read exactly once
+        #expect(store.load() == Self.testKey) // fresh key cached
+    }
+
+    @Test func firstEverReadReadsSafeStorageAndCachesKey() {
+        let keyReads = KeyReadCounter()
+        let store = EphemeralDesktopKeyStore(nil)   // never cached a key
+        let client = OAuthClient(
+            keychain: KeychainOAuth(rawReader: { .failure(.notFound) }),
+            desktop: DesktopOAuth(
+                keyReader: { keyReads.bump(); return .success(Self.testKey) },
+                cacheReader: { [self.blob(token: "desk-live")] }
+            ),
+            desktopEnabled: { true },
+            desktopKeyStore: store
+        )
+        _ = client.candidateCredentials()
+        #expect(keyReads.count == 1)
+        #expect(store.load() == Self.testKey)
+    }
+
+    // MARK: - Poller seeds from the persisted pool on restart
+
+    @Test func pollerSeedsLanesFromPersistedPool() async throws {
+        struct StubError: Error {}
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Heartbeat.self, TokenSample.self, DailyAggregate.self, ProjectDailyAggregate.self,
+            RateLimitSample.self, SessionInfo.self, ClaudeCodeMeta.self, configurations: config
+        )
+        let pool = EphemeralTokenPoolStore([
+            StoredToken(
+                credential: OAuthCredential(accessToken: "seed-tok", expiresAt: Date().addingTimeInterval(3600), subscriptionType: nil),
+                source: .desktop
+            )
+        ])
+        // Client that discovers nothing new (no keychain, Desktop off) — so the
+        // only lane can come from the seeded pool.
+        let client = OAuthClient(
+            keychain: KeychainOAuth(rawReader: { .failure(.notFound) }),
+            transport: { _ in throw StubError() },
+            desktopEnabled: { false }
+        )
+        let poller = OAuthPoller(client: client, container: container, configuration: .init(),
+                                 clock: TestClock(), poolStore: pool)
+        let outcome = await poller.runOnce()
+        // A seeded lane exists and got polled (transport stub throws) — proving
+        // the pool restored a lane without any source read.
+        if case .transport = outcome {} else { Issue.record("expected transport from seeded lane, got \(outcome)") }
+        #expect(await poller.snapshot().laneCount >= 1)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
@@ -136,6 +136,72 @@ import Testing
         #expect(store.load() == Self.testKey)
     }
 
+    // MARK: - Manual "Add token"
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: Heartbeat.self, TokenSample.self, DailyAggregate.self, ProjectDailyAggregate.self,
+            RateLimitSample.self, SessionInfo.self, ClaudeCodeMeta.self, configurations: config
+        )
+    }
+
+    private func successClient(orgs: [String]) -> OAuthClient {
+        let counter = AtomicCounter()
+        let outcomes = orgs.map {
+            HTTPOutcome.success(jsonBody: #"{"five_hour":{"utilization":5}}"#,
+                                headers: ["anthropic-organization-id": $0])
+        }
+        return OAuthClient(
+            keychain: KeychainOAuth(rawReader: { .failure(.notFound) }),
+            transport: { _ in try outcomes[min(counter.next(), outcomes.count - 1)].materialize() },
+            desktopEnabled: { false }
+        )
+    }
+
+    @Test func addManualTokenJoinsPoolPersistsAndDedupes() async throws {
+        let container = try makeContainer()
+        let pool = EphemeralTokenPoolStore()
+        let poller = OAuthPoller(client: successClient(orgs: ["orgA"]),
+                                 container: container, configuration: .init(),
+                                 clock: TestClock(), poolStore: pool)
+        let r = await poller.addManualToken("manual-tok-1")
+        if case .success = r {} else { Issue.record("expected success, got \(r)") }
+        #expect(await poller.snapshot().laneCount == 1)
+        #expect(pool.loadAll().contains { $0.credential.accessToken == "manual-tok-1" && $0.source == .override })
+        // Duplicate add is a no-op.
+        #expect(await poller.addManualToken("manual-tok-1") == .alreadyTracked)
+        #expect(await poller.snapshot().laneCount == 1)
+    }
+
+    @Test func addManualTokenForeignAccountNotKept() async throws {
+        let container = try makeContainer()
+        let pool = EphemeralTokenPoolStore()
+        // First add establishes primary org A; second is org B (foreign).
+        let poller = OAuthPoller(client: successClient(orgs: ["orgA", "orgB"]),
+                                 container: container, configuration: .init(),
+                                 clock: TestClock(), poolStore: pool)
+        _ = await poller.addManualToken("tok-A")           // primary
+        let r = await poller.addManualToken("tok-B")       // foreign
+        #expect(r == .foreignAccount(org: "orgB"))
+        // Only the primary lane remains; foreign token not persisted.
+        #expect(await poller.snapshot().laneCount == 1)
+        #expect(!pool.loadAll().contains { $0.credential.accessToken == "tok-B" })
+    }
+
+    @Test func removeManualTokenDropsFromLanesAndPool() async throws {
+        let container = try makeContainer()
+        let pool = EphemeralTokenPoolStore()
+        let poller = OAuthPoller(client: successClient(orgs: ["orgA"]),
+                                 container: container, configuration: .init(),
+                                 clock: TestClock(), poolStore: pool)
+        _ = await poller.addManualToken("manual-tok-1")
+        #expect(await poller.snapshot().laneCount == 1)
+        await poller.removeManualToken(id: OAuthPoller.laneId("manual-tok-1"))
+        #expect(await poller.snapshot().laneCount == 0)
+        #expect(pool.loadAll().isEmpty)
+    }
+
     // MARK: - Poller seeds from the persisted pool on restart
 
     @Test func pollerSeedsLanesFromPersistedPool() async throws {

--- a/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
@@ -147,7 +147,7 @@ import Testing
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try ModelContainer(
             for: Heartbeat.self, TokenSample.self, DailyAggregate.self, ProjectDailyAggregate.self,
-            RateLimitSample.self, SessionInfo.self, ClaudeCodeMeta.self, configurations: config
+            RateLimitSample.self, SessionInfo.self, ClaudeCodeMeta.self, TokenLaneMeta.self, configurations: config
         )
     }
 
@@ -240,7 +240,7 @@ import Testing
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(
             for: Heartbeat.self, TokenSample.self, DailyAggregate.self, ProjectDailyAggregate.self,
-            RateLimitSample.self, SessionInfo.self, ClaudeCodeMeta.self, configurations: config
+            RateLimitSample.self, SessionInfo.self, ClaudeCodeMeta.self, TokenLaneMeta.self, configurations: config
         )
         let pool = EphemeralTokenPoolStore([
             StoredToken(
@@ -262,5 +262,52 @@ import Testing
         // the pool restored a lane without any source read.
         if case .transport = outcome {} else { Issue.record("expected transport from seeded lane, got \(outcome)") }
         #expect(await poller.snapshot().laneCount >= 1)
+    }
+
+    @Test func laneMetadataPersistsAcrossRestart() async throws {
+        let container = try makeContainer()   // includes TokenLaneMeta
+        let pool = EphemeralTokenPoolStore([
+            StoredToken(
+                credential: OAuthCredential(accessToken: Self.validToken("z"),
+                                            expiresAt: Date().addingTimeInterval(3600), subscriptionType: nil),
+                source: .desktop
+            )
+        ])
+
+        // First launch: a successful poll learns the account + stamps the lane,
+        // which must be written to SwiftData.
+        let poller1 = OAuthPoller(client: successClient(orgs: ["orgZ"]),
+                                  container: container, configuration: .init(),
+                                  clock: TestClock(), poolStore: pool)
+        let out1 = await poller1.runOnce()
+        if case .success = out1 {} else { Issue.record("expected success, got \(out1)") }
+
+        // Extract plain values inside the MainActor hop — the @Model itself
+        // isn't Sendable and can't cross the boundary.
+        let meta = await MainActor.run { () -> (count: Int, account: String?, org: String?, polled: Bool) in
+            let ctx = ModelContext(container)
+            let rows = (try? ctx.fetch(FetchDescriptor<TokenLaneMeta>())) ?? []
+            return (rows.count, rows.first?.accountRaw, rows.first?.organizationId, rows.first?.lastPolledAt != nil)
+        }
+        #expect(meta.count == 1)
+        #expect(meta.account == "primary")
+        #expect(meta.org == "orgZ")
+        #expect(meta.polled)
+
+        // Second launch (fresh poller, same store): a transport that only ever
+        // throws — so the restored primary org / membership can ONLY come from
+        // the persisted metadata, not from anything this run polled.
+        struct StubError: Error {}
+        let client2 = OAuthClient(
+            keychain: KeychainOAuth(rawReader: { .failure(.notFound) }),
+            transport: { _ in throw StubError() },
+            desktopEnabled: { false }
+        )
+        let poller2 = OAuthPoller(client: client2, container: container, configuration: .init(),
+                                  clock: TestClock(), poolStore: pool)
+        _ = await poller2.runOnce()
+        let snap = await poller2.snapshot()
+        #expect(snap.primaryOrg == "orgZ")     // restored, not re-derived
+        #expect(snap.primaryLaneCount == 1)    // lane came back a confirmed member
     }
 }

--- a/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
@@ -174,8 +174,12 @@ import Testing
         if case .success = r {} else { Issue.record("expected success, got \(r)") }
         #expect(await poller.snapshot().laneCount == 1)
         #expect(pool.loadAll().contains { $0.credential.accessToken == Self.validToken("1") && $0.source == .override })
-        // Duplicate add is a no-op.
-        #expect(await poller.addManualToken(Self.validToken("1")) == .alreadyTracked)
+        // Duplicate add is a no-op and reports the matching source.
+        if case .alreadyTracked(let source, _) = await poller.addManualToken(Self.validToken("1")) {
+            #expect(source == .override)
+        } else {
+            Issue.record("expected alreadyTracked")
+        }
         #expect(await poller.snapshot().laneCount == 1)
     }
 

--- a/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/TokenPoolLayeredTests.swift
@@ -138,6 +138,11 @@ import Testing
 
     // MARK: - Manual "Add token"
 
+    /// A well-formed OAuth token (passes the offline format gate), distinct per seed.
+    private static func validToken(_ seed: Character) -> String {
+        TokenFormat.oauthPrefix + String(repeating: seed, count: 50)
+    }
+
     private func makeContainer() throws -> ModelContainer {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try ModelContainer(
@@ -165,12 +170,12 @@ import Testing
         let poller = OAuthPoller(client: successClient(orgs: ["orgA"]),
                                  container: container, configuration: .init(),
                                  clock: TestClock(), poolStore: pool)
-        let r = await poller.addManualToken("manual-tok-1")
+        let r = await poller.addManualToken(Self.validToken("1"))
         if case .success = r {} else { Issue.record("expected success, got \(r)") }
         #expect(await poller.snapshot().laneCount == 1)
-        #expect(pool.loadAll().contains { $0.credential.accessToken == "manual-tok-1" && $0.source == .override })
+        #expect(pool.loadAll().contains { $0.credential.accessToken == Self.validToken("1") && $0.source == .override })
         // Duplicate add is a no-op.
-        #expect(await poller.addManualToken("manual-tok-1") == .alreadyTracked)
+        #expect(await poller.addManualToken(Self.validToken("1")) == .alreadyTracked)
         #expect(await poller.snapshot().laneCount == 1)
     }
 
@@ -181,12 +186,34 @@ import Testing
         let poller = OAuthPoller(client: successClient(orgs: ["orgA", "orgB"]),
                                  container: container, configuration: .init(),
                                  clock: TestClock(), poolStore: pool)
-        _ = await poller.addManualToken("tok-A")           // primary
-        let r = await poller.addManualToken("tok-B")       // foreign
+        _ = await poller.addManualToken(Self.validToken("A"))           // primary
+        let r = await poller.addManualToken(Self.validToken("B"))       // foreign
         #expect(r == .foreignAccount(org: "orgB"))
         // Only the primary lane remains; foreign token not persisted.
         #expect(await poller.snapshot().laneCount == 1)
-        #expect(!pool.loadAll().contains { $0.credential.accessToken == "tok-B" })
+        #expect(!pool.loadAll().contains { $0.credential.accessToken == Self.validToken("B") })
+    }
+
+    @Test func tokenFormatGate() {
+        #expect(TokenFormat.validate(TokenFormat.oauthPrefix + String(repeating: "a", count: 50)) == .ok)
+        for bad in ["", "random garbage", "sk-ant-oat01-short",
+                    "sk-ant-api03-" + String(repeating: "a", count: 50),
+                    "sk-ant-sid01-" + String(repeating: "a", count: 50)] {
+            if case .invalid = TokenFormat.validate(bad) {} else {
+                Issue.record("expected invalid for \(bad.prefix(16))…")
+            }
+        }
+    }
+
+    @Test func addManualTokenRejectsBadFormatOffline() async throws {
+        let container = try makeContainer()
+        let pool = EphemeralTokenPoolStore()
+        let poller = OAuthPoller(client: successClient(orgs: ["orgA"]),
+                                 container: container, configuration: .init(),
+                                 clock: TestClock(), poolStore: pool)
+        let r = await poller.addManualToken("not-a-real-token")
+        if case .failure = r {} else { Issue.record("expected failure, got \(r)") }
+        #expect(await poller.snapshot().laneCount == 0)   // never added, never polled
     }
 
     @Test func removeManualTokenDropsFromLanesAndPool() async throws {
@@ -195,9 +222,9 @@ import Testing
         let poller = OAuthPoller(client: successClient(orgs: ["orgA"]),
                                  container: container, configuration: .init(),
                                  clock: TestClock(), poolStore: pool)
-        _ = await poller.addManualToken("manual-tok-1")
+        _ = await poller.addManualToken(Self.validToken("1"))
         #expect(await poller.snapshot().laneCount == 1)
-        await poller.removeManualToken(id: OAuthPoller.laneId("manual-tok-1"))
+        await poller.removeManualToken(id: OAuthPoller.laneId(Self.validToken("1")))
         #expect(await poller.snapshot().laneCount == 0)
         #expect(pool.loadAll().isEmpty)
     }

--- a/docs/oauth-usage-endpoint.md
+++ b/docs/oauth-usage-endpoint.md
@@ -1,0 +1,80 @@
+# The OAuth usage endpoint & adaptive multi-token polling
+
+Pacer's rate-limit numbers come from `GET https://api.anthropic.com/api/oauth/usage`
+— the undocumented endpoint Claude Code itself polls for its banner. This
+note records what we measured about it (2026-07-08) and why the poller is
+shaped the way it is, so nobody has to re-run the experiments.
+
+## Request
+
+```
+GET /api/oauth/usage
+Authorization: Bearer <oauth access token>   # user:profile scope
+anthropic-beta: oauth-2025-04-20
+User-Agent: pacer/1.0 (+https://github.com/ericandrechek/pacer)
+Accept: application/json
+```
+
+Response is `application/json`, `cf-cache-status: DYNAMIC` (computed at
+origin per request), carrying `anthropic-organization-id` — the account
+the token belongs to. Body includes `five_hour` / `seven_day`
+(`utilization` 0–100, `resets_at`), plus a richer `limits[]` array with
+per-model **scoped** windows, `severity`, and `is_active` that we don't
+yet surface (a future enhancement).
+
+## What we measured
+
+Two experiments (a 20s two-token sampler, then a rate-respecting 90s
+round-robin over 4 Desktop tokens):
+
+1. **The value is computed live, not bucketed to 5 minutes.** Utilization
+   steps landed *mid-bucket* (e.g. 13:47 and 13:56), not only on `:00`/`:05`
+   wall-clock marks, and `resets_at` varies by microseconds per request.
+   So polling more often genuinely yields fresher numbers.
+2. **…but resolution is integer percent.** At moderate burn the value only
+   changes about once every 15–25 min, so extra freshness mostly matters
+   during heavy bursts.
+3. **Rate limit ≈ 1 request / 5 min / token, and it bites.** At 3 req/min
+   the Claude Code token 429'd after 28 requests (~9.5 min); a Desktop
+   token after 16 (~5.5 min). Once throttled, recovery was ~1 success per
+   5 min, and a single ~28-request burst kept a token throttled for **~35
+   minutes**. There are **no rate-limit headers**; 429s carry only
+   `Retry-After: 0` (present but useless).
+4. **Multiple tokens are independent budgets for the same data.** An
+   account often has several tokens (Claude Code + Claude Desktop). They
+   return **identical** utilization (same account) but each has its own
+   per-token budget — 4 Desktop tokens round-robined at 90s ran clean
+   indefinitely.
+
+### The consequence
+
+Because the data is *live* but each token is capped at ~1 poll / 5 min,
+spreading polls across N same-account tokens gives a genuinely finer
+**effective** cadence (5 min ÷ N) at a sustainable per-token rate. That's
+the lever the poller pulls.
+
+## Design (`OAuthPoller` + `OAuthPollScheduler`)
+
+- **Lanes.** One lane per discovered token (`OAuthClient.candidateCredentials()`
+  — Claude Code keychain always, opted-in Desktop behind the
+  `DesktopReadGate` so it isn't re-read/re-prompted).
+- **Scheduler** (`OAuthPollScheduler`, pure/unit-tested) spreads polls:
+  - **Per-token invariant:** no lane polled more than once per
+    `perTokenMinInterval` (300s) — the hard rail that keeps every lane off
+    the ~30-min throttle.
+  - **Active** (recent Claude usage): aim for `activeInterval` (150s),
+    realized by interleaving lanes. One lane floors at 300s.
+  - **Idle:** relax to `idleInterval` (600s).
+  - **Poll-on-wake:** the `ScanCoordinator` calls `notifyActivity()` when
+    fresh usage lands, waking the loop to re-evaluate (still bounded by the
+    per-token floor, so a nudge can never over-poll).
+- **Same-account guard.** The first successful poll sets the pool's primary
+  org (`anthropic-organization-id`); a lane resolving to a different org is
+  marked *foreign* — never selected, never persisted — so interleaving can
+  never mix two accounts into one timeline.
+- **Per-lane cooldown.** A 429/transport/5xx cools *that lane* (exponential,
+  capped); other lanes keep the timeline fresh. There's no `Retry-After` to
+  honor, so cooldown is our own schedule.
+
+With one token this degrades cleanly to single-lane activity-gating. Tuning
+constants live in `OAuthPoller.Configuration` / `OAuthPollScheduler.Tuning`.

--- a/docs/oauth-usage-endpoint.md
+++ b/docs/oauth-usage-endpoint.md
@@ -62,8 +62,9 @@ the lever the poller pulls.
   - **Per-token invariant:** no lane polled more than once per
     `perTokenMinInterval` (300s) — the hard rail that keeps every lane off
     the ~30-min throttle.
-  - **Active** (recent Claude usage): aim for `activeInterval` (150s),
-    realized by interleaving lanes. One lane floors at 300s.
+  - **Active** (recent Claude usage): the fastest *even* cadence the
+    lanes sustain — `max(activeInterval floor 60s, perTokenMin/lanes)`.
+    So 5 tokens → ~1 min, 2 → ~2.5 min, 1 → 5 min.
   - **Idle:** relax to `idleInterval` (600s).
   - **Poll-on-wake:** the `ScanCoordinator` calls `notifyActivity()` when
     fresh usage lands, waking the loop to re-evaluate (still bounded by the


### PR DESCRIPTION
## What & why

Pacer polled Anthropic's usage endpoint on a fixed single-token cadence. That endpoint computes usage live per request but rate-limits to ~1 poll / 5 min / token with no budget headers (over-polling trips a ~30-min throttle). Most accounts have **several** independent tokens (Claude Code + Claude Desktop, sometimes more), each with its own budget — so this PR spreads polls across every token it can read for the account, refreshing far more often while you're active without ever exceeding a single token's limit.

## Polling engine (`PacerCore`)

- **Lane-based scheduler** (`OAuthPollScheduler` + rewritten `OAuthPoller`): one lane per discovered token; effective cadence = 5 min ÷ usable-token-count when active, relaxing when idle, with a hard per-token floor so no lane is ever polled more than once / 5 min.
- **Same-account guard** — the first successful poll pins the account (`anthropic-organization-id`); a token resolving to a different org is marked foreign and never selected or persisted, so interleaving can't mix two accounts.
- **Per-lane cooldown** (exponential, capped) on 429/transport/5xx; other lanes keep the timeline fresh. **Poll-on-wake** re-evaluates when fresh usage lands. Degrades cleanly to single-lane activity-gating with one token.
- Logs a diagnostic line when a window's utilization *decreases* for a non-reset reason (backend replica lag surfaced by interleaving).

## Tokens settings section (`App`)

- New **Tokens** card under Authentication: every token in the pool with its source, account, expiry, health, priority and when it last polled; a live cadence header.
- **Add token** — additive manual entry (e.g. a token from another Mac / a Claude app Pacer doesn't scrape), with an offline `user:profile` format gate, duplicate detection + row highlight, a copyable retrieval command, and remove buttons. Manual tests route *through* the poller so the reading is kept and counts against that token's budget instead of racing it.

## Persistence & resilience

- Token pool + the Claude Desktop `Safe Storage` AES key are cached in Pacer's own keychain, so restarts are silent (3-layer Desktop read: cached-key decrypt → cached tokens → Safe Storage only as a last resort).
- New additive `TokenLaneMeta` `@Model` persists each lane's account / org / expiry / last-poll / cooldown, restored (and published before the startup delay) on launch so the table shows real status immediately and the poller doesn't re-poll a just-polled token after a restart.

## Tests

+ `OAuthPollSchedulerTests`, expanded `OAuthPollerTests`, `TokenPoolLayeredTests` (format gate, layered Desktop read, add/remove, pool seeding, `laneMetadataPersistsAcrossRestart`). **561 tests pass.**

Endpoint measurements + the design rationale are recorded in `docs/oauth-usage-endpoint.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
