### PR TITLE
Window placement, a subagent that knows what it is not, and a green CI

### DIFF
--- a/App/Background/DashboardWindowRegistrar.swift
+++ b/App/Background/DashboardWindowRegistrar.swift
@@ -1,0 +1,31 @@
+import AppKit
+import SwiftUI
+
+/// Tells `MainWindowPlacement` which `NSWindow` belongs to the dashboard
+/// scene, the moment the scene's content is put into one.
+///
+/// Everything else in the app identifies the dashboard by guessing —
+/// "can become main and isn't a panel" — and that guess is wrong for
+/// Settings, the About box, and Sparkle's update alert, each of which
+/// then got treated as the window whose position we restore and record.
+/// The scene knows the answer for free, so ask it.
+///
+/// `viewDidMoveToWindow` fires while the window is being built, before it
+/// is ordered on screen, which is earlier than any AppKit visibility
+/// notification — so the restore can happen before the user sees the
+/// window in the wrong place rather than after.
+struct DashboardWindowRegistrar: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { RegistrarView() }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class RegistrarView: NSView {
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard let window else { return }
+            MainActor.assumeIsolated {
+                MainWindowPlacement.register(window)
+            }
+        }
+    }
+}

--- a/App/Background/MainWindowPlacement.swift
+++ b/App/Background/MainWindowPlacement.swift
@@ -83,6 +83,12 @@ enum MainWindowPlacement {
 
     static func noteLaunch() {
         isEnabled = true
+        // The scene mounts before this runs — `register(_:)` is logged ahead
+        // of the launch path on every observed launch — so the adopt it
+        // attempted was gated off. Place the window the instant the gate
+        // opens rather than waiting for the sweep a runloop turn later,
+        // which is a turn with the window on screen at SwiftUI's frame.
+        if let window = dashboardWindow { adopt(window) }
     }
 
     // MARK: - Which window is the dashboard

--- a/App/Background/MainWindowPlacement.swift
+++ b/App/Background/MainWindowPlacement.swift
@@ -26,25 +26,100 @@ import PacerCore
 /// launch, and wrong for the case this exists to serve: a maintainer who
 /// keeps the dashboard on a second monitor and reinstalls a dozen times an
 /// hour should not lose it every time.
+///
+/// ## Three things that made the restore unreliable
+///
+/// **The hold was anchored to process launch.** Re-asserting our frame for
+/// three seconds after launch only covers a window that SwiftUI restores
+/// immediately. The window that comes back through `reopenIfPreviouslyOpen`
+/// cannot appear before launch + 1.5s and often lands after the three
+/// seconds are up — so on exactly the relaunch this feature exists for
+/// (install an update, app restarts), nothing re-asserted the frame and
+/// SwiftUI's own placement got the last word: wrong display, default size.
+/// The hold is now anchored to the window appearing.
+///
+/// **"Can become main and isn't a panel" is not a test for the dashboard.**
+/// Settings, the About box and Sparkle's update alert all pass it. Adopting
+/// one of those moved *that* window to the dashboard's parked frame, marked
+/// the dashboard as "already placed" for the rest of the launch, and let its
+/// frame be recorded as the dashboard's home. The scene tells us which
+/// window is really hers — see `register(_:)`.
+///
+/// **Windows were remembered by `ObjectIdentifier`.** That is an address.
+/// Close the dashboard and reopen it and the new `NSWindow` can land on the
+/// freed one's address, at which point we skip placing it because we think
+/// we already did. Identity is now held weakly, so a dead window cannot
+/// vouch for a live one.
 @MainActor
 enum MainWindowPlacement {
     private static let frameKey = "PacerMainWindowFrame"
     private static let wasOpenKey = "PacerMainWindowWasOpen"
 
-    /// How long after launch to ignore window moves.
+    /// Arbitrates which moves are the user parking the window. See
+    /// `WindowPlacementGate` for why this is a clock and not a flag.
+    private static var gate = WindowPlacementGate()
+
+    /// The dashboard, once anything has positively identified it.
     ///
-    /// SwiftUI places the restored window during this period, and those moves
-    /// are not the user's intent — recording them is exactly how the stored
-    /// frame got corrupted before. Anything later is a real move.
-    private static let settleWindow: TimeInterval = 3.0
+    /// Weak on purpose: when the dashboard is closed the window is
+    /// deallocated, and holding it strongly (or by address) is how a dead
+    /// window ends up answering for a live one.
+    private static weak var dashboardWindow: NSWindow?
 
-    private static var launchedAt = Date()
-    private static var isApplying = false
+    /// Whether `dashboardWindow` has been put where the user left it.
+    /// Reset whenever a different window becomes the dashboard.
+    private static var hasPlacedDashboard = false
 
-    static func noteLaunch() { launchedAt = Date() }
+    /// False until the app reaches its normal launch path.
+    ///
+    /// The screenshot renderer, cold-start probe, archive round-trip and
+    /// account-assign modes all render real scenes in a second process of
+    /// the same bundle and exit before `noteLaunch()`. None of them should
+    /// move a window onto the user's display or record what their throwaway
+    /// window did. Gating on "did we get to the real launch" rather than
+    /// enumerating the modes keeps this from rotting the next time one is
+    /// added — the mode list already has to be kept in sync in two places.
+    private static var isEnabled = false
 
-    private static var isSettling: Bool {
-        Date().timeIntervalSince(launchedAt) < settleWindow
+    static func noteLaunch() {
+        isEnabled = true
+    }
+
+    // MARK: - Which window is the dashboard
+
+    /// The dashboard scene telling us which `NSWindow` is actually hers.
+    ///
+    /// Called from `DashboardWindowRegistrar`, mounted in the scene's view
+    /// tree, so this is exact by construction and lands the moment the
+    /// content view is put into a window — earlier than any of AppKit's
+    /// visibility notifications, which is the point.
+    static func register(_ window: NSWindow) {
+        if dashboardWindow !== window {
+            dashboardWindow = window
+            hasPlacedDashboard = false
+            Log.write("Placement", "dashboard is \(describe(window))")
+        }
+        adopt(window)
+    }
+
+    /// Is this the dashboard?
+    ///
+    /// Identity when we have it. Before the scene has mounted — the launch
+    /// sweep runs then — fall back to the marks SwiftUI puts on its own
+    /// window. Both `main…` (the scene id) and `Pacer.ContentView…` have
+    /// been observed across macOS releases; Settings (`com_apple_SwiftUI_
+    /// Settings_window`), About (`about`) and Sparkle (`SUUpdateAlert2`)
+    /// are excluded by the same test, which is the whole reason it is a
+    /// name match and not a class test.
+    static func isDashboard(_ window: NSWindow) -> Bool {
+        if let known = dashboardWindow { return window === known }
+        guard window.canBecomeMain, !(window is NSPanel) else { return false }
+        let marks = [window.identifier?.rawValue, window.frameAutosaveName]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+        return marks.contains {
+            $0 == "main" || $0.hasPrefix("main-") || $0.hasPrefix("Pacer.ContentView")
+        }
     }
 
     // MARK: - Stored state
@@ -83,72 +158,147 @@ enum MainWindowPlacement {
         return NSScreen.screens.contains { $0.visibleFrame.intersects(frame) }
     }
 
-    /// Take a window off AppKit's autosave and put it where the user left it.
+    /// Take the dashboard off AppKit's autosave and put it where the user
+    /// left it.
     ///
     /// Clearing `frameAutosaveName` is the load-bearing half: it stops
     /// AppKit writing a frame we did not choose, which is what corrupted
     /// every previous attempt.
     static func adopt(_ window: NSWindow) {
-        guard window.canBecomeMain, !(window is NSPanel) else { return }
+        guard isEnabled, isDashboard(window) else { return }
+        if dashboardWindow !== window {
+            dashboardWindow = window
+            hasPlacedDashboard = false
+        }
         if !window.frameAutosaveName.isEmpty {
             window.setFrameAutosaveName("")
         }
         // Position it once. Re-applying on every becomes-key would fight the
         // user the moment they moved the window, and moves a window while a
         // menu may be open — see `holdPlacement`.
-        guard !adopted.contains(ObjectIdentifier(window)) else { return }
-        adopted.insert(ObjectIdentifier(window))
-        apply(to: window)
+        guard !hasPlacedDashboard else { return }
+        hasPlacedDashboard = true
+        gate.noteWindowAppeared()
+        apply(to: window, reason: "adopt")
     }
-
-    /// Windows already positioned this launch.
-    private static var adopted: Set<ObjectIdentifier> = []
 
     /// Apply the stored frame, if we have a usable one and the window isn't
     /// already there.
-    static func apply(to window: NSWindow) {
-        guard let frame = storedFrame, isUsable(frame) else { return }
+    static func apply(to window: NSWindow, reason: String) {
+        guard isEnabled, isDashboard(window) else { return }
+        guard let frame = storedFrame else { return }
+        guard isUsable(frame) else {
+            // A display that has not come back yet. Leaving the window alone
+            // beats dragging it somewhere arbitrary — and critically, the
+            // stored frame is left untouched so it still points home when
+            // the display returns.
+            Log.write("Placement", "\(reason): \(fmt(frame)) is on no connected display — leaving it")
+            return
+        }
         guard window.frame != frame else { return }
-        isApplying = true
+        let from = window.frame
+        gate.noteProgrammaticMove()
         window.setFrame(frame, display: true)
-        isApplying = false
+        Log.write("Placement", "\(reason): \(fmt(from)) → \(fmt(frame))")
     }
 
     /// Record a move the user actually made.
     static func record(_ window: NSWindow) {
-        guard window.canBecomeMain, !(window is NSPanel) else { return }
-        guard !isApplying, !isSettling else { return }
+        guard isEnabled, isDashboard(window), window.isVisible else { return }
+        let userDriven = isUserDrivenMove()
+        guard gate.shouldRecordMove(userDriven: userDriven) else { return }
         guard isUsable(window.frame) else { return }
+        if userDriven { gate.noteUserParked() }
+        guard window.frame != storedFrame else {
+            wasOpen = true
+            return
+        }
         storedFrame = window.frame
         wasOpen = true
+        Log.write("Placement", "parked at \(fmt(window.frame))")
     }
 
-    /// Re-assert placement across the launch settle window, so SwiftUI's own
-    /// restore cannot get the last word.
+    /// Is the user's hand on this move?
     ///
-    /// **Only while settling.** This is called from `didBecomeKey`, which
-    /// fires every time the user clicks into the window — so without the
-    /// guard, every click scheduled five `setFrame` calls over the next two
-    /// seconds. Open a dropdown and one of them lands *while the menu is up*,
-    /// moving the window out from under an anchor the menu had already
-    /// resolved; the menu then draws against stale geometry, which is how
-    /// every popup in the app ended up in a screen corner. It was
-    /// intermittent because whether a `setFrame` fell inside the menu's
-    /// lifetime depended on how fast you clicked, and it sometimes
-    /// self-corrected because a later one triggered a reposition.
+    /// A window being dragged sits in a continuous run of mouse-drag events,
+    /// so the event AppKit is currently dispatching still says so one
+    /// main-actor hop later, when the move is judged. This is a positive
+    /// signal only — "no mouse event" means keyboard, zoom, Stage Manager or
+    /// a restore, all of which the clock already handles correctly.
+    private static func isUserDrivenMove() -> Bool {
+        switch NSApp.currentEvent?.type {
+        case .leftMouseDragged, .leftMouseUp, .leftMouseDown: return true
+        default: return false
+        }
+    }
+
+    /// Re-assert placement while a newly appeared window is still being
+    /// placed, so SwiftUI's own restore cannot get the last word.
+    ///
+    /// **Only while it is being placed** — the grace is anchored to the
+    /// window appearing and lasts a couple of seconds. This is called from
+    /// `didBecomeKey`, which fires every time the user clicks into the
+    /// window, so without the bound every click scheduled five `setFrame`
+    /// calls over the next two seconds. Open a dropdown and one of them
+    /// lands *while the menu is up*, moving the window out from under an
+    /// anchor the menu had already resolved; the menu then draws against
+    /// stale geometry, which is how every popup in the app ended up in a
+    /// screen corner. It was intermittent because whether a `setFrame` fell
+    /// inside the menu's lifetime depended on how fast you clicked, and it
+    /// sometimes self-corrected because a later one triggered a reposition.
     ///
     /// Re-asserting a frame is only needed to win a race against SwiftUI's
-    /// restore at launch. After that the window belongs to the user.
+    /// restore. After that the window belongs to the user.
     static func holdPlacement(for window: NSWindow) {
-        guard isSettling else { return }
+        guard isEnabled, isDashboard(window), gate.isPlacingNewWindow() else { return }
         for delay in [0.0, 0.15, 0.4, 1.0, 2.0] {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 MainActor.assumeIsolated {
-                    guard isSettling else { return }
-                    apply(to: window)
+                    guard gate.isPlacingNewWindow() else { return }
+                    apply(to: window, reason: "hold")
                 }
             }
         }
+    }
+
+    /// The set of displays changed — one woke, slept, was plugged in, or the
+    /// arrangement moved.
+    ///
+    /// Two jobs. Stop recording for a few seconds, because AppKit is about
+    /// to shove every window onto whatever screens currently exist and none
+    /// of that is the user's intent. Then put the dashboard back, because
+    /// the display it lives on may be the one that just returned.
+    static func noteDisplayConfigurationChanged() {
+        guard isEnabled else { return }
+        gate.noteDisplayConfigurationChanged()
+        Log.write("Placement", "displays changed: \(NSScreen.screens.count) connected")
+        for delay in [0.5, 2.0, 4.0] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                MainActor.assumeIsolated {
+                    guard let window = dashboardWindow, window.isVisible else { return }
+                    apply(to: window, reason: "displays changed")
+                }
+            }
+        }
+    }
+
+    /// Put the window back on a connected display, if it is on none.
+    ///
+    /// Prefers home over centering: the stored frame is usable again the
+    /// moment its display comes back, and centering on the built-in screen
+    /// is a consolation prize. Either way the move is ours, not the user's,
+    /// so the stored frame survives it.
+    static func rescueIfOffscreen(_ window: NSWindow) {
+        guard isEnabled, isDashboard(window) else { return }
+        guard !NSScreen.screens.contains(where: { $0.visibleFrame.intersects(window.frame) })
+        else { return }
+        if let frame = storedFrame, isUsable(frame) {
+            apply(to: window, reason: "offscreen rescue")
+            return
+        }
+        gate.noteProgrammaticMove()
+        window.center()
+        Log.write("Placement", "offscreen rescue: centered at \(fmt(window.frame))")
     }
 
     /// Bring the dashboard back if it was open when we were last quit,
@@ -166,9 +316,9 @@ enum MainWindowPlacement {
         // running. Waiting for launch to finish is what makes it take.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
             MainActor.assumeIsolated {
-                guard !NSApp.windows.contains(where: {
-                    $0.canBecomeMain && !($0 is NSPanel) && $0.isVisible
-                }) else { return }
+                guard !NSApp.windows.contains(where: { isDashboard($0) && $0.isVisible })
+                else { return }
+                Log.write("Placement", "reopening the dashboard it was quit with")
                 let configuration = NSWorkspace.OpenConfiguration()
                 configuration.activates = false
                 configuration.createsNewApplicationInstance = false
@@ -181,5 +331,17 @@ enum MainWindowPlacement {
                 }
             }
         }
+    }
+
+    // MARK: - Logging
+
+    private static func fmt(_ r: NSRect) -> String {
+        "\(Int(r.origin.x)),\(Int(r.origin.y)) \(Int(r.size.width))×\(Int(r.size.height))"
+    }
+
+    private static func describe(_ window: NSWindow) -> String {
+        let id = window.identifier?.rawValue ?? "-"
+        let autosave = window.frameAutosaveName.isEmpty ? "-" : window.frameAutosaveName
+        return "id=\(id) autosave=\(autosave) frame=\(fmt(window.frame))"
     }
 }

--- a/App/Background/MainWindowPlacement.swift
+++ b/App/Background/MainWindowPlacement.swift
@@ -70,6 +70,16 @@ enum MainWindowPlacement {
     /// Reset whenever a different window becomes the dashboard.
     private static var hasPlacedDashboard = false
 
+    /// The window closed at launch because the user had closed the dashboard
+    /// before quitting.
+    ///
+    /// The launch sweep runs afterwards and would otherwise adopt it — which
+    /// moves a window nobody can see, and worse, marks the dashboard as
+    /// already placed for the rest of the launch. Weak, so that when the user
+    /// does ask for the dashboard the new window is a different object and
+    /// gets placed normally.
+    private static weak var closedAtLaunch: NSWindow?
+
     /// False until the app reaches its normal launch path.
     ///
     /// The screenshot renderer, cold-start probe, archive round-trip and
@@ -85,10 +95,36 @@ enum MainWindowPlacement {
         isEnabled = true
         // The scene mounts before this runs — `register(_:)` is logged ahead
         // of the launch path on every observed launch — so the adopt it
-        // attempted was gated off. Place the window the instant the gate
-        // opens rather than waiting for the sweep a runloop turn later,
-        // which is a turn with the window on screen at SwiftUI's frame.
-        if let window = dashboardWindow { adopt(window) }
+        // attempted was gated off. Act the instant the gate opens rather
+        // than waiting for the sweep a runloop turn later, which is a turn
+        // with the window on screen at SwiftUI's frame.
+        guard let window = dashboardWindow else { return }
+        guard wasOpenWhenQuit else {
+            // SwiftUI's `Window` scene materializes its window on every
+            // launch, unconditionally — verified here: the scene registers
+            // its NSWindow before `applicationDidFinishLaunching` finishes,
+            // with no saved-application-state directory involved. For a
+            // menu-bar agent that is the wrong default. Logging in at the
+            // start of the day should not put a dashboard on screen that
+            // you closed before you shut down.
+            //
+            // So the open/closed half of the window's state is restored by
+            // hand, the same way its frame is. `reopenIfPreviouslyOpen` is
+            // the other half and never fires in practice, because SwiftUI
+            // always beats it to the window; it stays as the safety net for
+            // a macOS release where the scene does not.
+            //
+            // Closed here rather than anywhere later on purpose: this runs
+            // once, at launch, before the window observers exist, so it
+            // cannot close a window the user has asked for. If a future
+            // macOS creates the window after this point we simply miss it
+            // and the dashboard shows — the harmless direction to fail.
+            Log.write("Placement", "dashboard was closed when we were quit — closing SwiftUI's")
+            closedAtLaunch = window
+            window.close()
+            return
+        }
+        adopt(window)
     }
 
     // MARK: - Which window is the dashboard
@@ -151,17 +187,37 @@ enum MainWindowPlacement {
 
     static var wasOpen: Bool {
         get { UserDefaults.standard.bool(forKey: wasOpenKey) }
-        set { UserDefaults.standard.set(newValue, forKey: wasOpenKey) }
+        set {
+            if wasOpenAtStart == nil {
+                wasOpenAtStart = UserDefaults.standard.bool(forKey: wasOpenKey)
+            }
+            UserDefaults.standard.set(newValue, forKey: wasOpenKey)
+        }
     }
+
+    /// The value this process started with, snapshotted by the first write.
+    private static var wasOpenAtStart: Bool?
+
+    /// Was the dashboard open when we were last quit?
+    ///
+    /// Deliberately not just a read of `wasOpen`: the window observers set
+    /// that true the moment the window becomes visible, which happens on
+    /// this same launch. Today `noteLaunch()` runs before those observers
+    /// are installed, so a plain read would be correct — but that is an
+    /// accident of one function's layout, and if it ever flips the failure
+    /// is silent and the dashboard decides it was open when it was not.
+    /// Snapshotting on first write is order-independent.
+    static var wasOpenWhenQuit: Bool { wasOpenAtStart ?? wasOpen }
 
     // MARK: - Applying
 
-    /// A frame worth restoring: on a connected screen, and not collapsed to
-    /// a sliver. Both failures end with the user staring at nothing, so
-    /// neither is worth obeying.
+    /// A frame worth restoring: enough of it lands on one connected screen
+    /// to be worth looking at, and it is not collapsed to a sliver. Both
+    /// failures end with the user staring at nothing, so neither is worth
+    /// obeying. See `WindowPlacementFit` for why "touches a screen" is not
+    /// the same question.
     static func isUsable(_ frame: NSRect) -> Bool {
-        guard frame.width >= 480, frame.height >= 320 else { return false }
-        return NSScreen.screens.contains { $0.visibleFrame.intersects(frame) }
+        WindowPlacementFit.isRestorable(frame, onAnyOf: NSScreen.screens.map(\.visibleFrame))
     }
 
     /// Take the dashboard off AppKit's autosave and put it where the user
@@ -171,7 +227,7 @@ enum MainWindowPlacement {
     /// AppKit writing a frame we did not choose, which is what corrupted
     /// every previous attempt.
     static func adopt(_ window: NSWindow) {
-        guard isEnabled, isDashboard(window) else { return }
+        guard isEnabled, isDashboard(window), window !== closedAtLaunch else { return }
         if dashboardWindow !== window {
             dashboardWindow = window
             hasPlacedDashboard = false
@@ -316,7 +372,7 @@ enum MainWindowPlacement {
     /// triggers `applicationShouldHandleReopen` — but with `activates = false`
     /// so it does not pull the user out of whatever they are in.
     static func reopenIfPreviouslyOpen() {
-        guard wasOpen else { return }
+        guard wasOpenWhenQuit else { return }
         // Deferred: asking AppKit to reopen us *during* our own launch is a
         // no-op — the reopen path only fires for an app it considers already
         // running. Waiting for launch to finish is what makes it take.

--- a/App/Background/PacerAppDelegate.swift
+++ b/App/Background/PacerAppDelegate.swift
@@ -426,11 +426,16 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // installed — the ordering is not guaranteed, and a missed window
         // keeps SwiftUI's per-instance autosave name for the whole session.
         Task { @MainActor in
-            for window in NSApp.windows where window.canBecomeMain && !(window is NSPanel) {
-                Self.ensureWindowAutosaves(window)
-                Self.ensureWindowOnScreen(window)
+            for window in NSApp.windows where MainWindowPlacement.isDashboard(window) {
+                Self.placeDashboardWindow(window)
             }
         }
+
+        // A display waking after the Mac did, or a dock being unplugged,
+        // makes AppKit shove every window onto whatever screens exist right
+        // now. Those moves are not the user's, and recording one as the
+        // dashboard's home is permanent — every later launch restores it.
+        Self.observeDisplayChanges()
 
         NotificationCoordinator.shared.clearCollectionPausedNotification()
         // If the bundle was just replaced under us (Sparkle auto-update
@@ -544,9 +549,8 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 // `.accessory` mid-creation and the dashboard never
                 // appeared at all. Policy stays owned by the key/close
                 // observers, which fire once the window's state is settled.
-                Self.ensureWindowAutosaves(window)
-                Self.ensureWindowOnScreen(window)
-                if window.canBecomeMain, !(window is NSPanel), window.isVisible {
+                Self.placeDashboardWindow(window)
+                if MainWindowPlacement.isDashboard(window), window.isVisible {
                     MainWindowPlacement.wasOpen = true
                 }
             }
@@ -566,13 +570,19 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 guard let self else { return }
                 self.applyActivationPolicyForCurrentWindows()
                 if let window {
-                    Self.ensureWindowAutosaves(window)
-                    Self.ensureWindowOnScreen(window)
+                    Self.placeDashboardWindow(window)
                     // Cold-open reseat: a window we asked AppKit to
                     // materialize (closed dashboard → reopened from the
                     // menu bar) just became key. Move it onto the screen
                     // the user opened us from, then clear the one-shot
                     // hint so ordinary refocus events never relocate it.
+                    //
+                    // Only ever a fallback. `ensureMainWindowVisible` leaves
+                    // this hint unset when there is a frame the user parked,
+                    // because following the cursor across displays would drag
+                    // the window off the monitor they keep it on — and the
+                    // move observer then records that as the new home, which
+                    // is how a parked position gets lost for good.
                     if let screen = self.pendingActiveScreen {
                         self.pendingActiveScreen = nil
                         Self.reposition(window, onto: screen)
@@ -603,7 +613,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 self?.applyActivationPolicyForCurrentWindows()
                 // A dashboard the user closed should stay closed across a
                 // relaunch — only one they left open comes back.
-                if let window, window.canBecomeMain, !(window is NSPanel) {
+                if let window, MainWindowPlacement.isDashboard(window) {
                     MainWindowPlacement.wasOpen = false
                 }
             }
@@ -614,30 +624,42 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         windowObservers.append(contentsOf: [didBecomeKey, willClose])
     }
 
-    /// Fallback AppKit autosave name we install when SwiftUI didn't
-    /// already give the main window one. Most builds will use whatever
-    /// `Window("Pacer", id: "main")` produces; this is just the safety
-    /// net for the dev-build case where SwiftUI sometimes leaves the
-    /// property empty.
-    private static let mainWindowAutosaveName = "PacerMainWindow"
-
-    /// SwiftUI's `Window` scene typically auto-sets a non-empty
-    /// `frameAutosaveName` from the scene id — but the exact behavior
-    /// has shifted across macOS releases and at least one Sequoia
-    /// point release left it empty in dev builds. Install a fallback
-    /// name when that happens so frame size + position reliably
-    /// persist across launches.
+    /// Put the dashboard where the user left it, and keep it there while
+    /// SwiftUI finishes placing it.
     ///
-    /// Also pins the menu-bar-app collection behavior. Both `Window`
-    /// scene's `.defaultPosition(.center)` and `.defaultSize(...)`
-    /// modifiers handle first-launch placement on the SwiftUI side,
-    /// so this function doesn't touch the frame.
-    private static func ensureWindowAutosaves(_ window: NSWindow) {
-        // Placement is owned by `MainWindowPlacement`, not AppKit autosave —
-        // see that type for why sharing the mechanism with SwiftUI could not
-        // be made to work.
+    /// Placement is owned by `MainWindowPlacement`, not AppKit autosave —
+    /// see that type for why sharing the mechanism with SwiftUI could not
+    /// be made to work, and why the hold is bounded.
+    ///
+    /// Safe to call for any window: everything below is a no-op unless the
+    /// window is actually the dashboard.
+    private static func placeDashboardWindow(_ window: NSWindow) {
         MainWindowPlacement.adopt(window)
         MainWindowPlacement.holdPlacement(for: window)
+        MainWindowPlacement.rescueIfOffscreen(window)
+    }
+
+    /// Watch for displays coming and going.
+    ///
+    /// Two things go wrong without this. AppKit relocates windows onto the
+    /// screens that exist at that instant, and the move observer recorded
+    /// the result as the user's parked frame. And a dashboard parked on a
+    /// monitor that is asleep at launch has nowhere to be restored to — it
+    /// needs putting back once that monitor returns.
+    private static func observeDisplayChanges() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            // `Task { @MainActor }` rather than `assumeIsolated`, matching the
+            // other observers here: the two toolchains in play disagree about
+            // the isolation of a notification-observer closure, and this shape
+            // compiles the same under both.
+            Task { @MainActor in
+                MainWindowPlacement.noteDisplayConfigurationChanged()
+            }
+        }
     }
 
     /// Make the main window behave like a tool window for a menu-bar
@@ -693,17 +715,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     /// post-display-disconnect setups it lands on whatever screen
     /// macOS has elected as primary, which is exactly where the user
     /// is working from after their secondary went away.
-    private static func ensureWindowOnScreen(_ window: NSWindow) {
-        // Skip auxiliary windows (panels, menu-bar popover host) — only
-        // the main "Pacer" window needs reseating.
-        guard window.canBecomeMain, !(window is NSPanel) else { return }
-        let onSomeScreen = NSScreen.screens.contains { screen in
-            screen.visibleFrame.intersects(window.frame)
-        }
-        guard !onSomeScreen else { return }
-        window.center()
-        window.saveFrame(usingName: window.frameAutosaveName)
-    }
+
 
     /// The screen the user is currently working on — the one whose menu
     /// bar they just clicked, or where the cursor sits when the global
@@ -1037,7 +1049,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // async runs — the cursor may drift afterward.
         let target = Self.activeScreen()
         NSApp.activate()
-        if let window = NSApp.windows.first(where: { $0.canBecomeMain && !($0 is NSPanel) }) {
+        if let window = NSApp.windows.first(where: { MainWindowPlacement.isDashboard($0) }) {
             // Pin the menu-bar-app collection behavior BEFORE
             // `makeKeyAndOrderFront` so the very first activation
             // already pulls the window to the current Space rather
@@ -1060,7 +1072,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             // frame. So: stored placement first, cursor only as the fallback.
             if let stored = MainWindowPlacement.storedFrame,
                MainWindowPlacement.isUsable(stored) {
-                MainWindowPlacement.apply(to: window)
+                MainWindowPlacement.apply(to: window, reason: "menu-bar open")
             } else if let target {
                 Self.reposition(window, onto: target)
             }
@@ -1069,7 +1081,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             // Re-assert after ordering front: AppKit can nudge a window as it
             // comes forward, and this is the gesture where being a few points
             // off is most visible.
-            MainWindowPlacement.apply(to: window)
+            MainWindowPlacement.apply(to: window, reason: "menu-bar open")
             // Scoped to this gesture only — see `releaseMenuBarAppBehavior`.
             Self.releaseMenuBarAppBehavior(window)
             return true
@@ -1077,7 +1089,18 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // Cold open: the window doesn't exist yet and will materialize
         // asynchronously via the reopen flow below. Stash the target
         // screen so `didBecomeKey` reseats the new window onto it once.
-        pendingActiveScreen = target
+        //
+        // Unless the user has parked the window somewhere, in which case
+        // there is nothing to decide and following the cursor is actively
+        // wrong: it drags the dashboard off the monitor it lives on, and
+        // the move observer then records the arrival as the new home. That
+        // is not hypothetical — it is how a window parked on the bottom of
+        // a portrait display ends up pinned to a corner of another one,
+        // permanently, because the clamp that fits it onto the new screen
+        // lands on the screen's own origin.
+        let hasParkedFrame = MainWindowPlacement.storedFrame
+            .map(MainWindowPlacement.isUsable) ?? false
+        pendingActiveScreen = hasParkedFrame ? nil : target
         // No window exists. With `LSUIElement=true` and a SwiftUI
         // `Window("Pacer", id: "main")` scene, closing the dashboard
         // tears the window down — the scene is still in memory but no
@@ -1118,7 +1141,7 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     /// expectation for menu-bar app shortcuts (1Password, Raycast,
     /// Bartender all do this).
     private func toggleMainWindow() {
-        let mainWindow = NSApp.windows.first { $0.canBecomeMain && !($0 is NSPanel) }
+        let mainWindow = NSApp.windows.first { MainWindowPlacement.isDashboard($0) }
         if let window = mainWindow,
            window.isKeyWindow,
            window.isVisible,

--- a/App/Background/PacerAppDelegate.swift
+++ b/App/Background/PacerAppDelegate.swift
@@ -83,17 +83,6 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // is main-actor isolated, matching the inner Task.
     private var menuBarLastChipsEmpty: Bool = false
 
-    /// One-shot screen hint for the cold-open path. When the user opens
-    /// Pacer from the menu bar / hotkey but the window scene was torn
-    /// down (closed dashboard → SwiftUI `Window` destroys its NSWindow),
-    /// we can't reposition the window synchronously — it doesn't exist
-    /// yet. We capture the screen the gesture happened on here and let
-    /// the `didBecomeKey` observer reseat the freshly-materialized
-    /// window onto it exactly once. Captured at gesture time (not read
-    /// in the observer) because the cursor may drift between the click
-    /// and the async window creation.
-    private var pendingActiveScreen: NSScreen?
-
     override init() {
         // Screenshot/demo mode: never touch the user's real store, logs,
         // or the single-instance gate (we may be running alongside a live
@@ -571,22 +560,6 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 self.applyActivationPolicyForCurrentWindows()
                 if let window {
                     Self.placeDashboardWindow(window)
-                    // Cold-open reseat: a window we asked AppKit to
-                    // materialize (closed dashboard → reopened from the
-                    // menu bar) just became key. Move it onto the screen
-                    // the user opened us from, then clear the one-shot
-                    // hint so ordinary refocus events never relocate it.
-                    //
-                    // Only ever a fallback. `ensureMainWindowVisible` leaves
-                    // this hint unset when there is a frame the user parked,
-                    // because following the cursor across displays would drag
-                    // the window off the monitor they keep it on — and the
-                    // move observer then records that as the new home, which
-                    // is how a parked position gets lost for good.
-                    if let screen = self.pendingActiveScreen {
-                        self.pendingActiveScreen = nil
-                        Self.reposition(window, onto: screen)
-                    }
                 }
             }
         }
@@ -662,113 +635,59 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
     }
 
-    /// Make the main window behave like a tool window for a menu-bar
-    /// agent app: when the user activates Pacer (clicks the status
-    /// item, hits the global shortcut, ⌘-Tabs to it), the window
-    /// follows them to the active Space rather than yanking them via
-    /// Mission Control to whichever Space it was last left on.
+    /// Summoning the dashboard takes you to it. It does not come to you.
     ///
-    /// `.moveToActiveSpace` is exactly the right knob for this — it
-    /// only fires on app activation, doesn't make the window appear
-    /// on every Space at once, and doesn't fight Spaces assignment
-    /// for users who pin windows to specific Spaces. It matches what
-    /// 1Password / Things / Raycast / Bartender / etc. all do.
+    /// The window belongs where the user put it — on a display, on a Space.
+    /// Both mechanisms that used to override that are gone:
+    /// `reposition(_:onto:)` moved it to whichever display the cursor was
+    /// on, and `.moveToActiveSpace` moved it to whichever Space you were
+    /// looking at. Each was a deliberate choice (#37 and the menu-bar
+    /// rework) made before Pacer remembered a parked frame at all;
+    /// together they meant a window kept on a second monitor could not
+    /// stay there.
     ///
-    /// We `.insert` rather than assign so we preserve whatever defaults
-    /// AppKit/SwiftUI already set (most importantly `.managed`, which
-    /// is what lets the window participate in Mission Control / Stage
-    /// Manager normally).
-    private static func applyMenuBarAppBehavior(_ window: NSWindow) {
-        window.collectionBehavior.insert(.moveToActiveSpace)
-    }
-
-    /// Undo `applyMenuBarAppBehavior` once the window has been brought
-    /// across.
+    /// Without `.moveToActiveSpace`, AppKit's documented default is the
+    /// behaviour we now want — ordering the window front switches you to
+    /// the Space it is on — so the primary path asks for nothing special.
     ///
-    /// `.moveToActiveSpace` is not a property of the *gesture*, it is a
-    /// property of the *window* — so leaving it applied means the window
-    /// follows onto the active Space every time it is shown, including on
-    /// the relaunch after a dev install, which is nobody's intent. Pairing
-    /// each apply with a removal keeps the behavior scoped to the moment
-    /// the user asked for the window, and lets it otherwise belong to the
-    /// Space and display they left it on.
+    /// **The safety net.** That switch is also subject to a system
+    /// preference: Desktop & Dock → Mission Control → "When switching to
+    /// an application, switch to a Space with open windows for the
+    /// application" (`AppleSpacesSwitchOnActivate`, off on at least one
+    /// machine that runs this). With it off macOS may decline to follow
+    /// the window, and the failure mode is the worst one available — you
+    /// click the menu bar and nothing appears to happen. So check, and if
+    /// the window is still somewhere you cannot see, bring it over rather
+    /// than leave you staring at nothing.
     ///
-    /// Removal is deferred one runloop turn so it lands after AppKit has
-    /// finished ordering the window front; clearing it synchronously can
-    /// race the move it was meant to cause. Once the window is on a Space,
-    /// dropping the behavior does not move it back.
-    private static func releaseMenuBarAppBehavior(_ window: NSWindow) {
-        DispatchQueue.main.async {
-            window.collectionBehavior.remove(.moveToActiveSpace)
+    /// A window on a display with only one Space is always on the active
+    /// Space, so none of this fires for that case.
+    private static func revealAcrossSpaces(_ window: NSWindow) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            MainActor.assumeIsolated {
+                guard window.isVisible, !window.isOnActiveSpace else { return }
+                Log.write(
+                    "Placement",
+                    "summon: macOS did not follow the window to its Space — bringing it over")
+                // `.insert` rather than assign, preserving the defaults
+                // AppKit/SwiftUI already set — most importantly `.managed`,
+                // which is what lets the window take part in Mission Control
+                // and Stage Manager normally.
+                window.collectionBehavior.insert(.moveToActiveSpace)
+                window.makeKeyAndOrderFront(nil)
+                // Scoped to this gesture. `.moveToActiveSpace` is a property
+                // of the *window*, not of the gesture, so leaving it on means
+                // the window follows you every time it is shown — including
+                // on the relaunch after an install, which is nobody's intent.
+                // Deferred a turn so removal lands after AppKit has finished
+                // the move it was meant to cause.
+                DispatchQueue.main.async {
+                    window.collectionBehavior.remove(.moveToActiveSpace)
+                }
+            }
         }
     }
 
-    /// macOS persists the main window's frame across launches via the
-    /// `frameAutosaveName`. If the user moved the window onto a
-    /// secondary display and then disconnected it, the restored frame
-    /// can sit entirely off-screen — the user opens "Pacer" from the
-    /// menu bar, sees nothing, and has no obvious way back. Recenter
-    /// on the primary screen (the one with the menu bar) and save so
-    /// the next launch doesn't repeat the dance.
-    ///
-    /// `NSWindow.center()` is AppKit's blessed centering API; on
-    /// post-display-disconnect setups it lands on whatever screen
-    /// macOS has elected as primary, which is exactly where the user
-    /// is working from after their secondary went away.
-
-
-    /// The screen the user is currently working on — the one whose menu
-    /// bar they just clicked, or where the cursor sits when the global
-    /// hotkey fires. `NSEvent.mouseLocation` and `NSScreen.frame` share
-    /// the same bottom-left-origin global coordinate space, so a simple
-    /// containment test resolves it. Falls back to `NSScreen.main` (the
-    /// screen with the key window / active menu bar) when the cursor is
-    /// in a gap between displays.
-    private static func activeScreen() -> NSScreen? {
-        let mouse = NSEvent.mouseLocation
-        return NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
-    }
-
-    /// Move the main window onto `target` when — and only when — it's
-    /// currently on a *different* display. A user who keeps Pacer on one
-    /// screen and positions it deliberately is never disturbed; a
-    /// multi-monitor user gets the window to follow them to whichever
-    /// display they opened it from. We preserve the window's relative
-    /// position within the screen (top-left stays top-left, etc.) rather
-    /// than always centering, so the layout stays familiar across the
-    /// jump, then clamp so the whole frame lands inside the visible area.
-    private static func reposition(_ window: NSWindow, onto target: NSScreen) {
-        guard window.canBecomeMain, !(window is NSPanel) else { return }
-        let frame = window.frame
-        let center = NSPoint(x: frame.midX, y: frame.midY)
-        // Already on the target display? Leave the in-screen position
-        // exactly as the user left it — we only ever relocate across
-        // displays, never nudge within one.
-        if target.frame.contains(center) { return }
-
-        let targetVF = target.visibleFrame
-        let source = NSScreen.screens.first { $0.frame.contains(center) }
-        var origin: NSPoint
-        if let sourceVF = source?.visibleFrame, sourceVF.width > 0, sourceVF.height > 0 {
-            let relX = (frame.minX - sourceVF.minX) / sourceVF.width
-            let relY = (frame.minY - sourceVF.minY) / sourceVF.height
-            origin = NSPoint(x: targetVF.minX + relX * targetVF.width,
-                             y: targetVF.minY + relY * targetVF.height)
-        } else {
-            // Window wasn't on any screen (e.g. a stale off-screen
-            // autosaved frame) — center it on the target instead.
-            origin = NSPoint(x: targetVF.midX - frame.width / 2,
-                             y: targetVF.midY - frame.height / 2)
-        }
-        // Clamp fully on-screen. `max(targetVF.minX, maxX)` keeps the
-        // lower bound sane when the window is wider/taller than the
-        // target's visible area (pins to top-left instead of inverting).
-        let maxX = targetVF.maxX - frame.width
-        let maxY = targetVF.maxY - frame.height
-        origin.x = min(max(origin.x, targetVF.minX), max(targetVF.minX, maxX))
-        origin.y = min(max(origin.y, targetVF.minY), max(targetVF.minY, maxY))
-        window.setFrameOrigin(origin)
-    }
 
     /// `.regular` when at least one user-visible window is open
     /// (Dock icon shows so user can Cmd+Q, Cmd+Tab back, etc.);
@@ -1045,62 +964,32 @@ final class PacerAppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // brings us forward when called from one of those gestures.
         // The deprecated form would silently leave the window behind
         // whatever app was previously frontmost.
-        // Resolve the display the user opened us from BEFORE anything
-        // async runs — the cursor may drift afterward.
-        let target = Self.activeScreen()
         NSApp.activate()
         if let window = NSApp.windows.first(where: { MainWindowPlacement.isDashboard($0) }) {
-            // Pin the menu-bar-app collection behavior BEFORE
-            // `makeKeyAndOrderFront` so the very first activation
-            // already pulls the window to the current Space rather
-            // than bouncing the user via Mission Control to wherever
-            // the window was last left.
-            Self.applyMenuBarAppBehavior(window)
-            // Where the user *parked* it wins over where their cursor is.
-            //
-            // Two systems owned this and they fought. `MainWindowPlacement`
-            // exists precisely so a dashboard kept on a second monitor stays
-            // there across relaunches; `reposition(_:onto:)` predates it and
-            // drags the window to whichever screen the menu bar was clicked
-            // on. Opening from the menu bar ran the second, so the window
-            // arrived on the wrong display *and* in the wrong spot — and the
-            // `didBecomeKey` observer then recorded that as the new home, so
-            // it stuck.
-            //
-            // Following the cursor is still right for someone who has never
-            // placed the window, which is exactly when there is no stored
-            // frame. So: stored placement first, cursor only as the fallback.
-            if let stored = MainWindowPlacement.storedFrame,
-               MainWindowPlacement.isUsable(stored) {
-                MainWindowPlacement.apply(to: window, reason: "menu-bar open")
-            } else if let target {
-                Self.reposition(window, onto: target)
-            }
+            // The window keeps the display and the Space the user left it
+            // on. All this gesture does is put it in front of them — which,
+            // for a window on another Space, means taking them to it. See
+            // `revealAcrossSpaces`.
+            MainWindowPlacement.apply(to: window, reason: "menu-bar open")
             window.deminiaturize(nil)
             window.makeKeyAndOrderFront(nil)
             // Re-assert after ordering front: AppKit can nudge a window as it
             // comes forward, and this is the gesture where being a few points
             // off is most visible.
             MainWindowPlacement.apply(to: window, reason: "menu-bar open")
-            // Scoped to this gesture only — see `releaseMenuBarAppBehavior`.
-            Self.releaseMenuBarAppBehavior(window)
+            Self.revealAcrossSpaces(window)
             return true
         }
-        // Cold open: the window doesn't exist yet and will materialize
-        // asynchronously via the reopen flow below. Stash the target
-        // screen so `didBecomeKey` reseats the new window onto it once.
+        // Cold open: the window doesn't exist yet and materializes
+        // asynchronously via the reopen flow below.
         //
-        // Unless the user has parked the window somewhere, in which case
-        // there is nothing to decide and following the cursor is actively
-        // wrong: it drags the dashboard off the monitor it lives on, and
-        // the move observer then records the arrival as the new home. That
-        // is not hypothetical — it is how a window parked on the bottom of
-        // a portrait display ends up pinned to a corner of another one,
-        // permanently, because the clamp that fits it onto the new screen
-        // lands on the screen's own origin.
-        let hasParkedFrame = MainWindowPlacement.storedFrame
-            .map(MainWindowPlacement.isUsable) ?? false
-        pendingActiveScreen = hasParkedFrame ? nil : target
+        // There is no Space to switch to — a window that does not exist has
+        // not been anywhere. macOS creates it on the Space you are on, and
+        // `MainWindowPlacement` puts it at the frame you parked, so it opens
+        // where you keep it, on the Space you asked from. With no parked
+        // frame (a first ever open) the scene's `.defaultPosition(.center)`
+        // centres it on the main display, and the first time you move it
+        // that becomes home.
         // No window exists. With `LSUIElement=true` and a SwiftUI
         // `Window("Pacer", id: "main")` scene, closing the dashboard
         // tears the window down — the scene is still in memory but no

--- a/App/PacerApp.swift
+++ b/App/PacerApp.swift
@@ -57,6 +57,9 @@ struct PacerApp: App {
                 // alongside ContentView keeps it scoped to the app's
                 // foreground lifetime.
                 .background(NotificationsHost())
+                // Hands the placement code this scene's real NSWindow, so
+                // it stops having to guess which window is the dashboard.
+                .background(DashboardWindowRegistrar())
                 // Hand the shared intelligence engine to the view tree so
                 // cards can ask it typed questions. Created in the background
                 // service's init, so it's non-nil here.

--- a/PacerCore/Sources/PacerCore/API/PacerSessionLookup.swift
+++ b/PacerCore/Sources/PacerCore/API/PacerSessionLookup.swift
@@ -17,14 +17,36 @@ import SwiftData
 ///   these turns, not an inference about a profile.
 ///
 /// Both come from the newest recorded turn, so a session Pacer has not seen a
-/// turn from yet is "not found" rather than a guess. A subagent gets its own
-/// session id, so this answers for the subagent rather than its parent.
+/// turn from yet is "not found" rather than a guess.
+///
+/// **A session is not one model.** This used to claim a subagent gets its own
+/// session id and so gets an answer about itself. It does not. Claude Code
+/// writes a subagent's turns to `<session>/subagents/agent-*.jsonl` under the
+/// *parent's* session id — checked across every subagent transcript on this
+/// machine, 2,156 of them, and all carrying the parent's id. So "the newest
+/// turn" is whichever agent wrote last, and a Sonnet builder asking what it
+/// runs was told "Fable", its orchestrator's model, and gated on a window
+/// that does not bind it.
+///
+/// Nothing can be inferred to fix that: there is no per-agent model variable
+/// in the environment a tool call inherits, and the session id is shared. So
+/// `models` reports the set instead, and a caller that finds more than one
+/// member knows its own identity is not knowable from here.
 public struct PacerSessionLookup: Codable, Sendable {
     public let schemaVersion: Int
     public let generatedAt: Date
     public let sessionId: String
-    /// The model on the most recent real turn — what a per-model cap gates.
+    /// The model on the most recent real turn.
+    ///
+    /// Only as meaningful as `models` is short — with a fan-out running, this
+    /// is whichever agent happened to write last. Prefer `models`.
     public let model: String?
+    /// Every model this session has run recently, newest first.
+    ///
+    /// One member means the answer is unambiguous. More than one means the
+    /// session is a parent and its subagents running different models at the
+    /// same time, and no caller inside it can tell which one it is.
+    public let models: [String]
     /// The account that turn was attributed to.
     public let accountId: String?
     public let projectPath: String?
@@ -73,6 +95,12 @@ public struct PacerSessionList: Codable, Sendable {
 }
 
 public enum PacerSessionLookupBuilder {
+
+    /// How far back a turn still counts as "this session is running that
+    /// model right now". Long enough to span a subagent that is thinking,
+    /// short enough that a model used once an hour ago stops muddying the
+    /// answer.
+    static let concurrencyWindow: TimeInterval = 15 * 60
 
     public nonisolated static func lookup(sessionId: String,
                                           now: Date = Date()) throws -> PacerSessionLookup? {
@@ -149,19 +177,32 @@ public enum PacerSessionLookupBuilder {
         var descriptor = FetchDescriptor<TokenSample>(
             predicate: #Predicate { $0.sessionId == trimmed },
             sortBy: [SortDescriptor(\.sampledAt, order: .reverse)])
-        descriptor.fetchLimit = 16
+        // Enough rows to see a fan-out, not so many that an on-demand API
+        // call walks a long session. A parent and its subagents interleave
+        // within seconds of each other, so the models in flight show up in
+        // the newest handful either way.
+        descriptor.fetchLimit = 200
         let rows = (try? context.fetch(descriptor)) ?? []
         guard let newest = rows.first else { return nil }
 
-        let model = rows.first {
-            $0.model != JSONLLineParser.syntheticModelSentinel && !$0.model.isEmpty
-        }?.model
+        // Distinct models on recent turns, newest first. `<synthetic>` is
+        // Claude Code's sentinel for non-billable internal traffic, which
+        // names no real model and is skipped everywhere else in Pacer.
+        let cutoff = newest.sampledAt.addingTimeInterval(-concurrencyWindow)
+        var seen = Set<String>()
+        var models: [String] = []
+        for row in rows where row.sampledAt >= cutoff {
+            guard row.model != JSONLLineParser.syntheticModelSentinel,
+                  !row.model.isEmpty else { continue }
+            if seen.insert(row.model).inserted { models.append(row.model) }
+        }
         let path = newest.projectPath
         return PacerSessionLookup(
             schemaVersion: 1,
             generatedAt: now,
             sessionId: trimmed,
-            model: model,
+            model: models.first,
+            models: models,
             accountId: newest.accountId,
             projectPath: path,
             project: path.map { URL(fileURLWithPath: $0).lastPathComponent },

--- a/PacerCore/Sources/PacerCore/Util/WindowPlacementFit.swift
+++ b/PacerCore/Sources/PacerCore/Util/WindowPlacementFit.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+import Foundation
+
+/// Whether a remembered window frame is worth putting a window back into.
+///
+/// The obvious test — "does this frame touch a connected screen?" — is the
+/// one that shipped, and it is too generous in a way that only shows up
+/// when a display goes away. `CGRect.intersects` is true for *any* overlap,
+/// down to a single point, and it does not care *which* screen was
+/// overlapped. So a frame parked near the right-hand edge of a wide display
+/// still "fits" after that display is unplugged, by clipping the corner of
+/// whatever monitor happens to sit next to where it used to be — and the
+/// window is restored into mostly dead space with a strip showing.
+///
+/// The rule here is that enough of the window has to land on one screen to
+/// be worth looking at. A frame that fails is not discarded: the caller
+/// leaves the window where it is and keeps the frame for when the display
+/// it belongs to comes back.
+public enum WindowPlacementFit {
+
+    /// Smaller than this and the window is a sliver — the user ends up
+    /// staring at nothing whether or not it is on a screen.
+    public static let minimumSize = CGSize(width: 480, height: 320)
+
+    /// How much of the window has to be on one screen.
+    ///
+    /// A judgement call rather than a platform rule. Half is comfortably
+    /// past "deliberately hanging off the edge" and comfortably short of
+    /// "restored into the gap where a monitor used to be".
+    public static let minimumVisibleFraction: CGFloat = 0.5
+
+    /// - Parameter visibleFrames: `NSScreen.visibleFrame` for each
+    ///   connected screen — the menu bar and Dock already excluded.
+    public static func isRestorable(_ frame: CGRect, onAnyOf visibleFrames: [CGRect]) -> Bool {
+        guard frame.width >= minimumSize.width, frame.height >= minimumSize.height else {
+            return false
+        }
+        let frameArea = frame.width * frame.height
+        guard frameArea > 0 else { return false }
+
+        return visibleFrames.contains { screen in
+            let overlap = screen.intersection(frame)
+            guard !overlap.isNull, overlap.width > 0, overlap.height > 0 else { return false }
+            let overlapArea = overlap.width * overlap.height
+            if overlapArea >= frameArea * minimumVisibleFraction { return true }
+            // A window bigger than the display it lives on can never cover
+            // half of *itself*. Covering half the display is the same
+            // statement from the other side, and is what a window sized for
+            // an ultrawide looks like when it is restored onto one.
+            let screenArea = screen.width * screen.height
+            return screenArea > 0 && overlapArea >= screenArea * minimumVisibleFraction
+        }
+    }
+}

--- a/PacerCore/Sources/PacerCore/Util/WindowPlacementGate.swift
+++ b/PacerCore/Sources/PacerCore/Util/WindowPlacementGate.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Decides whether a window move is the user parking the window, or
+/// something else moving it.
+///
+/// Pacer remembers where the dashboard was left by watching
+/// `NSWindow.didMove` / `didResize`. The trouble is that most moves a
+/// window makes are not the user's:
+///
+/// - we move it ourselves, restoring it to its stored frame at launch;
+/// - the menu-bar open path relocates it to the display the cursor is on;
+/// - AppKit shuffles every window on screen when a display sleeps, wakes,
+///   or is unplugged — a Mac on a dock does that several times a day.
+///
+/// Recording one of those overwrites the parked frame with a frame nobody
+/// chose. And because the stored frame is what every later launch
+/// restores, a wrong answer written once is permanent: the window comes
+/// back in the wrong place forever, and each launch re-records it.
+///
+/// **Why a clock rather than a flag.** The obvious guard is a boolean set
+/// around our own `setFrame` call. That is what shipped, and it never once
+/// fired: the move notification is observed on the main queue, but the
+/// observer defers the actual recording by one main-actor hop, so a flag
+/// set and cleared on consecutive lines is always back to `false` by the
+/// time the move is judged. A deadline survives the hop; a flag cannot.
+///
+/// Extracted from the AppKit layer because this rule is the whole bug, and
+/// a rule that cannot be tested is a rule that regresses.
+public struct WindowPlacementGate: Sendable {
+
+    /// How long to disown moves after we set a frame ourselves. Covers the
+    /// notification hop plus AppKit's own follow-up constrain pass.
+    public static let programmaticGrace: TimeInterval = 1.0
+
+    /// How long a freshly appeared window keeps being placed by SwiftUI.
+    /// Anything inside this window is the restore finishing, not a user.
+    public static let appearanceGrace: TimeInterval = 2.5
+
+    /// How long AppKit keeps rearranging windows after the set of displays
+    /// changes. Deliberately the longest of the three: a monitor waking up
+    /// behind a Mac that woke first can move windows twice, seconds apart.
+    public static let displayChangeGrace: TimeInterval = 5.0
+
+    private var programmaticEndsAt: Date = .distantPast
+    private var appearanceEndsAt: Date = .distantPast
+    private var displayChangeEndsAt: Date = .distantPast
+
+    public init() {}
+
+    private var ignoreMovesUntil: Date {
+        max(programmaticEndsAt, max(appearanceEndsAt, displayChangeEndsAt))
+    }
+
+    /// We are about to set the frame ourselves.
+    public mutating func noteProgrammaticMove(at now: Date = Date()) {
+        programmaticEndsAt = max(programmaticEndsAt, now + Self.programmaticGrace)
+    }
+
+    /// A window just materialized and is still being placed.
+    ///
+    /// Assigned rather than `max`'d: a *new* window restarts the grace, and
+    /// it is anchored here — at the moment the window appears — rather than
+    /// at process launch. Anchoring it to launch is what made the restore
+    /// unreliable, because the window that comes back through the reopen
+    /// path appears a second and a half after launch at the earliest and
+    /// can miss a launch-anchored window entirely.
+    public mutating func noteWindowAppeared(at now: Date = Date()) {
+        appearanceEndsAt = now + Self.appearanceGrace
+    }
+
+    /// A display was connected, disconnected, woken, or rearranged.
+    public mutating func noteDisplayConfigurationChanged(at now: Date = Date()) {
+        displayChangeEndsAt = max(displayChangeEndsAt, now + Self.displayChangeGrace)
+    }
+
+    /// The user parked the window; stop second-guessing moves.
+    ///
+    /// Leaves the programmatic deadline alone — that one is about frames
+    /// *we* are mid-way through setting, and a user gesture does not make
+    /// those ours to record.
+    public mutating func noteUserParked() {
+        appearanceEndsAt = .distantPast
+        displayChangeEndsAt = .distantPast
+    }
+
+    /// Should an observed move be stored as where the user keeps the window?
+    ///
+    /// - Parameter userDriven: the move arrived while the user was working
+    ///   the mouse, so it is a drag rather than a restore. It outranks the
+    ///   appearance and display-change graces — someone dragging a window
+    ///   that just came back in the wrong place means it *now*, and making
+    ///   them wait out a grace period would snap it back under their cursor.
+    ///   It never outranks the programmatic grace: the user may well be
+    ///   dragging something else entirely while we set a frame.
+    public func shouldRecordMove(userDriven: Bool = false, at now: Date = Date()) -> Bool {
+        if now >= ignoreMovesUntil { return true }
+        return userDriven && now >= programmaticEndsAt
+    }
+
+    /// True while a newly appeared window may still be moved by SwiftUI's
+    /// own restore — the period in which we keep re-asserting our frame so
+    /// that ours, not SwiftUI's, gets the last word.
+    public func isPlacingNewWindow(at now: Date = Date()) -> Bool {
+        now < appearanceEndsAt
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/JSONLWatcherTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/JSONLWatcherTests.swift
@@ -7,38 +7,33 @@ import Testing
 /// implicitly via the M3.5 ScanCoordinator integration test against
 /// the user's real ~/.claude/projects/ tree.
 
-@Test func manualTriggerEmitsOnStream() async throws {
+/// The trigger is yielded *before* anything iterates, on purpose.
+///
+/// `triggers()` builds its stream with `.bufferingNewest(1)`, so a yield with
+/// no reader waiting is held rather than dropped — which means this test needs
+/// no second task, no delay, and no timeout. It is a plain sequence of awaits.
+///
+/// It used to race the trigger against a five-second `Task.sleep` and assert
+/// that the trigger won. That is a wall clock, and a wall clock measures the
+/// CI runner rather than the watcher: the sleeping task needs no thread until
+/// it fires, while the task consuming the stream needs one immediately, so
+/// under a loaded pool the timeout wins a race the watcher never lost. It
+/// failed twice in a row on `main` that way, each run taking 46 seconds to
+/// decide, while passing locally in 53 ms — a red build that said nothing
+/// about the code under test.
+///
+/// The time limit is only so a genuine regression fails instead of hanging
+/// forever on an iterator nobody will ever feed.
+@Test(.timeLimit(.minutes(1)))
+func manualTriggerEmitsOnStream() async throws {
     let watcher = JSONLWatcher(mode: .manual)
     let stream = await watcher.triggers()
     await watcher.start(roots: [])
 
-    Task {
-        // Small delay to make sure the iterator is parked before we yield.
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        await watcher.manualTrigger()
-    }
+    await watcher.manualTrigger()
 
-    // Race the trigger against a safety timeout so a miss fails loudly
-    // rather than hanging the suite. 5s, not 1s: the trigger fires after
-    // ~50ms, but on a loaded/slow CI runner (where the whole suite's tests
-    // run in parallel) scheduling that task within 1s isn't guaranteed — a
-    // too-tight timeout turns a scheduling delay into a spurious failure.
-    let received = await withTaskGroup(of: Date?.self) { group in
-        group.addTask {
-            for await date in stream {
-                return date
-            }
-            return nil
-        }
-        group.addTask {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
-            return nil
-        }
-        let first = await group.next() ?? nil
-        group.cancelAll()
-        return first
-    }
-    #expect(received != nil)
+    var iterator = stream.makeAsyncIterator()
+    #expect(await iterator.next() != nil)
     await watcher.stop()
 }
 

--- a/PacerCore/Tests/PacerCoreTests/PaceScriptTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PaceScriptTests.swift
@@ -528,6 +528,85 @@ struct PaceScriptTests {
 
     // MARK: - Knowing what you are
 
+    private func sessionStub(_ models: [String]) throws -> StubServer {
+        let list = models.map { "\"\($0)\"" }.joined(separator: ", ")
+        return try StubServer(status: 200, body: """
+        {
+          "accountId" : "org-work",
+          "model" : "\(models.first ?? "")",
+          "models" : [\(list)],
+          "sessionId" : "abc-123"
+        }
+        """)
+    }
+
+    /// Reported from a real run: "a subagent running `pace.sh status --model
+    /// auto` resolves the session's model (Fable), not its own (Sonnet), so
+    /// builders are gating on the Fable window rather than theirs."
+    ///
+    /// A subagent shares its parent's session id — every subagent transcript
+    /// on the machine this was found on carries the parent's, all 2,156 — so
+    /// the session endpoint answers about whichever agent wrote last. Here
+    /// that is the orchestrator, whose weekly cap sits at 95% and does not
+    /// reset for three days. Stalling a fan-out of builders on a window that
+    /// does not bind them costs the whole run.
+    @Test func aFanOutDoesNotGateBuildersOnTheOrchestratorsCap() throws {
+        let box = try Sandbox(metrics: Self.metrics)
+        let server = try sessionStub(["claude-fable-5-1", "claude-sonnet-5"])
+        defer { server.stop() }
+        let result = try run(box, ["gate", "--cap", "85", "--model", "auto"],
+                             extra: ["CLAUDE_CODE_SESSION_ID": "abc-123",
+                                     "PACE_SESSION_API": server.base])
+        #expect(result.status == 0)
+        #expect(result.out.contains("GO"))
+        #expect(result.out.contains("ambiguous"))
+        // Account-wide windows still bind: 12% and 32%, both under the cap.
+        #expect(!box.stateText.contains("\"tripWindow\": \"Fable\""))
+    }
+
+    /// The other half of that trade. One model in flight is not ambiguous, and
+    /// a per-model cap must still stop the work — otherwise the fix for the
+    /// fan-out would have quietly ungated everybody.
+    @Test func oneModelInFlightStillGatesOnItsOwnCap() throws {
+        let box = try Sandbox(metrics: Self.metrics)
+        let server = try sessionStub(["claude-fable-5-1"])
+        defer { server.stop() }
+        let result = try run(box, ["gate", "--cap", "85", "--model", "auto"],
+                             extra: ["CLAUDE_CODE_SESSION_ID": "abc-123",
+                                     "PACE_SESSION_API": server.base])
+        #expect(result.status == 10)
+        #expect(result.out.contains("PAUSE"))
+        #expect(result.out.contains("Fable"))
+    }
+
+    /// `--model auto` decided something on every run and printed it nowhere,
+    /// so an agent could gate against the wrong model indefinitely with
+    /// nothing on screen to say which one it had picked.
+    @Test func autoSaysWhichModelItResolved() throws {
+        let box = try Sandbox(metrics: Self.metrics)
+        let server = try sessionStub(["claude-fable-5-1"])
+        defer { server.stop() }
+        let result = try run(box, ["report", "--model", "auto"],
+                             extra: ["CLAUDE_CODE_SESSION_ID": "abc-123",
+                                     "PACE_SESSION_API": server.base])
+        #expect(result.status == 0)
+        #expect(result.out.contains("detected"))
+        #expect(result.out.contains("claude-fable-5-1"))
+    }
+
+    /// "I cannot tell which model I am" is a third state, distinct from naming
+    /// one and from asking for all of them. Only a window that names no model
+    /// binds it.
+    @Test func anUnknownIdentityBindsOnlyAccountWideWindows() throws {
+        let box = try Sandbox(metrics: Self.metrics)
+        let result = try run(box, ["gate", "--cap", "85"],
+                             extra: ["PACE_MODEL": "__ambiguous__"])
+        #expect(result.status == 0)
+        #expect(result.out.contains("GO"))
+        let listing = try run(box, ["report"], extra: ["PACE_MODEL": "__ambiguous__"])
+        #expect(listing.out.contains("binds Fable only"))
+    }
+
     /// `--model auto` asks Pacer what this session is running, using the
     /// session id Claude Code exports into every command it runs.
     @Test func modelAutoResolvesThroughTheSessionEndpoint() throws {

--- a/PacerCore/Tests/PacerCoreTests/PacerSessionModelsTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/PacerSessionModelsTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import PacerCore
+
+/// What model is *this* agent running?
+///
+/// The session endpoint used to answer with the newest turn's model, which is
+/// only right when a session runs one model at a time. Claude Code writes a
+/// subagent's turns under the parent's session id, so a fan-out means several
+/// models share one id and "newest" is whichever agent wrote last. A Sonnet
+/// builder was told "Fable" and gated on its orchestrator's cap.
+@Suite("Session models")
+struct PacerSessionModelsTests {
+
+    private static func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: Account.self, AccountSessionInfo.self, ProjectMeta.self,
+            AccountActivation.self, AccountDailyAggregate.self, TokenSample.self,
+            RateLimitSample.self, UsageLimitSample.self, ExtraUsageSample.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    }
+
+    @MainActor
+    private static func turn(_ context: ModelContext, session: String, model: String,
+                             secondsAgo: Double, now: Date) {
+        context.insert(TokenSample(
+            sampledAt: now.addingTimeInterval(-secondsAgo),
+            date: TokenSample.formatDate(now.addingTimeInterval(-secondsAgo)),
+            model: model,
+            inputTokens: 10, outputTokens: 20, cacheReadTokens: 0,
+            cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+            sessionId: session, projectPath: "/tmp/p"))
+    }
+
+    @MainActor
+    @Test func aFanOutReportsEveryModelInFlight() throws {
+        let container = try Self.makeContainer()
+        let context = ModelContext(container)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        // An orchestrator and its builders, interleaved under one session id.
+        Self.turn(context, session: "s1", model: "claude-sonnet-5", secondsAgo: 30, now: now)
+        Self.turn(context, session: "s1", model: "claude-fable-5-1", secondsAgo: 10, now: now)
+        Self.turn(context, session: "s1", model: "claude-sonnet-5", secondsAgo: 5, now: now)
+        try context.save()
+
+        let found = try #require(try PacerSessionLookupBuilder.lookup(
+            container: container, sessionId: "s1", now: now))
+        #expect(Set(found.models) == ["claude-sonnet-5", "claude-fable-5-1"])
+        // Newest first, so a single-model session's `model` is unchanged.
+        #expect(found.model == "claude-sonnet-5")
+    }
+
+    @MainActor
+    @Test func oneModelSessionsAreStillUnambiguous() throws {
+        let container = try Self.makeContainer()
+        let context = ModelContext(container)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        Self.turn(context, session: "s1", model: "claude-opus-5", secondsAgo: 60, now: now)
+        Self.turn(context, session: "s1", model: "claude-opus-5", secondsAgo: 5, now: now)
+        try context.save()
+
+        let found = try #require(try PacerSessionLookupBuilder.lookup(
+            container: container, sessionId: "s1", now: now))
+        #expect(found.models == ["claude-opus-5"])
+        #expect(found.model == "claude-opus-5")
+    }
+
+    /// A model used an hour ago is not a model in flight. Without a horizon,
+    /// any long session eventually looks ambiguous forever and never gates on
+    /// a per-model cap again.
+    @MainActor
+    @Test func aModelFromHoursAgoIsNotStillRunning() throws {
+        let container = try Self.makeContainer()
+        let context = ModelContext(container)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        Self.turn(context, session: "s1", model: "claude-haiku-4-5-20251001",
+                  secondsAgo: 3 * 3600, now: now)
+        Self.turn(context, session: "s1", model: "claude-opus-5", secondsAgo: 5, now: now)
+        try context.save()
+
+        let found = try #require(try PacerSessionLookupBuilder.lookup(
+            container: container, sessionId: "s1", now: now))
+        #expect(found.models == ["claude-opus-5"])
+    }
+
+    /// `<synthetic>` is Claude Code's sentinel for non-billable internal
+    /// traffic. It names no real model and must not make a session look like
+    /// it is running two.
+    @MainActor
+    @Test func syntheticTurnsAreNotAModel() throws {
+        let container = try Self.makeContainer()
+        let context = ModelContext(container)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        Self.turn(context, session: "s1", model: "claude-opus-5", secondsAgo: 20, now: now)
+        Self.turn(context, session: "s1", model: JSONLLineParser.syntheticModelSentinel,
+                  secondsAgo: 2, now: now)
+        try context.save()
+
+        let found = try #require(try PacerSessionLookupBuilder.lookup(
+            container: container, sessionId: "s1", now: now))
+        #expect(found.models == ["claude-opus-5"])
+        #expect(found.model == "claude-opus-5")
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/WindowPlacementFitTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/WindowPlacementFitTests.swift
@@ -1,0 +1,91 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Window placement fit")
+struct WindowPlacementFitTests {
+
+    // A real three-display arrangement, as `NSScreen.visibleFrame` reports it.
+    private let builtIn = CGRect(x: 0, y: 0, width: 1512, height: 944)
+    private let portrait = CGRect(x: 2500, y: 551, width: 1080, height: 1920)
+    private let ultrawide = CGRect(x: -1596, y: 982, width: 4096, height: 1152)
+
+    private var allScreens: [CGRect] { [builtIn, portrait, ultrawide] }
+
+    @Test("a frame sitting squarely on a screen is restorable")
+    func squarelyOnScreen() {
+        let parked = CGRect(x: 2500, y: 551, width: 1080, height: 947)
+        #expect(WindowPlacementFit.isRestorable(parked, onAnyOf: allScreens))
+    }
+
+    @Test("a frame on no screen at all is not restorable")
+    func onNoScreen() {
+        let parked = CGRect(x: 9000, y: 9000, width: 1080, height: 947)
+        #expect(!WindowPlacementFit.isRestorable(parked, onAnyOf: allScreens))
+    }
+
+    /// The failure this type was written for. A window parked near the right
+    /// edge of the ultrawide overlaps the portrait display next to it. Unplug
+    /// the ultrawide and the old "does it touch anything?" test still said
+    /// yes — restoring the window into the gap where the monitor used to be,
+    /// with a strip showing on the neighbour.
+    @Test("a frame is not restorable just because it clips the neighbouring display")
+    func doesNotSurviveOnASliverOfTheNeighbour() {
+        let parked = CGRect(x: 1800, y: 1100, width: 1080, height: 947)
+        // With the ultrawide present it is a normal, mostly-on-screen window.
+        #expect(WindowPlacementFit.isRestorable(parked, onAnyOf: allScreens))
+        // Unplug it and only ~380pt of width lands on the portrait display.
+        #expect(!WindowPlacementFit.isRestorable(parked, onAnyOf: [builtIn, portrait]))
+    }
+
+    @Test("a sliver on screen is not enough")
+    func sliverIsNotEnough() {
+        // 20pt of a 1080-wide window overlapping the portrait display.
+        let parked = CGRect(x: 1440, y: 600, width: 1080, height: 947)
+        #expect(!WindowPlacementFit.isRestorable(parked, onAnyOf: [portrait]))
+    }
+
+    @Test("half on screen is restorable")
+    func halfIsEnough() {
+        // Exactly half the width on the portrait display.
+        let parked = CGRect(x: 1960, y: 600, width: 1080, height: 947)
+        #expect(WindowPlacementFit.isRestorable(parked, onAnyOf: [portrait]))
+    }
+
+    /// A window sized for the ultrawide cannot cover half of itself on a
+    /// smaller display, but it covers that display completely — which is a
+    /// perfectly usable place to be, not a restore into nowhere.
+    @Test("a window larger than the screen is judged by how much of the screen it covers")
+    func oversizedWindowIsJudgedByScreenCoverage() {
+        // 3600×1100 covers the whole of the 1512×944 built-in, but that is
+        // only ~36% of the window itself.
+        let wide = CGRect(x: 0, y: 0, width: 3600, height: 1100)
+        #expect(WindowPlacementFit.isRestorable(wide, onAnyOf: [builtIn]))
+    }
+
+    @Test("a collapsed frame is never restorable")
+    func collapsedFrame() {
+        #expect(!WindowPlacementFit.isRestorable(
+            CGRect(x: 2500, y: 551, width: 300, height: 947), onAnyOf: allScreens))
+        #expect(!WindowPlacementFit.isRestorable(
+            CGRect(x: 2500, y: 551, width: 1080, height: 100), onAnyOf: allScreens))
+        #expect(!WindowPlacementFit.isRestorable(.zero, onAnyOf: allScreens))
+    }
+
+    @Test("no connected screens means nothing is restorable")
+    func noScreens() {
+        #expect(!WindowPlacementFit.isRestorable(
+            CGRect(x: 2500, y: 551, width: 1080, height: 947), onAnyOf: []))
+    }
+
+    /// Touching along an edge is not being on a screen. This is the case that
+    /// already worked by luck: a frame starting exactly at the portrait
+    /// display's left edge shares a boundary with the ultrawide and must not
+    /// count as overlapping it.
+    @Test("sharing an edge is not overlapping")
+    func edgeContactIsNotOverlap() {
+        let parked = CGRect(x: 2500, y: 551, width: 1080, height: 947)
+        #expect(!WindowPlacementFit.isRestorable(parked, onAnyOf: [ultrawide]))
+    }
+}

--- a/PacerCore/Tests/PacerCoreTests/WindowPlacementGateTests.swift
+++ b/PacerCore/Tests/PacerCoreTests/WindowPlacementGateTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import PacerCore
+
+@Suite("Window placement gate")
+struct WindowPlacementGateTests {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("a quiet move is the user parking the window")
+    func quietMoveIsRecorded() {
+        let gate = WindowPlacementGate()
+        #expect(gate.shouldRecordMove(at: t0))
+    }
+
+    /// The bug this type exists for. The move notification is observed on
+    /// the main queue but recorded one main-actor hop later, so a boolean
+    /// cleared right after `setFrame` is already false by then — and the
+    /// frame we just set gets stored as the user's choice.
+    @Test("a frame we set ourselves is not recorded, even a hop later")
+    func programmaticMoveSurvivesTheAsyncHop() {
+        var gate = WindowPlacementGate()
+        gate.noteProgrammaticMove(at: t0)
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(0.001)))
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(0.25)))
+        #expect(gate.shouldRecordMove(at: t0.addingTimeInterval(1.5)))
+    }
+
+    @Test("SwiftUI finishing its own restore is not recorded")
+    func appearanceGraceSuppressesRestoreMoves() {
+        var gate = WindowPlacementGate()
+        gate.noteWindowAppeared(at: t0)
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(1.0)))
+        #expect(gate.shouldRecordMove(at: t0.addingTimeInterval(3.0)))
+    }
+
+    /// A dock unplug, or a monitor waking up after the Mac did, moves every
+    /// window on screen. None of it is a decision the user made.
+    @Test("a display reshuffle is not recorded")
+    func displayChangeSuppressesMoves() {
+        var gate = WindowPlacementGate()
+        gate.noteDisplayConfigurationChanged(at: t0)
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(4.0)))
+        #expect(gate.shouldRecordMove(at: t0.addingTimeInterval(6.0)))
+    }
+
+    @Test("a shorter grace never cuts a longer one short")
+    func gracesExtendRatherThanReplace() {
+        var gate = WindowPlacementGate()
+        gate.noteDisplayConfigurationChanged(at: t0)
+        gate.noteProgrammaticMove(at: t0.addingTimeInterval(0.5))
+        // The 1s programmatic grace ends well before the 5s display one.
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(3.0)))
+    }
+
+    @Test("a new window restarts the appearance grace rather than extending it")
+    func appearanceGraceIsAnchoredToTheWindow() {
+        var gate = WindowPlacementGate()
+        gate.noteWindowAppeared(at: t0)
+        gate.noteWindowAppeared(at: t0.addingTimeInterval(10))
+        #expect(gate.isPlacingNewWindow(at: t0.addingTimeInterval(11)))
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(11)))
+        #expect(gate.shouldRecordMove(at: t0.addingTimeInterval(13)))
+    }
+
+    /// Someone whose window came back in the wrong place drags it home in
+    /// the first second. That has to stick, or we snap it back under their
+    /// hand and forget where they wanted it.
+    @Test("a drag outranks the appearance grace")
+    func userDragBeatsAppearanceGrace() {
+        var gate = WindowPlacementGate()
+        gate.noteWindowAppeared(at: t0)
+        #expect(!gate.shouldRecordMove(at: t0.addingTimeInterval(0.5)))
+        #expect(gate.shouldRecordMove(userDriven: true, at: t0.addingTimeInterval(0.5)))
+    }
+
+    @Test("a drag does not outrank a frame we are setting ourselves")
+    func userDragDoesNotBeatProgrammaticGrace() {
+        var gate = WindowPlacementGate()
+        gate.noteProgrammaticMove(at: t0)
+        // The user may be dragging something else while we restore.
+        #expect(!gate.shouldRecordMove(userDriven: true, at: t0.addingTimeInterval(0.2)))
+    }
+
+    @Test("parking ends the restore graces so the next move is honored")
+    func parkingClearsGraces() {
+        var gate = WindowPlacementGate()
+        gate.noteWindowAppeared(at: t0)
+        gate.noteDisplayConfigurationChanged(at: t0)
+        gate.noteUserParked()
+        #expect(gate.shouldRecordMove(at: t0.addingTimeInterval(0.1)))
+        #expect(!gate.isPlacingNewWindow(at: t0.addingTimeInterval(0.1)))
+    }
+
+    /// Re-asserting our frame is only for the moment a window is being
+    /// placed. Doing it on every click is what put the app's popup menus in
+    /// a screen corner — a `setFrame` landing mid-menu moves the window out
+    /// from under an anchor the menu had already resolved.
+    @Test("we stop re-asserting placement once the window has settled")
+    func placementHoldIsBounded() {
+        var gate = WindowPlacementGate()
+        gate.noteWindowAppeared(at: t0)
+        #expect(gate.isPlacingNewWindow(at: t0.addingTimeInterval(2.0)))
+        #expect(!gate.isPlacingNewWindow(at: t0.addingTimeInterval(2.6)))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ ships, it offers to install it for you — no re-downloading, no reinstalling.
   icon, percent chips, and an explicit choice of which window drives the icon —
   plus home-screen-style widgets, each pickable to whichever window you care
   about (5-hour, weekly, or a per-model cap) for cost and pacing.
+- **The window stays where you put it.** Park the dashboard on whichever
+  display and Space suits you and it comes back there — across relaunches,
+  updates and a monitor that was asleep at login. Summoning it from the menu
+  bar takes you to it rather than dragging it to you, and a dashboard you
+  closed stays closed.
 - **Optional nudges.** Local notifications when you cross a rate-limit threshold
   (50 / 75 / 90%) — on any window, including a per-model cap — or blow past a
   daily spending limit you set. Off by default.

--- a/Skills/pacer/SKILL.md
+++ b/Skills/pacer/SKILL.md
@@ -147,16 +147,37 @@ $ pace.sh gate --cap 85 --model auto    # ask Pacer what this session runs
 pace: GO — 5h 40%, 7d 32% (cap 85%).
 ```
 
-**`--model auto` means you never have to say.** Claude Code exports
+**`--model auto` asks Pacer what this session runs.** Claude Code exports
 `CLAUDE_CODE_SESSION_ID` into every command it runs, and that id names the
-transcript Pacer already parses — so Pacer can answer what model this session
-is running, and which account its work is billed to. A subagent gets its own
-session id, so it resolves to the *subagent's* model, not its parent's. Export
-`PACE_MODEL=auto` once and every call in that session is model-aware.
+transcript Pacer already parses — so Pacer can answer what model the session is
+running, and which account its work is billed to. Export `PACE_MODEL=auto` once
+and every call in that session is model-aware.
+
+**Inside a fan-out, `auto` cannot tell you apart — so name your model.** A
+subagent does *not* get its own session id; its turns are written under the
+parent's, and nothing in the environment names a per-agent model. So when a
+session has more than one model in flight, `auto` will not guess: it binds only
+the account-wide windows and says so.
+
+```
+$ pace.sh gate --cap 85 --model auto     # Fable orchestrator, Sonnet builders
+pace: GO — 5h 12%, 7d 32% (cap 85%). [model ambiguous (claude-fable-5-1,
+claude-sonnet-5) — account-wide windows only; pass --model to gate on yours]
+```
+
+That is deliberate, and it is the lesser of two wrong answers. Guessing used to
+mean a Sonnet builder gated on its orchestrator's Fable cap — a window at 95%
+that does not bind it and does not reset for three days, stalling the whole
+fan-out. Binding only what certainly applies never does that. The cost is the
+other direction: an orchestrator running `auto` mid-fan-out is no longer
+stopped by its own per-model cap.
+
+**So an orchestrator should pass `--model` explicitly and tell each subagent
+its own** — it chose the model, so it is the one thing in the system that knows.
+`auto` is the fallback for a session running one model, where it is exact.
 
 It falls back to "every window binds" when Pacer has not yet seen a turn from
-the session — a brand-new subagent, most often — which is the safe reading of
-"cannot tell".
+the session at all, which is the safe reading of "cannot tell".
 
 Account-wide windows (5h, 7d) bind everything, always — those are never
 skipped. Only per-model caps are filtered, and only when you name a model. With
@@ -235,7 +256,7 @@ Invoke with a cap (default **85**). For a big fan-out:
 ## 7. The clause to paste into EVERY subagent prompt
 
 > **Usage gating:** before you start, and before any expensive step, run
-> `~/.claude/skills/pacer/pace.sh status --model auto`
+> `~/.claude/skills/pacer/pace.sh status --model <MODEL>`
 > (with the same `PACE_RUN` the orchestrator used). If it prints `paused` (exit 10):
 > immediately commit your work-in-progress in this worktree
 > (`git add -A && git commit -m "pace-checkpoint"`), append one line to
@@ -244,6 +265,12 @@ Invoke with a cap (default **85**). For a big fan-out:
 > prints `go`, proceed. If it prints `unknown` or `stale`, proceed but say so
 > in your final message — nobody is pacing this. It is a local file read — call
 > it freely.
+
+**Substitute `<MODEL>` with the model you gave that subagent** — `sonnet`,
+`opus`, `haiku`, `fable`. Do not leave `--model auto` here: a subagent's turns
+are recorded under the parent's session id, so `auto` inside a fan-out cannot
+tell the builder from the orchestrator, and will bind only the account-wide
+windows rather than the builder's own cap. You chose the model; say it.
 
 **In a Workflow script** (the deterministic `Workflow` tool): gate *between
 stages* instead — before each `parallel()`/`pipeline()` wave, run an `agent()`

--- a/Skills/pacer/pace.sh
+++ b/Skills/pacer/pace.sh
@@ -54,6 +54,10 @@ WINDOW=all
 MAXWAIT=21600
 MAXAGE=900
 MODEL="${PACE_MODEL:-}"
+# Stands for "which model I am is not knowable here". Deliberately not the
+# empty string: empty already means "every window binds", which is the
+# opposite instruction. Only windows that name no model bind this.
+AMBIGUOUS_MODEL="__ambiguous__"
 ETA=0
 INTERVAL_SET=0
 # How many times to re-ask before believing "nothing is listening". Pacer
@@ -217,6 +221,7 @@ END {
 # from an encoder we control, which prints one key per line. There is a test
 # pinning that shape.
 SESSION_MODEL=""
+SESSION_MODELS=""
 SESSION_ACCOUNT=""
 session_looked_up=false
 resolve_session() {
@@ -230,6 +235,15 @@ resolve_session() {
   case "$body" in *'"sessionId"'*) ;; *) return 1;; esac
   SESSION_MODEL=$(printf '%s\n' "$body" | awk -F'"' '/"model"/ { print $4; exit }')
   SESSION_ACCOUNT=$(printf '%s\n' "$body" | awk -F'"' '/"accountId"/ { print $4; exit }')
+  # Every model this session is running, not just the newest turn's. A
+  # subagent shares its parent's session id, so this is how we find out that
+  # "the session's model" is not a single answer.
+  SESSION_MODELS=$(printf '%s\n' "$body" \
+    | tr ',' '\n' \
+    | awk '/"models"/,/\]/' \
+    | grep -o '"[^"]*"' \
+    | grep -v '"models"' \
+    | tr -d '"')
   [ -n "$SESSION_MODEL" ] || [ -n "$SESSION_ACCOUNT" ]
 }
 
@@ -297,19 +311,22 @@ selected_rows() {
 # rule `binding_rows` applies, so the report's marker can never disagree with
 # what the gate actually did.
 model_binds() {
-  awk -v MODEL="$1" -v WANT="$MODEL" '
+  awk -v MODEL="$1" -v WANT="$MODEL" -v AMBIG="$AMBIGUOUS_MODEL" '
     function norm(v) { v = tolower(v); gsub(/[^a-z0-9]/, "", v); return v }
     BEGIN {
       want = norm(WANT); m = norm(MODEL)
+      # Identity unknown: only a window that binds every model binds us.
+      if (WANT == AMBIG) exit (m == "") ? 0 : 1
       if (want == "" || want == "all" || m == "") exit 0
       exit (index(m, want) || index(want, m)) ? 0 : 1
     }'
 }
 
 binding_rows() {
-  selected_rows | awk -F"$SEP" -v WANT="$MODEL" '
+  selected_rows | awk -F"$SEP" -v WANT="$MODEL" -v AMBIG="$AMBIGUOUS_MODEL" '
     function norm(v) { v = tolower(v); gsub(/[^a-z0-9]/, "", v); return v }
-    BEGIN { want = norm(WANT) }
+    BEGIN { want = norm(WANT); ambiguous = (WANT == AMBIG) }
+    ambiguous { if ($4 == "") print; next }
     want == "" || want == "all" { print; next }
     $4 == "" { print; next }
     { m = norm($4)
@@ -408,6 +425,14 @@ evaluate() {
 # falling back to "whichever login is active" is a guess, and a gate that
 # reports a percentage without saying whose it is invites exactly the mistake
 # this is here to prevent.
+# What `--model auto` decided. Says it out loud on the lines a caller reads,
+# because this was computed and never printed: a subagent gated against its
+# orchestrator's model for as long as that was true and nothing said so.
+auto_note() {
+  [ -n "$AUTO_NOTE" ] || return 0
+  printf ' [%s]' "$AUTO_NOTE"
+}
+
 scope_caveat() {
   [ -n "$AWK_WANT" ] && [ "$AWK_WANT" != all ] && return 0
   [ "${ALL_ACCOUNTS:-0}" -le 1 ] 2>/dev/null && return 0
@@ -450,6 +475,7 @@ off_exit_code() {
 cmd_report() {
   fetch_rows || { api_off_note; exit "$(off_exit_code)"; }
   require_selection
+  [ -n "$AUTO_NOTE" ] && printf 'pace:%s\n' "$(auto_note)"
   local multi
   multi=$(printf '%s\n' "$ROWS" | awk -F"$SEP" '{ a[$1] = 1 } END { print length(a) }')
   selected_rows | while IFS="$SEP" read -r acct id label model pct secs eta burn hit recent; do
@@ -617,12 +643,12 @@ cmd_gate() {
   evaluate
   if [ -z "$TRIP" ]; then
     write_state go "" "" "" "$(summary) (cap ${CAP}%)"
-    echo "pace: GO — $(summary) (cap ${CAP}%).$(scope_caveat)"
+    echo "pace: GO — $(summary) (cap ${CAP}%).$(auto_note)$(scope_caveat)"
     exit 0
   fi
   write_state paused "$TRIP" "$TPCT" "$TSECS" \
     "$(trip_reason); resets in $(human "$TSECS")"
-  echo "pace: PAUSE — $(trip_reason), resets in $(human "$TSECS") ($(clock "$TSECS"))."
+  echo "pace: PAUSE — $(trip_reason), resets in $(human "$TSECS") ($(clock "$TSECS")).$(auto_note)"
   exit 10
 }
 
@@ -738,7 +764,24 @@ if [ -z "$ACCOUNT" ] || [ "$ACCOUNT" = all ]; then
 fi
 
 if [ "$MODEL" = auto ]; then
-  if [ -n "$SESSION_MODEL" ]; then
+  model_count=$(printf '%s\n' "$SESSION_MODELS" | grep -c . || true)
+  if [ "${model_count:-0}" -gt 1 ]; then
+    # More than one model on recent turns means this session is a parent and
+    # its subagents at once, and *nothing available here says which one is
+    # asking* — the session id is shared and no environment variable names a
+    # per-agent model.
+    #
+    # The old code answered with the newest turn's model anyway. That is how a
+    # Sonnet builder came to gate on its Fable orchestrator's window: a cap
+    # that does not bind it, reported as if it did.
+    #
+    # So bind what certainly applies and nothing else. Account-wide windows
+    # (5h, 7d) bind every model including ours; a per-model cap might be
+    # somebody else's, and being paused by another model's cap is the same
+    # wrong answer in the other direction.
+    MODEL="$AMBIGUOUS_MODEL"
+    AUTO_NOTE="model ambiguous ($(printf '%s\n' "$SESSION_MODELS" | paste -sd, - )) — account-wide windows only; pass --model to gate on yours"
+  elif [ -n "$SESSION_MODEL" ]; then
     MODEL="$SESSION_MODEL"
     AUTO_NOTE="model $MODEL (detected)"
   else

--- a/Skills/pacer/pacing.md
+++ b/Skills/pacer/pacing.md
@@ -25,6 +25,11 @@ proceed ungated.**
   same percentage.
 - **Pass `--model auto`** so a per-model cap only gates work that actually uses
   that model, and so the right account is read when several are signed in.
+- **In a fan-out, name the model instead.** A subagent's turns are recorded
+  under its parent's session id and nothing names a per-agent model, so `auto`
+  cannot tell a builder from its orchestrator. With more than one model in
+  flight it binds only the account-wide windows and says so; pass
+  `--model <yours>` to gate on your own cap.
 
 The skill is the current word on flags and protocol. Don't restate its usage in
 CLAUDE.md — point at this file instead.


### PR DESCRIPTION
## Why

Reinstalling from an update put the dashboard back on the wrong display at the wrong size. Chasing that turned up three more things in the same area, plus a reported gating bug and the reason `main` has been red since #130.

## The window

The parked frame was stored correctly the whole time; the restore never got the last word. One line from the new logging, on a real relaunch:

```
[Placement] adopt: -88,1074 1080×944 → 2500,551 1080×947
```

SwiftUI restores its own stale autosaved frame and we move the window where the user put it. Before, SwiftUI's frame won.

- **The hold was anchored to process launch.** Three seconds from launch only covers a window SwiftUI materializes immediately; the one that comes back through `reopenIfPreviouslyOpen` cannot appear before launch + 1.5s and routinely lands after three. On exactly the relaunch the feature exists for, nothing re-asserted anything. Now anchored to the window appearing.
- **`record()`'s `isApplying` flag never fired once.** The move notification is observed on the main queue but recorded one main-actor hop later, so a flag cleared on the next line is always already false. Every frame *we* set was recorded as the user's choice. Replaced by `WindowPlacementGate` — a clock, in PacerCore, with tests.
- **Cursor-following outranked the parked frame**, and `.moveToActiveSpace` pulled the window to whichever Space you were looking at. Both deliberate choices from before a parked frame existed; both removed. Summoning the dashboard now takes you to it. A safety net brings the window over if macOS declines to follow it (`AppleSpacesSwitchOnActivate` can be off) so a menu-bar click never appears to do nothing.
- **"Can become main and isn't a panel" is not a test for the dashboard** — Settings, About and Sparkle's update alert all pass it. `DashboardWindowRegistrar` hands over the real `NSWindow` from the scene.
- **A dashboard you closed now stays closed.** The code claimed this and never had it: `wasOpen` was read only by a path that can just open, and SwiftUI materializes the window every launch regardless. Measured before implementing — a clean quit leaves the flag set, so AppKit doesn't fire `windowWillClose:` during `terminate`.
- **`isUsable` asked "does this frame touch a screen?"** via `CGRect.intersects`, true for a single point of overlap and indifferent to *which* screen. `WindowPlacementFit` requires half the window on one screen.

## `--model auto` in a fan-out

Reported: *"a subagent running `pace.sh status --model auto` resolves the session's model (Fable), not its own (Sonnet), so builders are gating on the Fable window rather than theirs."*

The premise the feature rested on is false. A subagent does **not** get its own session id — its turns are written under the parent's, verified across all 2,156 subagent transcripts on the machine this was found on — and nothing in the environment names a per-agent model. The identity is not knowable from inside the subagent.

So it stops asserting. `/v1/session` reports `models`, the distinct models on recent turns. One member and behaviour is unchanged; more than one and `auto` binds only the account-wide windows and says so. That is the lesser of two wrong answers: guessing stalled a fan-out on a weekly cap at 95% that doesn't bind the builders and doesn't reset for three days. The orchestrator chose the model, so the docs and the subagent clause now tell it to pass `--model`.

Also fixes `AUTO_NOTE`, computed on every `auto` run and printed nowhere — so nobody could see which model they'd been gated against.

## The red CI

`manualTriggerEmitsOnStream` failed the last two runs on `main` with the same assertion, taking 46s to decide while passing locally in 53ms. It raced the trigger against a 5s `Task.sleep`; the sleeping task needs no thread until it fires, the stream consumer needs one immediately, so a starved pool hands the win to the timeout. The pool is starved because #130's `pace.sh` suite takes 73s blocking on `waitUntilExit()`. The race was never needed — the stream buffers, so the test is now a plain sequence of awaits with no timer in it.

## Verification

989 tests, 21 new. Verified live across several installs, scripted and restoring state afterwards: open state relaunches to the parked frame, closed state relaunches to no window, `--model auto` resolves exactly on a single-model session against the running app. Space switching confirmed on the primary path by the maintainer.

Not folded in: #128 (screenshot title bar) — adjacent in theme but mechanically independent; the harness builds `ContentView()` directly rather than through the `Window` scene, so nothing here touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)