### PR TITLE
Scoped per-model pace charts plot their whole cycle, not one dot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ These are subtle, easy to miss, and break user-visible numbers:
 6. **Defensive parse-or-skip everywhere.** A single malformed line
    (often a truncated final line on a live session) must not break the
    scan.
+7. **Never match a rate-limit cycle with `resetsAt ==`.** The server
+   re-serializes `resets_at` per response and it jitters in the
+   milliseconds — one 7-day cycle carries thousands of distinct reset
+   instants. Cycle membership goes through `RateLimitCycle.contains`
+   (within half a window, `nil` counts as in-cycle), which both
+   `RateLimitSample.inCycle` and `UsageLimitSample.inCycle` call.
+   Exact equality matches ~1 row and collapses a chart to a single dot.
 
 ## What NOT to do
 
@@ -531,6 +538,16 @@ git log for "Views/Widgets: scope @Query" or "HourlyAggregate" or
   every SwiftData save materializes the whole table just to answer the
   question — see `WelcomeCard`, `LiveActivityCard.latestSampleProbe`,
   `LiveSessionWidget`.
+- **Bound history queries by TIME, not row count.** A `fetchLimit` on a
+  series a chart *draws* is a silent cap on how much of that series the
+  user can see, and it moves whenever write cadence does. The scoped pace
+  line was capped at 600 rows shared across every `limits[]` window; when
+  polling went adaptive (~1/min, #120) that became ~3 hours of a 7-day
+  cycle and the chart rendered as a stub. Use a cutoff predicate matching
+  what's plotted, plus `propertiesToFetch` to keep it cheap; keep
+  `fetchLimit` only as a burst backstop, set far above the real volume.
+  Compute the cutoff per view init — a `static let` freezes at process
+  start and widens the query by a day for every day the app stays open.
 
 ### Body work — cache derived values; never iterate raw rows in a view
 

--- a/App/Background/ScreenshotMode.swift
+++ b/App/Background/ScreenshotMode.swift
@@ -125,6 +125,16 @@ enum ScreenshotMode {
             return
         }
 
+        // Focused proof run for the scoped-history work: the pace card over a
+        // scoped window seeded at the real poll cadence with the real
+        // sub-second `resets_at` jitter — the regression proof that the scoped
+        // actual line plots its whole cycle and not just the newest reading.
+        if ProcessInfo.processInfo.environment["PACER_SCREENSHOT_SCOPED_HISTORY_ONLY"] == "1" {
+            await captureScopedHistoryScenes()
+            log("scoped-history screenshots complete")
+            return
+        }
+
         // Warm an intelligence engine over the seeded in-memory store so the
         // engine-powered cards (intelligence card, projected EOD/month tiles,
         // burn rows) render real answers instead of their warming-up states.
@@ -579,6 +589,95 @@ enum ScreenshotMode {
         await capture(name, width: width, height: nil, scheme: .light,
                       card: true, container: container) { PaceChartCard() }
         screenshotEngine = previous
+    }
+
+    // MARK: - Scoped-history proof scene
+
+    /// Render the `scoped-history-*` proof capture for the scoped pace line.
+    ///
+    /// Every other seeder writes scoped rows the *tidy* way — one row an hour
+    /// with a byte-identical `resetsAt` on all of them. The real server is
+    /// neither: it is polled about once a minute (adaptive polling, #120) and
+    /// its `resets_at` jitters by a few hundred milliseconds from poll to poll,
+    /// so a single weekly cycle carries a couple thousand rows with a couple
+    /// thousand *distinct* reset instants. Both properties matter — an exact
+    /// `resetsAt ==` cycle filter drops the whole history, and a small row cap
+    /// clips the tail to the last few hours — so this scene seeds them and
+    /// captures the pace card as the regression proof for both.
+    private static func captureScopedHistoryScenes() async {
+        await captureScopedHistoryScene("scoped-history-fable", width: 940)
+    }
+
+    private static func captureScopedHistoryScene(_ name: String, width: CGFloat) async {
+        guard let container = try? PacerStore.makeInMemoryContainer() else {
+            log("⚠️ \(name): container creation failed"); return
+        }
+        let ctx = ModelContext(container)
+        let now = Date()
+        seedRateLimits(ctx, now: now)
+        seedRealisticScoped(ctx, now: now)
+        do { try ctx.save() } catch { log("⚠️ \(name): seed save failed: \(error)") }
+
+        let engine = UsageIntelligenceEngine(modelContainer: container)
+        await engine.recompute(now: now)
+        let previous = screenshotEngine
+        screenshotEngine = engine
+        await capture(name, width: width, height: nil, scheme: .dark,
+                      card: true, container: container) { PaceChartCard() }
+        screenshotEngine = previous
+    }
+
+    /// Seed one scoped weekly window (plus the two account-wide rows that ride
+    /// along in every real `limits[]` response) at the real poll cadence and
+    /// with the real sub-second `resets_at` jitter. ~22% into the cycle, a
+    /// bursty monotone climb to 15% — i.e. the shape of the chart that exposed
+    /// the bug.
+    private static func seedRealisticScoped(_ ctx: ModelContext, now: Date) {
+        let duration: TimeInterval = 7 * 86_400
+        let elapsedFraction = 0.22
+        let cycleStart = now.addingTimeInterval(-duration * elapsedFraction)
+        let resetsAt = cycleStart.addingTimeInterval(duration)
+        // Real cadence: adaptive polling settles around one call a minute.
+        let interval: TimeInterval = 55
+        let sessionReset = now.addingTimeInterval(2 * 3_600 + 19 * 60)
+
+        var t = cycleStart
+        var i = 0
+        var scopedLast = 0.0
+        while t <= now {
+            // Sub-second reset jitter — the server re-serializes `resets_at`
+            // per response, so consecutive polls disagree in the milliseconds.
+            let jitter = (noise(i &* 31) - 0.5)
+            let scopedReset = resetsAt.addingTimeInterval(jitter)
+            let frac = t.timeIntervalSince(cycleStart) / (now.timeIntervalSince(cycleStart))
+            // Bursty: two working sessions separated by a quiet stretch.
+            let shape = frac < 0.35 ? frac * 1.7
+                      : frac < 0.62 ? 0.60 + (frac - 0.35) * 0.25
+                      : 0.67 + (frac - 0.62) * 0.87
+            var pct = (15.0 * shape).rounded()
+            pct = max(scopedLast, pct)
+            scopedLast = pct
+            ctx.insert(UsageLimitSample(
+                sampledAt: t, identity: "weekly_scoped|Fable|", kind: "weekly_scoped",
+                group: "weekly", label: "Fable", percent: pct, resetsAt: scopedReset,
+                severity: "normal", isActive: true,
+                modelId: nil, modelDisplayName: "Fable", surface: nil, source: "oauth"))
+            // The account-wide rows every poll also carries — they share the
+            // row budget with the scoped window, which is what made a flat
+            // fetch cap clip the scoped tail so aggressively.
+            ctx.insert(UsageLimitSample(
+                sampledAt: t, identity: "session||", kind: "session", group: "session",
+                label: "All models", percent: 39, resetsAt: sessionReset.addingTimeInterval(jitter),
+                severity: "normal", isActive: false,
+                modelId: nil, modelDisplayName: nil, surface: nil, source: "oauth"))
+            ctx.insert(UsageLimitSample(
+                sampledAt: t, identity: "weekly_all||", kind: "weekly_all", group: "weekly",
+                label: "All models", percent: 71, resetsAt: resetsAt.addingTimeInterval(jitter),
+                severity: "normal", isActive: false,
+                modelId: nil, modelDisplayName: nil, surface: nil, source: "oauth"))
+            t = t.addingTimeInterval(interval)
+            i += 1
+        }
     }
 
     // MARK: - Widget window-picker proof scenes

--- a/App/Views/PaceChartCard.swift
+++ b/App/Views/PaceChartCard.swift
@@ -31,12 +31,25 @@ struct PaceChartCard: View {
     /// own filter pass.
     @Query private var samples: [RateLimitSample]
 
-    /// Recent scoped `limits[]` rows, newest first. Bounded so the query never
-    /// scans the full append-only history: it feeds the latest-batch column set
-    /// plus a recent actual-line tail under each scoped column (the dashed
-    /// projection carries the forecast on to reset) — the same bounded-tail
-    /// pattern the retired scoped-limits tile card used.
-    @Query(PaceChartCard.scopedDescriptor) private var scopedSamples: [UsageLimitSample]
+    /// The newest scoped `limits[]` rows, newest first — just enough to resolve
+    /// the latest poll's batch, which is what decides the scoped column set.
+    /// Whole rows: the label, group→duration, binding flag and severity all
+    /// read fields a columnar projection wouldn't fetch.
+    @Query(PaceChartCard.scopedLatestDescriptor) private var scopedLatest: [UsageLimitSample]
+
+    /// Scoped rows over the same 8-day window the fixed query uses — the
+    /// actual-usage line under each scoped column. Separate from the batch
+    /// query because the two want opposite things: the batch needs whole rows
+    /// but only the newest few, while the line needs thousands of rows but
+    /// only four scalars, so this one is columnar (see `docs/perf-tuning.md`).
+    ///
+    /// It has no `fetchLimit` on purpose. A flat cap here is a *cap on how much
+    /// of the cycle you can see*: at the real poll cadence (~1/min) and one row
+    /// per limit per poll, 600 rows is about three hours — 2% of a weekly
+    /// window — so the scoped line rendered as a stub near "now" no matter how
+    /// long the cycle had been running. The 8-day cutoff bounds it by time
+    /// instead, which is the bound that matches what the chart draws.
+    @Query private var scopedHistory: [UsageLimitSample]
 
     /// The shared intelligence engine — single source of the forecast
     /// trajectories (the dashed overlay; the compare-models modal asks the
@@ -79,16 +92,27 @@ struct PaceChartCard: View {
         // RateLimitSample objects on every store save. See docs/perf-tuning.md.
         descriptor.propertiesToFetch = [\.window, \.sampledAt, \.resetsAt, \.usedPercentage]
         _samples = Query(descriptor)
+
+        // Same cutoff, same columnar treatment, for the scoped actual lines.
+        // Built here rather than in a `static let` so the 8 days are measured
+        // from when the view was created: a process-lifetime constant would
+        // keep its launch-day cutoff and quietly widen the query by a day for
+        // every day Pacer stays open.
+        var scopedDescriptor = FetchDescriptor<UsageLimitSample>(
+            predicate: #Predicate<UsageLimitSample> { $0.sampledAt >= cutoff },
+            sortBy: [SortDescriptor(\.sampledAt, order: .reverse)]
+        )
+        scopedDescriptor.propertiesToFetch = [\.identity, \.sampledAt, \.resetsAt, \.percent]
+        _scopedHistory = Query(scopedDescriptor)
     }
 
-    /// Recent scoped rows, newest first, bounded. Unlike the fixed query this
-    /// can't restrict `propertiesToFetch` — the latest-batch filter, label,
-    /// group→duration, binding flag, and severity all read whole rows.
-    private static let scopedDescriptor: FetchDescriptor<UsageLimitSample> = {
+    /// Newest scoped rows, whole, capped well above any plausible `limits[]`
+    /// count so one poll's batch always fits.
+    private static let scopedLatestDescriptor: FetchDescriptor<UsageLimitSample> = {
         var d = FetchDescriptor<UsageLimitSample>(
             sortBy: [SortDescriptor(\.sampledAt, order: .reverse)]
         )
-        d.fetchLimit = 600
+        d.fetchLimit = 120
         return d
     }()
 
@@ -119,50 +143,6 @@ struct PaceChartCard: View {
         struct SeverityTag: Equatable { let text: String; let band: UsageBand }
     }
 
-    // MARK: - Chart-data builders (one per source)
-
-    /// Fixed-window actual line from `RateLimitSample`. Byte-for-byte the old
-    /// `PaceChartColumn.chartData`: synthesizes a "now" tail so the line tracks
-    /// to current time even if the latest sample is a few minutes old.
-    static func fixedBaseChart(samples: [RateLimitSample], duration: TimeInterval, now: Date) -> PaceChartView.Data? {
-        guard let latest = samples.first, let resets = latest.resetsAt else { return nil }
-        let cycleStart = resets.addingTimeInterval(-duration)
-        var points = samples
-            .inCycle(resetting: resets, duration: duration)
-            .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
-            .sorted { $0.sampledAt < $1.sampledAt }
-            .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }
-        let tailTime = min(now, resets)
-        if points.last?.time != tailTime {
-            points.append(.init(time: tailTime, value: latest.usedPercentage))
-        }
-        return PaceChartView.Data(
-            cycleStart: cycleStart, resetsAt: resets, durationSeconds: duration,
-            points: points, usedPct: latest.usedPercentage)
-    }
-
-    /// Scoped-window actual line from this identity's `UsageLimitSample` history
-    /// in the current cycle, plus a synthesized "now" tail. Projection-free
-    /// (the column layers it), matching the fixed builder's shape.
-    static func scopedBaseChart(row: UsageLimitSample, history: [UsageLimitSample],
-                                duration: TimeInterval, now: Date) -> PaceChartView.Data? {
-        guard let resets = row.resetsAt else { return nil }
-        let cycleStart = resets.addingTimeInterval(-duration)
-        var points = history
-            .filter { $0.identity == row.identity && $0.resetsAt == resets
-                   && $0.sampledAt >= cycleStart && $0.sampledAt <= now }
-            .sorted { $0.sampledAt < $1.sampledAt }
-            .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.percent) }
-        let tailTime = min(now, resets)
-        if points.last?.time != tailTime {
-            points.append(.init(time: tailTime, value: row.percent))
-        }
-        guard !points.isEmpty else { return nil }
-        return PaceChartView.Data(
-            cycleStart: cycleStart, resetsAt: resets, durationSeconds: duration,
-            points: points, usedPct: row.percent)
-    }
-
     // MARK: - Column set
 
     private struct Bucketed {
@@ -189,7 +169,7 @@ struct PaceChartCard: View {
     /// Account-wide `session`/`weekly_all` rows are excluded — the fixed 5h/7d
     /// hero columns already own those (Decision C).
     private var scopedRows: [UsageLimitSample] {
-        scopedSamples.latestBatch().filter {
+        scopedLatest.latestBatch().filter {
             ($0.modelId?.isEmpty == false)
                 || ($0.modelDisplayName?.isEmpty == false)
                 || ($0.surface?.isEmpty == false)
@@ -228,8 +208,8 @@ struct PaceChartCard: View {
             tagged.append((side, Column(
                 id: row.identity, title: row.label, duration: duration,
                 usedPct: row.percent, resetsAt: row.resetsAt,
-                baseChart: Self.scopedBaseChart(row: row, history: scopedSamples,
-                                                duration: duration, now: now),
+                baseChart: .cycle(scoped: row, history: scopedHistory,
+                                  duration: duration, now: now),
                 isActive: row.isActive, severity: severity, isScoped: true)))
         }
         return tagged
@@ -250,7 +230,7 @@ struct PaceChartCard: View {
         return Column(
             id: key, title: title, duration: duration,
             usedPct: latest?.usedPercentage, resetsAt: latest?.resetsAt,
-            baseChart: Self.fixedBaseChart(samples: samples, duration: duration, now: now),
+            baseChart: .cycle(fixed: samples, duration: duration, now: now),
             isActive: false, severity: nil, isScoped: false)
     }
 
@@ -455,14 +435,7 @@ private struct PaceColumn: View {
         // At/over the cap the trajectory collapses to its origin — fall back to
         // the projection-free chart.
         guard pts.count >= 2 else { return base }
-        return PaceChartView.Data(
-            cycleStart: base.cycleStart,
-            resetsAt: base.resetsAt,
-            durationSeconds: base.durationSeconds,
-            points: base.points,
-            usedPct: base.usedPct,
-            projection: pts,
-            projectionCrossesFullAt: rebased.crossesFullAt)
+        return base.withProjection(pts, crossesFullAt: rebased.crossesFullAt)
     }
 
     var body: some View {

--- a/App/Views/ProjectionDetailView.swift
+++ b/App/Views/ProjectionDetailView.swift
@@ -61,39 +61,18 @@ struct ProjectionCompareModal: View {
     /// backs this window (fixed 5h/7d → `RateLimitSample`; scoped → the scoped
     /// identity's `UsageLimitSample` history).
     private var chartData: PaceChartView.Data? {
-        let latest: (resets: Date, used: Double)?
-        let pointsRaw: [(time: Date, value: Double)]
-        if isFixed {
-            guard let l = samples.last, let resets = l.resetsAt else { return nil }
-            latest = (resets, l.usedPercentage)
-            pointsRaw = samples
-                .inCycle(resetting: resets, duration: duration)
-                .map { ($0.sampledAt, $0.usedPercentage) }
-        } else {
-            guard let l = scopedSamples.last, let resets = l.resetsAt else { return nil }
-            latest = (resets, l.percent)
-            pointsRaw = scopedSamples
-                .filter { $0.resetsAt == resets }
-                .map { ($0.sampledAt, $0.percent) }
-        }
-        guard let latest else { return nil }
-        let resets = latest.resets
-        let cycle = DisplayCycle.resolve(resetsAt: resets, duration: duration)
-        guard !cycle.isAwaiting else { return nil }
-        let cycleStart = resets.addingTimeInterval(-duration)
         let now = Date()
-        var points = pointsRaw
-            .filter { $0.time >= cycleStart && $0.time <= now }
-            .sorted { $0.time < $1.time }
-            .map { PaceChartView.Data.Point(time: $0.time, value: $0.value) }
-        let tailTime = min(now, resets)
-        if points.last?.time != tailTime {
-            points.append(.init(time: tailTime, value: latest.used))
+        let data: PaceChartView.Data?
+        if isFixed {
+            data = .cycle(fixed: samples, duration: duration, now: now)
+        } else {
+            guard let row = scopedSamples.last else { return nil }
+            data = .cycle(scoped: row, history: scopedSamples, duration: duration, now: now)
         }
-        return PaceChartView.Data(
-            cycleStart: cycleStart, resetsAt: resets, durationSeconds: duration,
-            points: points, usedPct: latest.used
-        )
+        guard let data,
+              !DisplayCycle.resolve(resetsAt: data.resetsAt, duration: duration).isAwaiting
+        else { return nil }
+        return data
     }
 
     /// "62% used · resets Mon 6 AM" — the cycle context the chart is read in.

--- a/PacerCore/Sources/PacerCore/Models/CycleMembership.swift
+++ b/PacerCore/Sources/PacerCore/Models/CycleMembership.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Does a sample belong to the rate-limit cycle that resets at a given
+/// instant?
+///
+/// Every sample carries its own `resetsAt`, so cycle membership is a direct
+/// property of the row rather than an inference from its timestamp. But the
+/// server re-serializes `resets_at` on every response and the value **jitters
+/// by a few hundred milliseconds** between polls — a single 7-day cycle
+/// routinely carries a couple thousand rows with a couple thousand *distinct*
+/// reset instants. So membership can never be exact equality; it has to be
+/// "within half a window", which is unambiguous because consecutive resets are
+/// always a full window apart.
+///
+/// This lives in one place because both sample tables need the identical rule:
+/// `RateLimitSample` (the fixed 5h/7d blocks) and `UsageLimitSample` (every
+/// scoped `limits[]` window). The scoped chart originally filtered on `==` and
+/// therefore plotted a single point — the newest reading — instead of the
+/// cycle's curve.
+public enum RateLimitCycle {
+    /// Whether a sample whose own reset is `sampleReset` belongs to the cycle
+    /// resetting at `resets`.
+    ///
+    /// - A `nil` sample reset counts as in-cycle: the server returns
+    ///   `resets_at: null` for the post-reset 0%-used readings, before the new
+    ///   window re-anchors on your next message (#100).
+    /// - Otherwise the sample is in-cycle when its reset is within half a
+    ///   window of this cycle's, which absorbs the sub-second jitter while
+    ///   still excluding the neighboring cycle.
+    @inlinable
+    public static func contains(
+        sampleReset: Date?, resets: Date, duration: TimeInterval
+    ) -> Bool {
+        guard let sampleReset else { return true }
+        return abs(sampleReset.timeIntervalSince(resets)) < duration / 2
+    }
+}

--- a/PacerCore/Sources/PacerCore/Models/RateLimitSample.swift
+++ b/PacerCore/Sources/PacerCore/Models/RateLimitSample.swift
@@ -77,16 +77,9 @@ public final class RateLimitSample {
 
 public extension Sequence where Element == RateLimitSample {
     /// Samples that belong to the cycle resetting at `resets` — i.e. with
-    /// the stragglers from neighboring cycles dropped.
-    ///
-    /// Each sample carries its own `resetsAt`, so cycle membership is a
-    /// direct property of the row, not an inference from its timestamp.
-    /// A sample is in-cycle when its `resetsAt` matches `resets` (within
-    /// half a window — consecutive resets are always ≥ one window apart,
-    /// while a single cycle's `resets_at` only jitters by ~1s across
-    /// polls), or when it's `nil` (the server returns `resets_at: null`
-    /// for the post-reset 0%-used readings, before the new window
-    /// re-anchors on your next message).
+    /// the stragglers from neighboring cycles dropped. Membership is
+    /// `RateLimitCycle.contains` (jitter-tolerant, nil-keeping), the same
+    /// rule the scoped `UsageLimitSample` history uses.
     ///
     /// The chart consumers used to scope a cycle purely by timestamp
     /// (`sampledAt >= resets - duration`). Because the 7-day reset lands
@@ -98,10 +91,6 @@ public extension Sequence where Element == RateLimitSample {
     /// chart's left edge. Filtering on the sample's own reset removes it
     /// regardless of sub-second boundary jitter.
     func inCycle(resetting resets: Date, duration: TimeInterval) -> [RateLimitSample] {
-        let tolerance = duration / 2
-        return filter { sample in
-            guard let sampleReset = sample.resetsAt else { return true }
-            return abs(sampleReset.timeIntervalSince(resets)) < tolerance
-        }
+        filter { RateLimitCycle.contains(sampleReset: $0.resetsAt, resets: resets, duration: duration) }
     }
 }

--- a/PacerCore/Sources/PacerCore/Models/UsageLimitSample.swift
+++ b/PacerCore/Sources/PacerCore/Models/UsageLimitSample.swift
@@ -179,6 +179,27 @@ public extension Sequence where Element == UsageLimitSample {
             }
     }
 
+    /// One scoped window's rows for the cycle resetting at `resets`, ascending
+    /// by time — the actual-usage line for a `limits[]` identity, the scoped
+    /// mirror of `RateLimitSample.inCycle`.
+    ///
+    /// Both filters matter and both are easy to get wrong on their own:
+    ///
+    /// - **Identity.** Every poll writes one row per limit, so an unfiltered
+    ///   history interleaves every window's curve.
+    /// - **Cycle.** Membership goes through `RateLimitCycle.contains`, never
+    ///   `resetsAt ==`. The server's `resets_at` jitters by a few hundred
+    ///   milliseconds between polls, so exact equality matches only the rows
+    ///   that happen to share the newest row's millisecond — in practice one
+    ///   row — and the chart collapses to a single dot at "now".
+    func inCycle(identity: String, resetting resets: Date, duration: TimeInterval) -> [UsageLimitSample] {
+        filter {
+            $0.identity == identity
+                && RateLimitCycle.contains(sampleReset: $0.resetsAt, resets: resets, duration: duration)
+        }
+        .sorted { $0.sampledAt < $1.sampledAt }
+    }
+
     /// Rows that carry a *genuine* per-model / per-surface scope — i.e. a real
     /// scoped window (a "Fable" weekly cap) rather than an account-wide
     /// `session`/`weekly_all` row that merely duplicates the fixed 5h/7d hero

--- a/PacerCore/Sources/PacerUI/PaceChartData.swift
+++ b/PacerCore/Sources/PacerUI/PaceChartData.swift
@@ -1,0 +1,85 @@
+import Foundation
+import PacerCore
+
+/// Builders that turn stored samples into a `PaceChartView.Data` actual line.
+///
+/// Three surfaces draw this chart — the dashboard card, the compare-models
+/// modal, and the widget extension — and each used to carry its own copy of
+/// "filter to the current cycle, sort, synthesize a `now` tail". The copies
+/// drifted: the fixed-window ones filtered cycle membership through
+/// `inCycle` (jitter-tolerant) while every scoped copy used `resetsAt ==`,
+/// which matches roughly one row and collapses the scoped chart to a single
+/// dot. One builder per source, shared by all three consumers, is what keeps
+/// that from happening again.
+///
+/// The result is deliberately **projection-free**: the forecast overlay is
+/// layered by each consumer via `withProjection`, so the share image (which
+/// draws no forecast) and the live chart share this exact base.
+public extension PaceChartView.Data {
+
+    /// Current-cycle actual line for a fixed 5h/7d window from
+    /// `RateLimitSample` rows. `samples` may be in any order and may span
+    /// several cycles; the newest row picks the cycle.
+    static func cycle(
+        fixed samples: [RateLimitSample], duration: TimeInterval, now: Date
+    ) -> PaceChartView.Data? {
+        guard let latest = samples.max(by: { $0.sampledAt < $1.sampledAt }),
+              let resets = latest.resetsAt else { return nil }
+        return build(
+            points: samples
+                .inCycle(resetting: resets, duration: duration)
+                .map { (time: $0.sampledAt, value: $0.usedPercentage) },
+            latestUsed: latest.usedPercentage,
+            resetsAt: resets, duration: duration, now: now)
+    }
+
+    /// Current-cycle actual line for one scoped `limits[]` window from
+    /// `UsageLimitSample` rows. `row` is that identity's newest reading (the
+    /// latest-batch row that defines the column); `history` is any bag of
+    /// scoped rows — other identities and other cycles are filtered out here.
+    static func cycle(
+        scoped row: UsageLimitSample, history: [UsageLimitSample],
+        duration: TimeInterval, now: Date
+    ) -> PaceChartView.Data? {
+        guard let resets = row.resetsAt else { return nil }
+        return build(
+            points: history
+                .inCycle(identity: row.identity, resetting: resets, duration: duration)
+                .map { (time: $0.sampledAt, value: $0.percent) },
+            latestUsed: row.percent,
+            resetsAt: resets, duration: duration, now: now)
+    }
+
+    /// The same line with a forecast overlay attached. Consumers build the
+    /// projection themselves (from the live engine on the dashboard, from the
+    /// exported snapshot in the widget) and layer it on the shared base.
+    func withProjection(_ points: [Point], crossesFullAt: Date?) -> PaceChartView.Data {
+        PaceChartView.Data(
+            cycleStart: cycleStart, resetsAt: resetsAt, durationSeconds: durationSeconds,
+            points: self.points, usedPct: usedPct,
+            projection: points, projectionCrossesFullAt: crossesFullAt)
+    }
+
+    /// Clip to the cycle, sort ascending, and pin a tail at "now" so the line
+    /// tracks to the current time even when the newest poll is a few minutes
+    /// old. The tail is clamped to the reset: once `now > resetsAt` (cycle
+    /// over, no fresh sample yet) a point at `now` would fall outside the
+    /// chart's x domain.
+    private static func build(
+        points raw: [(time: Date, value: Double)], latestUsed: Double,
+        resetsAt: Date, duration: TimeInterval, now: Date
+    ) -> PaceChartView.Data {
+        let cycleStart = resetsAt.addingTimeInterval(-duration)
+        var points = raw
+            .filter { $0.time >= cycleStart && $0.time <= now }
+            .sorted { $0.time < $1.time }
+            .map { Point(time: $0.time, value: $0.value) }
+        let tailTime = min(now, resetsAt)
+        if points.last?.time != tailTime {
+            points.append(Point(time: tailTime, value: latestUsed))
+        }
+        return PaceChartView.Data(
+            cycleStart: cycleStart, resetsAt: resetsAt, durationSeconds: duration,
+            points: points, usedPct: latestUsed)
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/ScopedCycleHistoryTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/ScopedCycleHistoryTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import PacerCore
+@testable import PacerUI
+
+/// The scoped (`limits[]`) actual-usage line — cycle membership and the
+/// chart-data builder behind every per-model pace column.
+///
+/// Reproduces the failure captured on 2026-07-28: a "Fable" weekly column
+/// that plotted one dot at "now" instead of the cycle's curve, while the
+/// 5-hour and 7-day columns beside it drew fine. Two independent causes,
+/// one test suite:
+///
+///  1. **Exact-equality cycle membership.** The scoped path filtered
+///     `resetsAt == resets`. The server re-serializes `resets_at` per
+///     response and it jitters in the milliseconds, so of ~1,300 rows in the
+///     live store's current cycle, exactly one matched.
+///  2. **A flat row cap.** The scoped history query was capped at 600 rows
+///     shared across every limit the account reports. At the real cadence
+///     (~1 poll/min, one row per limit) that is about three hours — 2% of a
+///     seven-day window — so even with membership fixed the line would have
+///     drawn as a stub near "now".
+@Suite struct ScopedCycleHistoryTests {
+
+    private static let sevenDays: TimeInterval = 7 * 86400
+    private static let fable = "weekly_scoped|Fable|"
+
+    private func row(
+        _ sampledAt: Date, pct: Double, resets: Date?, identity: String = fable
+    ) -> UsageLimitSample {
+        UsageLimitSample(
+            sampledAt: sampledAt, identity: identity, kind: "weekly_scoped",
+            group: "weekly", label: "Fable", percent: pct, resetsAt: resets,
+            severity: "normal", isActive: true, modelDisplayName: "Fable", source: "oauth")
+    }
+
+    /// One realistic cycle: polled every 55 s with the `resets_at` jitter the
+    /// server actually emits, climbing monotonically.
+    private func jitteredCycle(
+        resets: Date, elapsed: TimeInterval, identity: String = fable
+    ) -> [UsageLimitSample] {
+        let cycleStart = resets.addingTimeInterval(-Self.sevenDays)
+        return stride(from: 0, to: elapsed, by: 55).enumerated().map { i, offset in
+            // Deterministic ±0.5 s wobble, distinct on essentially every row.
+            let jitter = Double((i &* 37) % 1000) / 1000.0 - 0.5
+            return row(cycleStart.addingTimeInterval(offset),
+                       pct: (offset / elapsed * 15).rounded(),
+                       resets: resets.addingTimeInterval(jitter),
+                       identity: identity)
+        }
+    }
+
+    // MARK: - Cycle membership
+
+    /// The core regression: sub-second reset jitter must not shrink a cycle.
+    @Test func keepsJitteredRowsExactEqualityWouldDrop() {
+        let resets = Date(timeIntervalSince1970: 2_000_000)
+        let history = jitteredCycle(resets: resets, elapsed: 1.5 * 86400)
+        let anchor = history.last!.resetsAt!
+
+        // What the old filter saw: the rows sharing the newest millisecond.
+        let exactMatches = history.filter { $0.resetsAt == anchor }
+        #expect(exactMatches.count < 5)          // ~1 of ~2,300
+
+        let kept = history.inCycle(identity: Self.fable, resetting: anchor, duration: Self.sevenDays)
+        #expect(kept.count == history.count)     // all of them
+    }
+
+    /// Other identities' rows share the table (one row per limit per poll) and
+    /// must never be interleaved into this window's line.
+    @Test func dropsOtherIdentities() {
+        let resets = Date(timeIntervalSince1970: 2_000_000)
+        let mine = jitteredCycle(resets: resets, elapsed: 6 * 3600)
+        let theirs = jitteredCycle(resets: resets, elapsed: 6 * 3600, identity: "weekly_all||")
+
+        let kept = (mine + theirs).inCycle(
+            identity: Self.fable, resetting: resets, duration: Self.sevenDays)
+        #expect(kept.count == mine.count)
+        #expect(kept.allSatisfy { $0.identity == Self.fable })
+    }
+
+    /// Same boundary rule as the fixed windows: the previous cycle's final
+    /// reading is excluded, the post-reset `resets_at: null` idle rows are not.
+    @Test func dropsPreviousCycleButKeepsNilResetIdleRows() {
+        let prevReset = Date(timeIntervalSince1970: 3_000_000)
+        let curReset = prevReset.addingTimeInterval(Self.sevenDays)
+        let straggler = row(prevReset.addingTimeInterval(0.034), pct: 82, resets: prevReset)
+        let idle = row(prevReset.addingTimeInterval(300), pct: 0, resets: nil)
+        let fresh = row(prevReset.addingTimeInterval(3600), pct: 5, resets: curReset)
+
+        let kept = [straggler, idle, fresh].inCycle(
+            identity: Self.fable, resetting: curReset, duration: Self.sevenDays)
+        #expect(kept.count == 2)
+        #expect(!kept.contains { $0.percent == 82 })
+    }
+
+    /// The line is plotted in time order regardless of how rows arrive (the
+    /// store hands them back newest-first).
+    @Test func returnsAscendingByTime() {
+        let resets = Date(timeIntervalSince1970: 4_000_000)
+        let history = jitteredCycle(resets: resets, elapsed: 3600).reversed()
+        let kept = Array(history).inCycle(
+            identity: Self.fable, resetting: resets, duration: Self.sevenDays)
+        #expect(kept == kept.sorted { $0.sampledAt < $1.sampledAt })
+    }
+
+    // MARK: - Chart data
+
+    /// End to end: a realistic jittered cycle becomes a real curve, spanning
+    /// cycle start → now, not a single point.
+    @Test func scopedChartPlotsWholeCycle() {
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        let elapsed = 1.55 * 86400
+        let resets = now.addingTimeInterval(Self.sevenDays - elapsed)
+        let history = jitteredCycle(resets: resets, elapsed: elapsed)
+        let latest = history.last!
+
+        let data = PaceChartView.Data.cycle(
+            scoped: latest, history: history, duration: Self.sevenDays, now: now)
+        let points = try! #require(data).points
+
+        // Every reading, none dropped, plus the tail pinned to "now" (the last
+        // poll landed a cadence-step short of it).
+        #expect(points.count == history.count + 1)
+        // Spans the elapsed cycle rather than clustering at the tail.
+        let span = points.last!.time.timeIntervalSince(points.first!.time)
+        #expect(span > elapsed - 120)
+        #expect(points.first!.time >= data!.cycleStart)
+        #expect(points.last!.time == now)        // pinned to now
+        #expect(data!.usedPct == latest.percent)
+    }
+
+    /// A window with no reading yet has no line (and no synthesized dot).
+    @Test func scopedChartNilWithoutReset() {
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        let idle = row(now, pct: 0, resets: nil)
+        #expect(PaceChartView.Data.cycle(
+            scoped: idle, history: [idle], duration: Self.sevenDays, now: now) == nil)
+    }
+
+    /// The fixed 5h/7d builder shares the same code path — same clipping,
+    /// same "now" tail — so the two window kinds can't drift apart again.
+    @Test func fixedChartMatchesScopedShape() {
+        let now = Date(timeIntervalSince1970: 6_000_000)
+        let resets = now.addingTimeInterval(3600)
+        let offsets: [TimeInterval] = Array(stride(from: -14340, to: 0, by: 300))
+        let samples: [RateLimitSample] = offsets.enumerated().map { i, offset in
+            let jitter: TimeInterval = Double((i &* 37) % 1000) / 1000.0 - 0.5
+            let used: Double = (offset + 14400) / 3600 * 8
+            return RateLimitSample(
+                sampledAt: now.addingTimeInterval(offset), window: "five_hour",
+                usedPercentage: used, resetsAt: resets.addingTimeInterval(jitter),
+                source: "oauth")
+        }
+        let data = try! #require(PaceChartView.Data.cycle(
+            fixed: samples.reversed(), duration: 5 * 3600, now: now))
+        #expect(data.points.count == samples.count + 1)   // + the "now" tail
+        #expect(data.points.last!.time == now)
+        #expect(data.points == data.points.sorted { $0.time < $1.time })
+    }
+
+    /// The forecast overlay is layered onto the shared base, leaving the
+    /// actual line (what the share image renders) untouched.
+    @Test func withProjectionLeavesActualLineAlone() {
+        let now = Date(timeIntervalSince1970: 7_000_000)
+        let resets = now.addingTimeInterval(Self.sevenDays * 0.5)
+        let history = jitteredCycle(resets: resets, elapsed: Self.sevenDays * 0.5)
+        let base = try! #require(PaceChartView.Data.cycle(
+            scoped: history.last!, history: history, duration: Self.sevenDays, now: now))
+
+        let overlay = [PaceChartView.Data.Point(time: now, value: 15),
+                       PaceChartView.Data.Point(time: resets, value: 40)]
+        let live = base.withProjection(overlay, crossesFullAt: nil)
+
+        #expect(live.points == base.points)
+        #expect(base.projection == nil)
+        #expect(live.projection?.count == 2)
+    }
+}

--- a/Widgets/PaceChartWidget.swift
+++ b/Widgets/PaceChartWidget.swift
@@ -199,22 +199,45 @@ struct PaceChartProvider: AppIntentTimelineProvider {
     /// ones (Decision C), and layers the engine's exported per-identity
     /// projection. Empty (⇒ every layout unchanged) when the account has none.
     private static func scopedStates(context: ModelContext, snapshot: EngineSnapshot?) -> [PaceChartEntry.ScopedState] {
-        // Recent scoped rows, newest first, bounded. Covers the latest batch
-        // (the column set) plus a short actual-line tail per identity.
-        var descriptor = FetchDescriptor<UsageLimitSample>(
+        // The latest poll's rows decide the column set — a small cap is all
+        // that's needed, since `latestBatch` only reads one poll's worth.
+        var latest = FetchDescriptor<UsageLimitSample>(
             sortBy: [SortDescriptor(\.sampledAt, order: .reverse)])
-        descriptor.fetchLimit = 600
-        guard let history = try? context.fetch(descriptor) else { return [] }
-        let batch = history.latestBatch().filter {
+        latest.fetchLimit = 120
+        guard let newest = try? context.fetch(latest) else { return [] }
+        let batch = newest.latestBatch().filter {
             ($0.modelId?.isEmpty == false)
                 || ($0.modelDisplayName?.isEmpty == false)
                 || ($0.surface?.isEmpty == false)
         }
         let outlookByIdentity = Dictionary(
             (snapshot?.scoped ?? []).map { ($0.identity, $0) }, uniquingKeysWith: { a, _ in a })
-        return batch.compactMap {
-            Self.scopedWindow(history: history, row: $0, outlook: outlookByIdentity[$0.identity])
+        // Then one bounded history fetch PER charted identity. Fetching a flat
+        // slice of the shared table instead (the old shape) spends the budget
+        // on whichever limits happen to be newest — with ~1 poll/min and a row
+        // per limit, 600 rows was about three hours of a seven-day window, so
+        // the line drew as a stub. Scoping by identity + cycle start bounds it
+        // by what's actually plotted.
+        return batch.compactMap { row in
+            Self.scopedWindow(
+                history: Self.scopedHistory(context: context, row: row),
+                row: row, outlook: outlookByIdentity[row.identity])
         }
+    }
+
+    /// One scoped identity's rows back to its cycle start, columnar — the four
+    /// scalars the actual line plots. `fetchLimit` is a burst backstop (a
+    /// stuck poller or a backfill shouldn't blow up widget memory), not a
+    /// coverage limit: at the real cadence a 7-day cycle holds ~11k rows.
+    private static func scopedHistory(context: ModelContext, row: UsageLimitSample) -> [UsageLimitSample] {
+        guard let resetsAt = row.resetsAt else { return [] }
+        let cutoff = resetsAt.addingTimeInterval(-WindowSpec.scopedDuration(group: row.group))
+        var d = FetchDescriptor<UsageLimitSample>(
+            predicate: #Predicate<UsageLimitSample> { $0.sampledAt >= cutoff },
+            sortBy: [SortDescriptor(\.sampledAt, order: .reverse)])
+        d.propertiesToFetch = [\.identity, \.sampledAt, \.resetsAt, \.percent]
+        d.fetchLimit = 20000
+        return (try? context.fetch(d)) ?? []
     }
 
     /// Used % for a window whose most-recent sample has no reset time —
@@ -251,18 +274,12 @@ struct PaceChartProvider: AppIntentTimelineProvider {
         guard let latest = windowRows.first, let resetsAt = latest.resetsAt else { return nil }
         let cycleStart = resetsAt.addingTimeInterval(-duration)
         let now = Date()
-        var points = windowRows
-            .inCycle(resetting: resetsAt, duration: duration)
-            .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= now }
-            .sorted { $0.sampledAt < $1.sampledAt }
-            .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.usedPercentage) }
-        // Clamp the synthesized tail to the cycle: once `now > resetsAt`
-        // (cycle ended, no fresh sample yet), a tail at `now` falls
-        // outside `chartXScale`'s domain.
+        guard let base = PaceChartView.Data.cycle(
+            fixed: windowRows, duration: duration, now: now) else { return nil }
+        // The synthesized tail is clamped to the cycle: once `now > resetsAt`
+        // (cycle ended, no fresh sample yet), a tail at `now` falls outside
+        // `chartXScale`'s domain.
         let tailTime = min(now, resetsAt)
-        if points.last?.time != tailTime {
-            points.append(.init(time: tailTime, value: latest.usedPercentage))
-        }
         // Attach the engine's trajectory only when it belongs to THIS cycle
         // (same reset, ±2 min) — a snapshot from a previous cycle would draw
         // a nonsense overlay — and clip it to the chart's domain.
@@ -288,15 +305,7 @@ struct PaceChartProvider: AppIntentTimelineProvider {
                 }
             }
         }
-        let chart = PaceChartView.Data(
-            cycleStart: cycleStart,
-            resetsAt: resetsAt,
-            durationSeconds: duration,
-            points: points,
-            usedPct: latest.usedPercentage,
-            projection: projection,
-            projectionCrossesFullAt: crossing
-        )
+        let chart = projection.map { base.withProjection($0, crossesFullAt: crossing) } ?? base
         return PaceChartEntry.WindowState(chart: chart, resetsAt: resetsAt)
     }
 
@@ -314,16 +323,9 @@ struct PaceChartProvider: AppIntentTimelineProvider {
         let duration = WindowSpec.scopedDuration(group: row.group)
         let cycleStart = resetsAt.addingTimeInterval(-duration)
         let now = Date()
-        var points = history
-            .filter { $0.identity == row.identity && $0.resetsAt == resetsAt
-                   && $0.sampledAt >= cycleStart && $0.sampledAt <= now }
-            .sorted { $0.sampledAt < $1.sampledAt }
-            .map { PaceChartView.Data.Point(time: $0.sampledAt, value: $0.percent) }
+        guard let base = PaceChartView.Data.cycle(
+            scoped: row, history: history, duration: duration, now: now) else { return nil }
         let tailTime = min(now, resetsAt)
-        if points.last?.time != tailTime {
-            points.append(.init(time: tailTime, value: row.percent))
-        }
-        guard !points.isEmpty else { return nil }
         var projection: [PaceChartView.Data.Point]?
         var crossing: Date?
         if let o = outlook?.outlook, abs(o.resetsUnix - resetsAt.timeIntervalSince1970) < 120 {
@@ -338,10 +340,7 @@ struct PaceChartProvider: AppIntentTimelineProvider {
                 if rebased.count >= 2 { projection = rebased; crossing = r.crossesFullAt }
             }
         }
-        let chart = PaceChartView.Data(
-            cycleStart: cycleStart, resetsAt: resetsAt, durationSeconds: duration,
-            points: points, usedPct: row.percent,
-            projection: projection, projectionCrossesFullAt: crossing)
+        let chart = projection.map { base.withProjection($0, crossesFullAt: crossing) } ?? base
         return PaceChartEntry.ScopedState(
             key: row.identity,
             label: row.label,


### PR DESCRIPTION
A per-model pace column (e.g. a **Fable** weekly cap) rendered as a single dot at "now" while the 5-hour and 7-day columns beside it drew full curves — on the dashboard, in the share image, in the compare-models modal, and in the widget.

Two independent causes, both scoped-only:

**1 · Cycle membership was `resetsAt ==`.** The server re-serializes `resets_at` on every response and the value jitters in the milliseconds. In the maintainer's live store that's **704 distinct reset instants across 1,338 rows of one Fable cycle**. Of the 200 Fable rows the dashboard had loaded, exactly **one** matched the newest row's timestamp — so the "history" was a single point with the synthesized `now` tail sitting on top of it. The fixed 5h/7d windows never hit this: they filter through `inCycle`, which has been jitter-tolerant since the 7-day boundary-straggler fix.

**2 · The scoped history query was capped at 600 rows** shared across every limit in the response. At the adaptive poll cadence (~1/min since #120) that's about **3 hours — 2% of a seven-day window** — so even with membership fixed, the line would have drawn as a stub near "now".

## What changed

- **One shared cycle rule.** `RateLimitCycle.contains` (within half a window, `nil` counts as in-cycle) is now the single definition, called by both `RateLimitSample.inCycle` and a new `UsageLimitSample.inCycle(identity:resetting:duration:)`.
- **One shared chart builder.** The four copies of "clip to cycle, sort, pin a `now` tail" collapse into `PaceChartView.Data.cycle(fixed:)` / `cycle(scoped:)` in PacerUI, with `withProjection` layering the forecast. The drift between the fixed and scoped copies is what let this ship in the first place.
- **Coverage bounded by time, not row count.** The dashboard splits its scoped query in two — a small whole-row query for the latest batch (which decides the column set) and a columnar 8-day query for the line. The widget fetches per identity back to its own cycle start. Cutoffs are computed per view init, not in a `static let` that would freeze at process start.

## Proof

New `PACER_SCREENSHOT_SCOPED_HISTORY_ONLY=1` scene seeds a scoped window the way the server actually reports it — ~1 poll/min with sub-second reset jitter. Every existing seeder uses tidy hourly rows with one fixed reset, which is exactly why the screenshots never caught this. The scene reproduces the lone dot on the parent commit and the full curve on this branch.

## Verification

- 648 tests pass (8 new, in `ScopedCycleHistoryTests` — including one asserting the old exact-equality filter matched <5 of ~2,300 rows).
- Installed locally; scan cycles 33–80 ms, unchanged against the ~100 ms documented p50, so the wider scoped query costs nothing measurable.
- README screenshots deliberately not regenerated: their seed has no reset jitter and sits under the old cap, so the rendered output is identical and a rerun would be timestamp churn only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSak6qppaVvekSsCm5JayR